### PR TITLE
fix: align Android session handling with backend refresh contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Infinite Track adalah sebuah sistem presensi karyawan berbasis Android yang cerd
 ### Backend
 - **Framework**: Laravel 11 (PHP)
 - **Database**: MySQL
-- **API**: RESTful API dengan otentikasi JWT
+- **API**: RESTful API dengan access token + refresh-session contract untuk client Android
+
+### Auth & Session Contract (Android)
+- Backend tetap source of truth untuk validitas session.
+- Android memakai `POST /api/auth/refresh` dengan `X-Client-Type: android` dan refresh token eksplisit untuk memulihkan access token yang expired.
+- Android hanya menganggap session valid saat bootstrap jika backend validity berhasil dikonfirmasi kembali.
+- `invalid/revoked` dan `inactivity > 48 jam` memaksa full re-auth, sedangkan temporary transport/server failure tidak dianggap auth invalid.
+- Detail governance perubahan ini didokumentasikan di `docs/adr/ADR-007-refresh-session-and-bootstrap-truthfulness.md`.
 
 ### Android App
 - **Bahasa**: Kotlin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
     // ============================================================================
     
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -6,11 +6,15 @@ import com.example.infinite_track.data.mapper.auth.toEntity
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.local.room.UserDao
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
 import com.example.infinite_track.data.soucre.network.response.ErrorResponse
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.repository.UnauthorizedSyncFailure
 import com.google.gson.Gson
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -29,6 +33,39 @@ class AuthRepositoryImpl @Inject constructor(
     private val userDao: UserDao
 ) : AuthRepository {
 
+    override suspend fun refreshSession(): RefreshSessionResult {
+        return try {
+            val existingRefreshToken = userPreference.getRefreshToken().first()
+            if (existingRefreshToken.isBlank()) {
+                return RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
+            }
+
+            val response = apiService.refreshSession(
+                RefreshSessionRequest(refreshToken = existingRefreshToken)
+            )
+
+            if (response.data.token.isBlank() || response.data.id <= 0) {
+                return RefreshSessionResult.TemporaryFailure("Invalid refresh session payload")
+            }
+
+            val refreshTokenToStore = response.data.refreshToken?.takeIf { it.isNotBlank() } ?: existingRefreshToken
+
+            userPreference.saveSession(
+                token = response.data.token,
+                userId = response.data.id.toString(),
+                refreshToken = refreshTokenToStore
+            )
+            RefreshSessionResult.Success
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            classifyRefreshHttpError(e)
+        } catch (e: IOException) {
+            RefreshSessionResult.TemporaryFailure(e.message)
+        }
+    }
+
+
     /**
      * Login a user with provided credentials
      * @param loginRequest Login credentials
@@ -37,11 +74,14 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
         return try {
             val response = apiService.login(loginRequest)
+            val refreshToken = response.data.refreshToken?.takeIf { it.isNotBlank() }
+                ?: return Result.failure(IllegalStateException("Login response missing usable refresh token"))
 
             // Save token and user ID to DataStore
             userPreference.saveSession(
                 token = response.data.token,
-                userId = response.data.id.toString()
+                userId = response.data.id.toString(),
+                refreshToken = refreshToken
             )
 
             // Convert network response to domain model
@@ -92,22 +132,12 @@ class AuthRepositoryImpl @Inject constructor(
 
             Result.success(user)
         } catch (e: HttpException) {
-            // Try to return cached user if available
-            val cachedUser = userDao.getUserProfile()
-            if (cachedUser != null) {
-                return Result.success(cachedUser.toDomain())
+            if (e.code() == 401 || e.code() == 403) {
+                Result.failure(UnauthorizedSyncFailure())
+            } else {
+                Result.failure(Exception("Failed to sync profile data"))
             }
-
-            Log.e("AuthRepositoryImpl", "HTTP Error during sync", e)
-            Result.failure(Exception("Failed to sync profile data"))
         } catch (e: IOException) {
-            // Try to return cached user if available
-            val cachedUser = userDao.getUserProfile()
-            if (cachedUser != null) {
-                return Result.success(cachedUser.toDomain())
-            }
-
-            Log.e("AuthRepositoryImpl", "Network Error during sync", e)
             Result.failure(Exception("Network error, please check your internet connection."))
         } catch (e: Exception) {
             Log.e("AuthRepositoryImpl", "Unknown Error during sync", e)
@@ -186,6 +216,39 @@ class AuthRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Log.e("AuthRepositoryImpl", "Error saving face embedding", e)
             Result.failure(e)
+        }
+    }
+
+    private fun classifyRefreshHttpError(httpException: HttpException): RefreshSessionResult {
+        val code = httpException.code()
+        val errorBody = parseHttpErrorBodySafely(httpException)
+        val normalizedCode = errorBody?.code?.uppercase()
+
+        return when {
+            normalizedCode == "INACTIVITY_TIMEOUT_48H" -> {
+                RefreshSessionResult.ReAuthRequired.InactivityExceeded
+            }
+
+            code == 401 || code == 403 || normalizedCode == "INVALID_REFRESH_TOKEN" || normalizedCode == "REFRESH_TOKEN_REVOKED" -> {
+                RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
+            }
+
+            else -> {
+                RefreshSessionResult.TemporaryFailure(errorBody?.message ?: "HTTP $code")
+            }
+        }
+    }
+
+    private fun parseHttpErrorBodySafely(httpException: HttpException): ErrorResponse? {
+        return try {
+            val rawBody = httpException.response()?.errorBody()?.string().orEmpty()
+            if (rawBody.isBlank()) {
+                null
+            } else {
+                Gson().fromJson(rawBody, ErrorResponse::class.java)
+            }
+        } catch (_: Exception) {
+            null
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.example.infinite_track.data.soucre.network.request.LoginRequest
 import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
 import com.example.infinite_track.data.soucre.network.response.ErrorResponse
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.RefreshSessionResult
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import retrofit2.HttpException
 import java.io.IOException
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +32,7 @@ import javax.inject.Singleton
 class AuthRepositoryImpl @Inject constructor(
     private val userPreference: UserPreference,
     private val apiService: ApiService,
+    private val authSessionApiService: AuthSessionApiService,
     private val userDao: UserDao
 ) : AuthRepository {
 
@@ -40,7 +43,7 @@ class AuthRepositoryImpl @Inject constructor(
                 return RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
             }
 
-            val response = apiService.refreshSession(
+            val response = authSessionApiService.refreshSession(
                 RefreshSessionRequest(refreshToken = existingRefreshToken)
             )
 
@@ -153,21 +156,21 @@ class AuthRepositoryImpl @Inject constructor(
         return try {
             try {
                 // Try to call logout API endpoint
-                apiService.logout()
-                Log.d("AuthRepositoryImpl", "Server logout successful")
+                authSessionApiService.logout()
+                safeLogDebug("Server logout successful")
             } catch (e: Exception) {
                 // Log the error but continue with local logout
-                Log.e("AuthRepositoryImpl", "Server logout failed, proceeding with local logout", e)
+                safeLogError("Server logout failed, proceeding with local logout", e)
             } finally {
                 // Always clear local data, regardless of API call result
                 userPreference.clearAuthData()
                 userDao.clearUserProfile()
-                Log.d("AuthRepositoryImpl", "Local data cleared successfully")
+                safeLogDebug("Local data cleared successfully")
             }
             Result.success(Unit)
         } catch (e: Exception) {
             // This would only happen if clearing local data fails
-            Log.e("AuthRepositoryImpl", "Critical error during logout", e)
+            safeLogError("Critical error during logout", e)
             Result.failure(e)
         }
     }
@@ -219,10 +222,18 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
+    private fun safeLogDebug(message: String) {
+        runCatching { Log.d("AuthRepositoryImpl", message) }
+    }
+
+    private fun safeLogError(message: String, throwable: Throwable) {
+        runCatching { Log.e("AuthRepositoryImpl", message, throwable) }
+    }
+
     private fun classifyRefreshHttpError(httpException: HttpException): RefreshSessionResult {
         val code = httpException.code()
         val errorBody = parseHttpErrorBodySafely(httpException)
-        val normalizedCode = errorBody?.code?.uppercase()
+        val normalizedCode = errorBody?.code?.uppercase(Locale.ROOT)
 
         return when {
             normalizedCode == "INACTIVITY_TIMEOUT_48H" -> {

--- a/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/UserPreference.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/UserPreference.kt
@@ -35,12 +35,26 @@ class UserPreference @Inject constructor(private val dataUserStore: DataStore<Pr
     }
 
     /**
-     * Save session information (token and user ID)
+     * Save session information (access token, user ID, and optional refresh token)
      */
-    suspend fun saveSession(token: String, userId: String) {
+    suspend fun saveSession(token: String, userId: String, refreshToken: String? = null) {
         dataUserStore.edit { preferences ->
             preferences[AUTH_TOKEN_KEY] = token
             preferences[USER_ID_KEY] = userId
+            if (refreshToken.isNullOrBlank()) {
+                preferences.remove(REFRESH_TOKEN_KEY)
+            } else {
+                preferences[REFRESH_TOKEN_KEY] = refreshToken
+            }
+        }
+    }
+
+    /**
+     * Get refresh token as a Flow
+     */
+    fun getRefreshToken(): Flow<String> {
+        return dataUserStore.data.map { preferences ->
+            preferences[REFRESH_TOKEN_KEY] ?: ""
         }
     }
 
@@ -51,11 +65,13 @@ class UserPreference @Inject constructor(private val dataUserStore: DataStore<Pr
         dataUserStore.edit { preferences ->
             preferences.remove(AUTH_TOKEN_KEY)
             preferences.remove(USER_ID_KEY)
+            preferences.remove(REFRESH_TOKEN_KEY)
         }
     }
 
     companion object {
         private val AUTH_TOKEN_KEY = stringPreferencesKey("auth_token")
         private val USER_ID_KEY = stringPreferencesKey("user_id")
+        private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
     }
 }

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/request/RefreshSessionRequest.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/request/RefreshSessionRequest.kt
@@ -1,0 +1,7 @@
+package com.example.infinite_track.data.soucre.network.request
+
+import com.google.gson.annotations.SerializedName
+
+data class RefreshSessionRequest(
+    @SerializedName("refresh_token") val refreshToken: String
+)

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt
@@ -21,7 +21,8 @@ data class UserData(
     @SerializedName("photo") val photo: String,
     @SerializedName("photo_updated_at") val photoUpdatedAt: String,
     @SerializedName("location") val location: LocationData,
-    @SerializedName("token") val token: String
+    @SerializedName("token") val token: String,
+    @SerializedName("refresh_token") val refreshToken: String? = null
 )
 
 data class LocationData(

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt
@@ -1,0 +1,15 @@
+package com.example.infinite_track.data.soucre.network.response
+
+import com.google.gson.annotations.SerializedName
+
+data class RefreshSessionResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("data") val data: RefreshSessionData,
+    @SerializedName("message") val message: String
+)
+
+data class RefreshSessionData(
+    @SerializedName("id") val id: Int,
+    @SerializedName("token") val token: String,
+    @SerializedName("refresh_token") val refreshToken: String? = null
+)

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
@@ -6,12 +6,9 @@ import com.example.infinite_track.data.soucre.network.request.CheckOutRequestDto
 import com.example.infinite_track.data.soucre.network.request.LocationEventRequest
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
 import com.example.infinite_track.data.soucre.network.request.ProfileUpdateRequest
-import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
 import com.example.infinite_track.data.soucre.network.response.AttendanceHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.AttendanceResponse
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
-import com.example.infinite_track.data.soucre.network.response.LogoutResponse
-import com.example.infinite_track.data.soucre.network.response.RefreshSessionResponse
 import com.example.infinite_track.data.soucre.network.response.ProfileUpdateResponse
 import com.example.infinite_track.data.soucre.network.response.TodayStatusResponse
 import com.example.infinite_track.data.soucre.network.response.WfaRecommendationResponse
@@ -19,7 +16,6 @@ import com.example.infinite_track.data.soucre.network.response.booking.BookingHi
 import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Headers
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -34,12 +30,6 @@ interface ApiService {
     @GET("api/auth/me")
     suspend fun getUserProfile(): LoginResponse
 
-    @Headers("X-Client-Type: android")
-    @POST("api/auth/refresh")
-    suspend fun refreshSession(@Body request: RefreshSessionRequest): RefreshSessionResponse
-
-    @POST("api/auth/logout")
-    suspend fun logout(): LogoutResponse
 
     @POST("api/attendance/check-in")
     suspend fun checkIn(

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
@@ -6,10 +6,12 @@ import com.example.infinite_track.data.soucre.network.request.CheckOutRequestDto
 import com.example.infinite_track.data.soucre.network.request.LocationEventRequest
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
 import com.example.infinite_track.data.soucre.network.request.ProfileUpdateRequest
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
 import com.example.infinite_track.data.soucre.network.response.AttendanceHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.AttendanceResponse
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.LogoutResponse
+import com.example.infinite_track.data.soucre.network.response.RefreshSessionResponse
 import com.example.infinite_track.data.soucre.network.response.ProfileUpdateResponse
 import com.example.infinite_track.data.soucre.network.response.TodayStatusResponse
 import com.example.infinite_track.data.soucre.network.response.WfaRecommendationResponse
@@ -17,6 +19,7 @@ import com.example.infinite_track.data.soucre.network.response.booking.BookingHi
 import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Headers
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -30,6 +33,10 @@ interface ApiService {
 
     @GET("api/auth/me")
     suspend fun getUserProfile(): LoginResponse
+
+    @Headers("X-Client-Type: android")
+    @POST("api/auth/refresh")
+    suspend fun refreshSession(@Body request: RefreshSessionRequest): RefreshSessionResponse
 
     @POST("api/auth/logout")
     suspend fun logout(): LogoutResponse

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
@@ -1,0 +1,19 @@
+package com.example.infinite_track.data.soucre.network.retrofit
+
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
+import com.example.infinite_track.data.soucre.network.response.LogoutResponse
+import com.example.infinite_track.data.soucre.network.response.RefreshSessionResponse
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import javax.inject.Singleton
+
+@Singleton
+interface AuthSessionApiService {
+    @Headers("X-Client-Type: android")
+    @POST("api/auth/refresh")
+    suspend fun refreshSession(@Body request: RefreshSessionRequest): RefreshSessionResponse
+
+    @POST("api/auth/logout")
+    suspend fun logout(): LogoutResponse
+}

--- a/app/src/main/java/com/example/infinite_track/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/NetworkModule.kt
@@ -4,6 +4,8 @@ import android.os.Build
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.data.soucre.network.retrofit.MapboxApiService
+import com.example.infinite_track.di.auth.AuthRefreshInterceptor
+import com.example.infinite_track.di.auth.RefreshSingleFlightCoordinator
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.google.gson.Gson
@@ -12,11 +14,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -38,56 +35,29 @@ object NetworkModule {
         return HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)
     }
 
-    // 2. Menyediakan Interceptor untuk Otentikasi dengan Auto Logout
+    @Provides
+    @Singleton
+    fun provideRefreshSingleFlightCoordinator(
+        authRepositoryProvider: Provider<com.example.infinite_track.domain.repository.AuthRepository>
+    ): RefreshSingleFlightCoordinator {
+        return RefreshSingleFlightCoordinator(authRepositoryProvider)
+    }
+
+    // 2. Menyediakan Interceptor untuk Otentikasi dengan single-flight refresh orchestration
     @Provides
     @Singleton
     fun provideAuthInterceptor(
         userPreference: UserPreference,
+        refreshSingleFlightCoordinator: RefreshSingleFlightCoordinator,
         logoutUseCaseProvider: Provider<LogoutUseCase>,
         sessionManagerProvider: Provider<SessionManager>
     ): Interceptor {
-        return Interceptor { chain ->
-            val token = runBlocking { userPreference.getAuthToken().first() }
-            val requestBuilder = chain.request().newBuilder()
-
-            if (!token.isNullOrEmpty()) {
-                requestBuilder.addHeader("Authorization", "Bearer $token")
-            }
-
-            val response = chain.proceed(requestBuilder.build())
-
-            // Check for 401 Unauthorized response
-            if (response.code == 401) {
-                // PERBAIKAN: Tambahkan pengecualian untuk endpoint logout
-                val requestUrl = chain.request().url.toString()
-                val isLogoutRequest =
-                    requestUrl.contains("/auth/logout") || requestUrl.endsWith("/logout")
-
-                // Hanya trigger auto-logout jika bukan dari endpoint logout itu sendiri
-                if (!isLogoutRequest) {
-                    // Launch coroutine to handle logout in background
-                    CoroutineScope(Dispatchers.IO).launch {
-                        try {
-                            // Clear session data
-                            logoutUseCaseProvider.get().invoke()
-
-                            // Trigger session expiration notification
-                            sessionManagerProvider.get().triggerSessionExpired()
-                        } catch (e: Exception) {
-                            // Log error but don't crash the app
-                            e.printStackTrace()
-                        }
-                    }
-                } else {
-                    // Log untuk debugging - logout endpoint memang boleh return 401
-                    android.util.Log.d(
-                        "AuthInterceptor",
-                        "Ignoring 401 from logout endpoint: $requestUrl"
-                    )
-                }
-            }
-            response
-        }
+        return AuthRefreshInterceptor(
+            userPreference = userPreference,
+            refreshSingleFlightCoordinator = refreshSingleFlightCoordinator,
+            logoutUseCaseProvider = logoutUseCaseProvider,
+            sessionManagerProvider = sessionManagerProvider
+        )
     }
 
     // 3. Menyediakan OkHttpClient dengan timeout yang lebih panjang

--- a/app/src/main/java/com/example/infinite_track/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.example.infinite_track.di
 import android.os.Build
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.example.infinite_track.data.soucre.network.retrofit.MapboxApiService
 import com.example.infinite_track.di.auth.AuthRefreshInterceptor
 import com.example.infinite_track.di.auth.RefreshSingleFlightCoordinator
@@ -60,35 +61,63 @@ object NetworkModule {
         )
     }
 
-    // 3. Menyediakan OkHttpClient dengan timeout yang lebih panjang
+    // 3. Menyediakan OkHttpClient untuk protected request path
     @Provides
     @Singleton
-    fun provideOkHttpClient(
+    @Named("protected")
+    fun provideProtectedOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: Interceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
             .addInterceptor(authInterceptor)
-            .connectTimeout(30, TimeUnit.SECONDS) // Increased timeout
+            .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .build()
     }
 
-    // 4. Menyediakan Retrofit untuk Backend API (yang sudah ada)
+    // 4. Menyediakan OkHttpClient untuk auth session calls tanpa auth-refresh interceptor
+    @Provides
+    @Singleton
+    @Named("authSession")
+    fun provideAuthSessionOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    // 5. Menyediakan Retrofit untuk Backend API protected path
     @Provides
     @Singleton
     @Named("backend")
-    fun provideBackendRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun provideBackendRetrofit(@Named("protected") okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(baseUrl) // Base URL backend lokal
+            .baseUrl(baseUrl)
             .addConverterFactory(GsonConverterFactory.create())
             .client(okHttpClient)
             .build()
     }
 
-    // 5. Menyediakan Retrofit untuk Mapbox API (BARU)
+    // 6. Menyediakan Retrofit untuk auth session path (refresh/logout)
+    @Provides
+    @Singleton
+    @Named("authSession")
+    fun provideAuthSessionRetrofit(@Named("authSession") okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(okHttpClient)
+            .build()
+    }
+
+    // 7. Menyediakan Retrofit untuk Mapbox API (BARU)
     @Provides
     @Singleton
     @Named("mapbox")
@@ -111,6 +140,12 @@ object NetworkModule {
     @Singleton
     fun provideApiService(@Named("backend") retrofit: Retrofit): ApiService {
         return retrofit.create(ApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAuthSessionApiService(@Named("authSession") retrofit: Retrofit): AuthSessionApiService {
+        return retrofit.create(AuthSessionApiService::class.java)
     }
 
     // 7. MapboxApiService untuk Mapbox API (BARU)

--- a/app/src/main/java/com/example/infinite_track/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/RepositoryModule.kt
@@ -16,6 +16,7 @@ import com.example.infinite_track.data.soucre.local.preferences.LocalizationPref
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.local.room.UserDao
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.example.infinite_track.data.soucre.network.retrofit.MapboxApiService
 import com.example.infinite_track.domain.repository.AttendanceHistoryRepository
 import com.example.infinite_track.domain.repository.AttendanceRepository
@@ -44,9 +45,10 @@ object RepositoryModule {
     fun provideAuthRepository(
         userPreference: UserPreference,
         apiService: ApiService,
+        authSessionApiService: AuthSessionApiService,
         userDao: UserDao
     ): AuthRepository {
-        return AuthRepositoryImpl(userPreference, apiService, userDao)
+        return AuthRepositoryImpl(userPreference, apiService, authSessionApiService, userDao)
     }
 
     @Provides

--- a/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
+++ b/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
@@ -4,6 +4,7 @@ import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.repository.RefreshSessionResult
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -41,7 +42,13 @@ class AuthRefreshInterceptor @Inject constructor(
             return response
         }
 
-        val refreshResult = runBlocking { refreshSingleFlightCoordinator.refreshOrJoin() }
+        val refreshResult = try {
+            runBlocking { refreshSingleFlightCoordinator.refreshOrJoin() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            return response
+        }
 
         return when (refreshResult) {
             RefreshSessionResult.Success -> {

--- a/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
+++ b/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
@@ -1,0 +1,132 @@
+package com.example.infinite_track.di.auth
+
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+@Singleton
+class AuthRefreshInterceptor @Inject constructor(
+    private val userPreference: UserPreference,
+    private val refreshSingleFlightCoordinator: RefreshSingleFlightCoordinator,
+    private val logoutUseCaseProvider: Provider<LogoutUseCase>,
+    private val sessionManagerProvider: Provider<SessionManager>
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val token = runBlocking { userPreference.getAuthToken().first() }
+
+        val requestWithToken = originalRequest.newBuilder().apply {
+            if (!token.isNullOrBlank() && !isAuthEndpoint(originalRequest)) {
+                header(HEADER_AUTHORIZATION, "Bearer $token")
+            }
+        }.build()
+
+        val response = chain.proceed(requestWithToken)
+
+        if (response.code != HTTP_UNAUTHORIZED) {
+            return response
+        }
+
+        if (!shouldAttemptRefresh(requestWithToken)) {
+            return response
+        }
+
+        val refreshResult = runBlocking { refreshSingleFlightCoordinator.refreshOrJoin() }
+
+        return when (refreshResult) {
+            RefreshSessionResult.Success -> {
+                response.close()
+                val newToken = runBlocking { userPreference.getAuthToken().first() }
+                val retriedRequest = originalRequest.newBuilder()
+                    .header(HEADER_RETRY_MARKER, RETRY_MARKER_VALUE)
+                    .apply {
+                        removeHeader(HEADER_AUTHORIZATION)
+                        if (!newToken.isNullOrBlank()) {
+                            header(HEADER_AUTHORIZATION, "Bearer $newToken")
+                        }
+                    }
+                    .build()
+
+                chain.proceed(retriedRequest)
+            }
+
+            is RefreshSessionResult.ReAuthRequired -> {
+                val sessionManager = sessionManagerProvider.get()
+                if (sessionManager.beginSessionExpiryHandling()) {
+                    runBlocking {
+                        logoutUseCaseProvider.get().invoke()
+                    }
+                    sessionManager.triggerSessionExpired()
+                }
+                response
+            }
+
+            is RefreshSessionResult.TemporaryFailure -> {
+                response
+            }
+        }
+    }
+
+    private fun shouldAttemptRefresh(request: okhttp3.Request): Boolean {
+        if (request.header(HEADER_RETRY_MARKER) == RETRY_MARKER_VALUE) {
+            return false
+        }
+
+        val url = request.url.toString()
+        if (isRefreshRequest(url) || isLogoutRequest(url) || isLoginRequest(url)) {
+            return false
+        }
+
+        return request.header(HEADER_AUTHORIZATION)?.startsWith("Bearer ") == true
+    }
+
+    private fun isAuthEndpoint(request: okhttp3.Request): Boolean {
+        val path = request.url.encodedPath
+        return isRefreshPath(path) || isLogoutPath(path) || isLoginPath(path)
+    }
+
+    private fun isRefreshRequest(url: String): Boolean {
+        return isRefreshPath(extractPath(url))
+    }
+
+    private fun isLogoutRequest(url: String): Boolean {
+        return isLogoutPath(extractPath(url))
+    }
+
+    private fun isLoginRequest(url: String): Boolean {
+        return isLoginPath(extractPath(url))
+    }
+
+    private fun isRefreshPath(path: String): Boolean {
+        return path == "/api/auth/refresh" || path.endsWith("/auth/refresh") || path.endsWith("/refresh")
+    }
+
+    private fun isLogoutPath(path: String): Boolean {
+        return path == "/api/auth/logout" || path.endsWith("/auth/logout") || path.endsWith("/logout")
+    }
+
+    private fun isLoginPath(path: String): Boolean {
+        return path == "/api/auth/login" || path.endsWith("/auth/login") || path.endsWith("/login")
+    }
+
+    private fun extractPath(url: String): String {
+        return url.toHttpUrlOrNull()?.encodedPath ?: url.substringBefore('?')
+    }
+
+    companion object {
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HEADER_AUTHORIZATION = "Authorization"
+        private const val HEADER_RETRY_MARKER = "X-Refresh-Retry"
+        private const val RETRY_MARKER_VALUE = "1"
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinator.kt
+++ b/app/src/main/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinator.kt
@@ -1,0 +1,47 @@
+package com.example.infinite_track.di.auth
+
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+@Singleton
+class RefreshSingleFlightCoordinator @Inject constructor(
+    private val authRepositoryProvider: Provider<AuthRepository>
+) {
+    private val lock = Mutex()
+    private var inFlight: CompletableDeferred<RefreshSessionResult>? = null
+
+    suspend fun refreshOrJoin(): RefreshSessionResult {
+        var createdByThisCaller: CompletableDeferred<RefreshSessionResult>? = null
+
+        val deferred = lock.withLock {
+            inFlight ?: CompletableDeferred<RefreshSessionResult>().also {
+                inFlight = it
+                createdByThisCaller = it
+            }
+        }
+
+        val ownedDeferred = createdByThisCaller
+        if (ownedDeferred != null) {
+            try {
+                ownedDeferred.complete(authRepositoryProvider.get().refreshSession())
+            } catch (t: Throwable) {
+                ownedDeferred.completeExceptionally(t)
+                throw t
+            } finally {
+                lock.withLock {
+                    if (inFlight === ownedDeferred) {
+                        inFlight = null
+                    }
+                }
+            }
+        }
+
+        return deferred.await()
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
@@ -16,6 +16,22 @@ class SessionManager @Inject constructor() {
     private val _sessionExpired = MutableStateFlow(false)
     val sessionExpired: StateFlow<Boolean> = _sessionExpired.asStateFlow()
 
+    private var sessionExpiryHandlingInProgress: Boolean = false
+
+    /**
+     * Try to acquire single-flight guard for session-expired handling.
+     * Returns true only for the first caller until resetSessionExpired is invoked.
+     */
+    @Synchronized
+    fun beginSessionExpiryHandling(): Boolean {
+        if (sessionExpiryHandlingInProgress) {
+            return false
+        }
+
+        sessionExpiryHandlingInProgress = true
+        return true
+    }
+
     /**
      * Trigger session expiration
      * Dipanggil oleh AuthInterceptor ketika mendapat 401 error
@@ -28,7 +44,9 @@ class SessionManager @Inject constructor() {
      * Reset session expiration state
      * Dipanggil setelah user dismiss dialog atau navigate ke login
      */
+    @Synchronized
     fun resetSessionExpired() {
         _sessionExpired.value = false
+        sessionExpiryHandlingInProgress = false
     }
 }

--- a/app/src/main/java/com/example/infinite_track/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/repository/AuthRepository.kt
@@ -8,7 +8,17 @@ import kotlinx.coroutines.flow.Flow
  * Repository interface for authentication operations
  * This is in the domain layer and does not depend on any implementation details
  */
+class UnauthorizedSyncFailure(message: String = "Unauthorized while syncing user profile") : Exception(message)
+
 interface AuthRepository {
+    /**
+     * Attempt to refresh the current auth session.
+     *
+     * This does not perform interceptor retry orchestration. It only classifies
+     * refresh outcomes so higher layers can decide between re-auth and retry.
+     */
+    suspend fun refreshSession(): RefreshSessionResult
+
     /**
      * Login a user with credentials
      * @param loginRequest The login credentials

--- a/app/src/main/java/com/example/infinite_track/domain/repository/RefreshSessionResult.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/repository/RefreshSessionResult.kt
@@ -1,0 +1,12 @@
+package com.example.infinite_track.domain.repository
+
+sealed interface RefreshSessionResult {
+    data object Success : RefreshSessionResult
+
+    sealed interface ReAuthRequired : RefreshSessionResult {
+        data object InvalidOrRevoked : ReAuthRequired
+        data object InactivityExceeded : ReAuthRequired
+    }
+
+    data class TemporaryFailure(val reason: String? = null) : RefreshSessionResult
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -2,6 +2,9 @@ package com.example.infinite_track.domain.use_case.auth
 
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.repository.UnauthorizedSyncFailure
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
@@ -18,46 +21,85 @@ class CheckSessionUseCase @Inject constructor(
      * @return Result<UserModel> with the user data if session exists, or failure if embedding generation fails
      */
     suspend operator fun invoke(): Result<UserModel> {
-        try {
-            // First, sync user profile from the server
-            val syncResult = authRepository.syncUserProfile()
+        return try {
+            val initialSyncResult = authRepository.syncUserProfile()
+            val syncResult = if (initialSyncResult.isSuccess) {
+                initialSyncResult
+            } else {
+                handleSyncFailure(initialSyncResult.exceptionOrNull())
+            }
 
-            // If sync failed, return the failure immediately
             if (syncResult.isFailure) {
                 return syncResult
             }
 
             val newUserData = syncResult.getOrNull()!!
 
-            // Get current user data from local storage to compare photoUpdatedAt
             val currentUser = authRepository.getLoggedInUser().first()
 
-            // If photoUpdatedAt has changed or face embedding is missing, generate new embedding
             if (currentUser != null &&
                 (newUserData.photoUpdatedAt != currentUser.photoUpdatedAt ||
                         currentUser.faceEmbedding == null)
             ) {
-
-                // Use GenerateAndSaveEmbeddingUseCase to handle face embedding generation
                 val embeddingResult = generateAndSaveEmbeddingUseCase(
                     userId = newUserData.id,
                     photoUrl = newUserData.photoUrl
                 )
 
-                // If embedding generation failed, stop the process and return failure
                 if (embeddingResult.isFailure) {
                     return Result.failure(
-                        embeddingResult.exceptionOrNull()
-                            ?: Exception("Face embedding generation failed")
+                        SessionBootstrapFailure.TemporaryFailure(
+                            cause = embeddingResult.exceptionOrNull()
+                                ?: Exception("Face embedding generation failed")
+                        )
                     )
                 }
             }
 
-            // If everything succeeded, return the sync result
-            return syncResult
-
+            syncResult
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            return Result.failure(e)
+            when (e) {
+                is SessionBootstrapFailure.ReAuthRequired,
+                is SessionBootstrapFailure.TemporaryFailure -> Result.failure(e)
+                else -> Result.failure(SessionBootstrapFailure.TemporaryFailure(cause = e))
+            }
         }
+    }
+
+    private suspend fun handleSyncFailure(cause: Throwable?): Result<UserModel> {
+        if (!isUnauthorizedSyncFailure(cause)) {
+            return Result.failure(
+                SessionBootstrapFailure.TemporaryFailure(
+                    cause = cause ?: Exception("Failed to sync profile data")
+                )
+            )
+        }
+
+        return when (val refreshResult = authRepository.refreshSession()) {
+            RefreshSessionResult.Success -> {
+                val retrySyncResult = authRepository.syncUserProfile()
+                if (retrySyncResult.isFailure && isUnauthorizedSyncFailure(retrySyncResult.exceptionOrNull())) {
+                    Result.failure(
+                        SessionBootstrapFailure.ReAuthRequired(
+                            RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
+                        )
+                    )
+                } else {
+                    retrySyncResult
+                }
+            }
+            is RefreshSessionResult.ReAuthRequired -> Result.failure(
+                SessionBootstrapFailure.ReAuthRequired(refreshResult)
+            )
+            is RefreshSessionResult.TemporaryFailure -> Result.failure(
+                SessionBootstrapFailure.TemporaryFailure(message = refreshResult.reason)
+            )
+        }
+    }
+
+    private fun isUnauthorizedSyncFailure(cause: Throwable?): Boolean {
+        return cause is UnauthorizedSyncFailure
     }
 }

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/SessionBootstrapFailure.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/SessionBootstrapFailure.kt
@@ -1,0 +1,14 @@
+package com.example.infinite_track.domain.use_case.auth
+
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+
+sealed class SessionBootstrapFailure(message: String? = null, cause: Throwable? = null) : Exception(message, cause) {
+    class ReAuthRequired(
+        val reason: RefreshSessionResult.ReAuthRequired
+    ) : SessionBootstrapFailure("Session requires re-authentication")
+
+    class TemporaryFailure(
+        cause: Throwable? = null,
+        message: String? = cause?.message
+    ) : SessionBootstrapFailure(message ?: "Temporary bootstrap failure", cause)
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,7 +22,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
-import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.example.infinite_track.R
 import com.example.infinite_track.presentation.core.headline1
@@ -35,36 +35,32 @@ fun SplashScreen(
 ) {
     // Get the composition for the Lottie animation
     val composition by rememberLottieComposition(spec = LottieCompositionSpec.RawRes(R.raw.profile_sync))
-    val progress by animateLottieCompositionAsState(composition)
-
     // Collect the navigation state from the ViewModel
     val navigationState by splashViewModel.navigationState.collectAsState()
 
-    // Handle navigation based on animation progress and navigation state
-    LaunchedEffect(progress, navigationState) {
-        if (progress == 1f) {
-            when (navigationState) {
-                is SplashNavigationState.NavigateToHome -> {
-                    navController.navigate(Screen.Home.route) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
+    // Handle navigation based on navigation state
+    LaunchedEffect(navigationState) {
+        when (navigationState) {
+            is SplashNavigationState.NavigateToHome -> {
+                navController.navigate(Screen.Home.route) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = true
                     }
-                }
-
-                is SplashNavigationState.NavigateToLogin -> {
-                    navController.navigate(Screen.Login.route) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                    }
-                }
-                // If still loading, wait for animation to complete
-                SplashNavigationState.Loading -> { /* Wait for sync to complete */
+                    launchSingleTop = true
                 }
             }
+
+            is SplashNavigationState.NavigateToLogin -> {
+                navController.navigate(Screen.Login.route) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                }
+            }
+
+            SplashNavigationState.Loading,
+            SplashNavigationState.TemporaryFailure -> Unit
         }
     }
 
@@ -87,12 +83,40 @@ fun SplashScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            Text(
-                text = "Sync Profile",
-                style = headline1,
-                color = Blue_500,
-                textAlign = TextAlign.Center
-            )
+            if (navigationState is SplashNavigationState.TemporaryFailure) {
+                Text(
+                    text = "Unable to verify session",
+                    style = headline1,
+                    color = Blue_500,
+                    textAlign = TextAlign.Center
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Button(onClick = { splashViewModel.retrySessionCheck() }) {
+                    Text(text = "Retry")
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Button(onClick = {
+                    navController.navigate(Screen.Login.route) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                    }
+                }) {
+                    Text(text = "Login")
+                }
+            } else {
+                Text(
+                    text = "Sync Profile",
+                    style = headline1,
+                    color = Blue_500,
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.infinite_track.domain.use_case.auth.CheckSessionUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.SessionBootstrapFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import javax.inject.Inject
 // Navigation states for the SplashScreen
 sealed class SplashNavigationState {
     object Loading : SplashNavigationState()
+    object TemporaryFailure : SplashNavigationState()
     object NavigateToHome : SplashNavigationState()
     object NavigateToLogin : SplashNavigationState()
 }
@@ -38,6 +40,11 @@ class SplashViewModel @Inject constructor(
         checkSession()
     }
 
+    fun retrySessionCheck() {
+        _navigationState.value = SplashNavigationState.Loading
+        checkSession()
+    }
+
     private fun checkSession() {
         viewModelScope.launch {
             checkSessionUseCase()
@@ -48,23 +55,32 @@ class SplashViewModel @Inject constructor(
                 .onFailure { exception ->
                     // Session is invalid or embedding generation failed
                     // DON'T show dialog in splash screen - directly navigate to login
-                    handleSessionFailure(exception)
+                    processSessionFailure(exception)
                 }
         }
     }
 
-    private suspend fun handleSessionFailure(exception: Throwable) {
-        try {
-            // Clear any existing session data
-            logoutUseCase()
+    private fun processSessionFailure(exception: Throwable) {
+        when (exception) {
+            is SessionBootstrapFailure.ReAuthRequired -> {
+                viewModelScope.launch {
+                    try {
+                        logoutUseCase()
+                    } finally {
+                        _navigationState.value = SplashNavigationState.NavigateToLogin
+                    }
+                }
+            }
 
-            // Directly navigate to login without showing dialog
-            // This prevents BadTokenException in splash screen
-            _navigationState.value = SplashNavigationState.NavigateToLogin
+            is SessionBootstrapFailure.TemporaryFailure -> {
+                // Bounded truthful state: bootstrap is currently unavailable; preserve local auth.
+                _navigationState.value = SplashNavigationState.TemporaryFailure
+            }
 
-        } catch (e: Exception) {
-            // Even if logout fails, still navigate to login
-            _navigationState.value = SplashNavigationState.NavigateToLogin
+            else -> {
+                // Unknown bootstrap failure is treated as temporary/bootstrap-unavailable.
+                _navigationState.value = SplashNavigationState.TemporaryFailure
+            }
         }
     }
 }

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -26,6 +26,7 @@ import com.example.infinite_track.data.soucre.network.response.WfaRecommendation
 import com.example.infinite_track.data.soucre.network.response.booking.BookingHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.example.infinite_track.domain.repository.RefreshSessionResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -42,6 +43,7 @@ import retrofit2.HttpException
 import retrofit2.Response
 import java.io.File
 import java.io.IOException
+import java.util.Locale
 
 class AuthRepositoryImplRefreshSessionTest {
 
@@ -58,7 +60,9 @@ class AuthRepositoryImplRefreshSessionTest {
                         message = "ok",
                         data = createUserData(refreshToken = null)
                     )
-                },
+                }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = { unsupportedRefreshSession() }
             ),
             userDao = userDao
@@ -87,7 +91,9 @@ class AuthRepositoryImplRefreshSessionTest {
                         message = "ok",
                         data = createUserData(refreshToken = "   ")
                     )
-                },
+                }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = { unsupportedRefreshSession() }
             ),
             userDao = userDao
@@ -132,13 +138,15 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                refreshSessionBlock = { unsupportedRefreshSession() },
                 getUserProfileBlock = {
                     throw httpException(
                         code = 500,
                         error = ErrorResponse(success = false, message = "server down", code = "SERVER_ERROR")
                     )
                 }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
             ),
             userDao = CachedUserDao(cachedUser)
         )
@@ -177,10 +185,12 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                refreshSessionBlock = { unsupportedRefreshSession() },
                 getUserProfileBlock = {
                     throw IOException("timeout")
                 }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
             ),
             userDao = CachedUserDao(cachedUser)
         )
@@ -191,9 +201,37 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
+    fun `logout uses auth session api service and clears local state`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        val userDao = CapturingUserDao()
+        val fakeAuthSessionApi = FakeAuthSessionApiService(
+            refreshSessionBlock = { unsupportedRefreshSession() },
+            logoutBlock = {
+                LogoutResponse(message = "ok")
+            }
+        )
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(),
+            authSessionApiService = fakeAuthSessionApi,
+            userDao = userDao
+        )
+
+        val result = repository.logout()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeAuthSessionApi.logoutCallCount)
+        assertTrue(userPreference.getAuthToken().first().isBlank())
+        assertTrue(userPreference.getRefreshToken().first().isBlank())
+        assertTrue(userPreference.getUserId().first().isBlank())
+    }
+
+    @Test
     fun `refresh session returns reauth required when refresh token revoked`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw httpException(
                         code = 401,
@@ -215,7 +253,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session returns inactivity reauth required when inactivity exceeded 48h`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw httpException(
                         code = 401,
@@ -235,9 +273,37 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
+    fun `refresh session uses locale-stable error code normalization with Locale ROOT`() = runBlocking {
+        val defaultLocale = Locale.getDefault()
+        Locale.setDefault(Locale("tr", "TR"))
+        try {
+            val repository = createRepository(
+                refreshApiService = FakeAuthSessionApiService(
+                    refreshSessionBlock = {
+                        throw httpException(
+                            code = 401,
+                            error = ErrorResponse(
+                                success = false,
+                                message = "session inactive for more than 48 hours",
+                                code = "inactivity_timeout_48h"
+                            )
+                        )
+                    }
+                )
+            )
+
+            val result = repository.refreshSession()
+
+            assertTrue(result is RefreshSessionResult.ReAuthRequired.InactivityExceeded)
+        } finally {
+            Locale.setDefault(defaultLocale)
+        }
+    }
+
+    @Test
     fun `refresh session rethrows cancellation exception`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw CancellationException("cancelled")
                 }
@@ -255,7 +321,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session returns temporary failure on network exception`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw IOException("timeout")
                 }
@@ -270,7 +336,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session returns temporary failure on server side refresh error`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw httpException(
                         code = 500,
@@ -293,7 +359,7 @@ class AuthRepositoryImplRefreshSessionTest {
     fun `refresh session success stores latest tokens`() = runBlocking {
         val userPreference = createUserPreference()
         userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
-        val fakeApi = FakeApiService(
+        val fakeAuthSessionApi = FakeAuthSessionApiService(
             refreshSessionBlock = {
                 RefreshSessionResponse(
                     success = true,
@@ -309,7 +375,8 @@ class AuthRepositoryImplRefreshSessionTest {
 
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
-            apiService = fakeApi,
+            apiService = FakeApiService(),
+            authSessionApiService = fakeAuthSessionApi,
             userDao = FakeUserDao()
         )
 
@@ -318,7 +385,7 @@ class AuthRepositoryImplRefreshSessionTest {
         assertTrue(result is RefreshSessionResult.Success)
         assertEquals("new-access", userPreference.getAuthToken().first())
         assertEquals("new-refresh", userPreference.getRefreshToken().first())
-        assertEquals("old-refresh", fakeApi.lastRefreshRequest?.refreshToken)
+        assertEquals("old-refresh", fakeAuthSessionApi.lastRefreshRequest?.refreshToken)
     }
 
     @Test
@@ -328,7 +395,8 @@ class AuthRepositoryImplRefreshSessionTest {
 
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
-            apiService = FakeApiService(
+            apiService = FakeApiService(),
+            authSessionApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     RefreshSessionResponse(
                         success = true,
@@ -358,7 +426,8 @@ class AuthRepositoryImplRefreshSessionTest {
 
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
-            apiService = FakeApiService(
+            apiService = FakeApiService(),
+            authSessionApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     RefreshSessionResponse(
                         success = true,
@@ -389,7 +458,8 @@ class AuthRepositoryImplRefreshSessionTest {
 
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
-            apiService = FakeApiService(
+            apiService = FakeApiService(),
+            authSessionApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     RefreshSessionResponse(
                         success = true,
@@ -416,7 +486,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session rethrows unexpected internal exception`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw IllegalStateException("boom")
                 }
@@ -434,7 +504,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session returns temporary failure when error body is malformed json`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw rawHttpException(code = 500, rawBody = "not-json")
                 }
@@ -449,7 +519,7 @@ class AuthRepositoryImplRefreshSessionTest {
     @Test
     fun `refresh session returns temporary failure when error body is empty`() = runBlocking {
         val repository = createRepository(
-            apiService = FakeApiService(
+            refreshApiService = FakeAuthSessionApiService(
                 refreshSessionBlock = {
                     throw rawHttpException(code = 500, rawBody = "")
                 }
@@ -461,7 +531,10 @@ class AuthRepositoryImplRefreshSessionTest {
         assertTrue(result is RefreshSessionResult.TemporaryFailure)
     }
 
-    private fun createRepository(apiService: ApiService): AuthRepositoryImpl {
+    private fun createRepository(
+        apiService: ApiService = FakeApiService(),
+        refreshApiService: AuthSessionApiService
+    ): AuthRepositoryImpl {
         val userPreference = createUserPreference().also {
             runBlocking {
                 it.saveSession(token = "existing-access", userId = "10", refreshToken = "existing-refresh")
@@ -471,6 +544,7 @@ class AuthRepositoryImplRefreshSessionTest {
         return AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = apiService,
+            authSessionApiService = refreshApiService,
             userDao = FakeUserDao()
         )
     }
@@ -571,16 +645,9 @@ private class CachedUserDao(
 }
 
 private class FakeApiService(
-    private val refreshSessionBlock: suspend () -> RefreshSessionResponse,
     private val loginBlock: suspend (LoginRequest) -> LoginResponse = { throw NotImplementedError("login not configured in test") },
     private val getUserProfileBlock: suspend () -> LoginResponse = { throw NotImplementedError("getUserProfile not configured in test") }
 ) : ApiService {
-    var lastRefreshRequest: RefreshSessionRequest? = null
-
-    override suspend fun refreshSession(request: RefreshSessionRequest): RefreshSessionResponse {
-        lastRefreshRequest = request
-        return refreshSessionBlock()
-    }
 
     override suspend fun login(loginRequest: LoginRequest): LoginResponse {
         return loginBlock(loginRequest)
@@ -588,10 +655,6 @@ private class FakeApiService(
 
     override suspend fun getUserProfile(): LoginResponse {
         return getUserProfileBlock()
-    }
-
-    override suspend fun logout(): LogoutResponse {
-        throw NotImplementedError()
     }
 
     override suspend fun checkIn(request: AttendanceRequest): AttendanceResponse {
@@ -634,5 +697,23 @@ private class FakeApiService(
 
     override suspend fun submitWfaBooking(request: BookingRequest): BookingResponse {
         throw NotImplementedError()
+    }
+}
+
+private class FakeAuthSessionApiService(
+    private val refreshSessionBlock: suspend () -> RefreshSessionResponse,
+    private val logoutBlock: suspend () -> LogoutResponse = { throw NotImplementedError("logout not configured in test") }
+) : AuthSessionApiService {
+    var lastRefreshRequest: RefreshSessionRequest? = null
+    var logoutCallCount: Int = 0
+
+    override suspend fun refreshSession(request: RefreshSessionRequest): RefreshSessionResponse {
+        lastRefreshRequest = request
+        return refreshSessionBlock()
+    }
+
+    override suspend fun logout(): LogoutResponse {
+        logoutCallCount += 1
+        return logoutBlock()
     }
 }

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -1,0 +1,638 @@
+package com.example.infinite_track.data.repository.auth
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.local.room.UserDao
+import com.example.infinite_track.data.soucre.local.room.UserEntity
+import com.example.infinite_track.data.soucre.network.request.AttendanceRequest
+import com.example.infinite_track.data.soucre.network.request.BookingRequest
+import com.example.infinite_track.data.soucre.network.request.CheckOutRequestDto
+import com.example.infinite_track.data.soucre.network.request.LocationEventRequest
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.data.soucre.network.request.ProfileUpdateRequest
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
+import com.example.infinite_track.data.soucre.network.response.AttendanceHistoryResponse
+import com.example.infinite_track.data.soucre.network.response.AttendanceResponse
+import com.example.infinite_track.data.soucre.network.response.ErrorResponse
+import com.example.infinite_track.data.soucre.network.response.LoginResponse
+import com.example.infinite_track.data.soucre.network.response.LogoutResponse
+import com.example.infinite_track.data.soucre.network.response.LocationData
+import com.example.infinite_track.data.soucre.network.response.RefreshSessionData
+import com.example.infinite_track.data.soucre.network.response.RefreshSessionResponse
+import com.example.infinite_track.data.soucre.network.response.ProfileUpdateResponse
+import com.example.infinite_track.data.soucre.network.response.TodayStatusResponse
+import com.example.infinite_track.data.soucre.network.response.UserData
+import com.example.infinite_track.data.soucre.network.response.WfaRecommendationResponse
+import com.example.infinite_track.data.soucre.network.response.booking.BookingHistoryResponse
+import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
+import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.File
+import java.io.IOException
+
+class AuthRepositoryImplRefreshSessionTest {
+
+    @Test
+    fun `login fails when refresh token is null in login response`() = runBlocking {
+        val userPreference = createUserPreference()
+        val userDao = CapturingUserDao()
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                loginBlock = {
+                    LoginResponse(
+                        success = true,
+                        message = "ok",
+                        data = createUserData(refreshToken = null)
+                    )
+                },
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = userDao
+        )
+
+        val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("refresh token", ignoreCase = true) == true)
+        assertTrue(userPreference.getAuthToken().first().isBlank())
+        assertTrue(userPreference.getRefreshToken().first().isBlank())
+        assertTrue(userPreference.getUserId().first().isBlank())
+        assertTrue(userDao.insertedUsers.isEmpty())
+    }
+
+    @Test
+    fun `login fails when refresh token is blank in login response`() = runBlocking {
+        val userPreference = createUserPreference()
+        val userDao = CapturingUserDao()
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                loginBlock = {
+                    LoginResponse(
+                        success = true,
+                        message = "ok",
+                        data = createUserData(refreshToken = "   ")
+                    )
+                },
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = userDao
+        )
+
+        val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("refresh token", ignoreCase = true) == true)
+        assertTrue(userPreference.getAuthToken().first().isBlank())
+        assertTrue(userPreference.getRefreshToken().first().isBlank())
+        assertTrue(userPreference.getUserId().first().isBlank())
+        assertTrue(userDao.insertedUsers.isEmpty())
+    }
+
+    @Test
+    fun `sync user profile returns failure on http exception even when cached user exists`() = runBlocking {
+        val cachedUser = UserEntity(
+            id = 10,
+            fullName = "Cached User",
+            email = "cached@example.com",
+            roleName = "staff",
+            positionName = "Engineer",
+            programName = "Program",
+            divisionName = "Division",
+            nipNim = "12345",
+            phone = "08123456789",
+            photo = "cached.jpg",
+            photoUpdatedAt = "2026-01-01T00:00:00Z",
+            latitude = -0.9,
+            longitude = 119.8,
+            radius = 100,
+            locationDescription = "Office",
+            locationCategoryName = "WFO",
+            faceEmbedding = null
+        )
+
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        }
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() },
+                getUserProfileBlock = {
+                    throw httpException(
+                        code = 500,
+                        error = ErrorResponse(success = false, message = "server down", code = "SERVER_ERROR")
+                    )
+                }
+            ),
+            userDao = CachedUserDao(cachedUser)
+        )
+
+        val result = repository.syncUserProfile()
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `sync user profile returns failure on io exception even when cached user exists`() = runBlocking {
+        val cachedUser = UserEntity(
+            id = 10,
+            fullName = "Cached User",
+            email = "cached@example.com",
+            roleName = "staff",
+            positionName = "Engineer",
+            programName = "Program",
+            divisionName = "Division",
+            nipNim = "12345",
+            phone = "08123456789",
+            photo = "cached.jpg",
+            photoUpdatedAt = "2026-01-01T00:00:00Z",
+            latitude = -0.9,
+            longitude = 119.8,
+            radius = 100,
+            locationDescription = "Office",
+            locationCategoryName = "WFO",
+            faceEmbedding = null
+        )
+
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        }
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() },
+                getUserProfileBlock = {
+                    throw IOException("timeout")
+                }
+            ),
+            userDao = CachedUserDao(cachedUser)
+        )
+
+        val result = repository.syncUserProfile()
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `refresh session returns reauth required when refresh token revoked`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw httpException(
+                        code = 401,
+                        error = ErrorResponse(
+                            success = false,
+                            message = "refresh token revoked",
+                            code = "INVALID_REFRESH_TOKEN"
+                        )
+                    )
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.ReAuthRequired.InvalidOrRevoked)
+    }
+
+    @Test
+    fun `refresh session returns inactivity reauth required when inactivity exceeded 48h`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw httpException(
+                        code = 401,
+                        error = ErrorResponse(
+                            success = false,
+                            message = "session inactive for more than 48 hours",
+                            code = "INACTIVITY_TIMEOUT_48H"
+                        )
+                    )
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.ReAuthRequired.InactivityExceeded)
+    }
+
+    @Test
+    fun `refresh session rethrows cancellation exception`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw CancellationException("cancelled")
+                }
+            )
+        )
+
+        try {
+            repository.refreshSession()
+            fail("Expected CancellationException to be rethrown")
+        } catch (e: CancellationException) {
+            assertEquals("cancelled", e.message)
+        }
+    }
+
+    @Test
+    fun `refresh session returns temporary failure on network exception`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw IOException("timeout")
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+    }
+
+    @Test
+    fun `refresh session returns temporary failure on server side refresh error`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw httpException(
+                        code = 500,
+                        error = ErrorResponse(
+                            success = false,
+                            message = "temporary server error",
+                            code = "TEMPORARY_REFRESH_FAILURE"
+                        )
+                    )
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+    }
+
+    @Test
+    fun `refresh session success stores latest tokens`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+        val fakeApi = FakeApiService(
+            refreshSessionBlock = {
+                RefreshSessionResponse(
+                    success = true,
+                    message = "ok",
+                    data = RefreshSessionData(
+                        id = 10,
+                        token = "new-access",
+                        refreshToken = "new-refresh"
+                    )
+                )
+            }
+        )
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = fakeApi,
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.Success)
+        assertEquals("new-access", userPreference.getAuthToken().first())
+        assertEquals("new-refresh", userPreference.getRefreshToken().first())
+        assertEquals("old-refresh", fakeApi.lastRefreshRequest?.refreshToken)
+    }
+
+    @Test
+    fun `refresh session success with null refresh token keeps existing refresh token`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    RefreshSessionResponse(
+                        success = true,
+                        message = "ok",
+                        data = RefreshSessionData(
+                            id = 10,
+                            token = "new-access",
+                            refreshToken = null
+                        )
+                    )
+                }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.Success)
+        assertEquals("new-access", userPreference.getAuthToken().first())
+        assertEquals("old-refresh", userPreference.getRefreshToken().first())
+    }
+
+    @Test
+    fun `refresh session returns temporary failure and does not persist when access token is blank`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    RefreshSessionResponse(
+                        success = true,
+                        message = "ok",
+                        data = RefreshSessionData(
+                            id = 10,
+                            token = "   ",
+                            refreshToken = "new-refresh"
+                        )
+                    )
+                }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+        assertEquals("old-access", userPreference.getAuthToken().first())
+        assertEquals("old-refresh", userPreference.getRefreshToken().first())
+        assertEquals("10", userPreference.getUserId().first())
+    }
+
+    @Test
+    fun `refresh session returns temporary failure and does not persist when user id is invalid`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    RefreshSessionResponse(
+                        success = true,
+                        message = "ok",
+                        data = RefreshSessionData(
+                            id = 0,
+                            token = "new-access",
+                            refreshToken = "new-refresh"
+                        )
+                    )
+                }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+        assertEquals("old-access", userPreference.getAuthToken().first())
+        assertEquals("old-refresh", userPreference.getRefreshToken().first())
+        assertEquals("10", userPreference.getUserId().first())
+    }
+
+    @Test
+    fun `refresh session rethrows unexpected internal exception`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw IllegalStateException("boom")
+                }
+            )
+        )
+
+        try {
+            repository.refreshSession()
+            fail("Expected IllegalStateException to be rethrown")
+        } catch (e: IllegalStateException) {
+            assertEquals("boom", e.message)
+        }
+    }
+
+    @Test
+    fun `refresh session returns temporary failure when error body is malformed json`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw rawHttpException(code = 500, rawBody = "not-json")
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+    }
+
+    @Test
+    fun `refresh session returns temporary failure when error body is empty`() = runBlocking {
+        val repository = createRepository(
+            apiService = FakeApiService(
+                refreshSessionBlock = {
+                    throw rawHttpException(code = 500, rawBody = "")
+                }
+            )
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.TemporaryFailure)
+    }
+
+    private fun createRepository(apiService: ApiService): AuthRepositoryImpl {
+        val userPreference = createUserPreference().also {
+            runBlocking {
+                it.saveSession(token = "existing-access", userId = "10", refreshToken = "existing-refresh")
+            }
+        }
+
+        return AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = apiService,
+            userDao = FakeUserDao()
+        )
+    }
+
+    private fun createUserPreference(): UserPreference {
+        val testFile = File.createTempFile("user_prefs", ".preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { testFile }
+        )
+        return UserPreference(dataStore)
+    }
+
+    private fun httpException(code: Int, error: ErrorResponse): HttpException {
+        val body = "{\"success\":${error.success},\"message\":\"${error.message}\",\"code\":\"${error.code}\"}"
+            .toResponseBody("application/json".toMediaType())
+        return HttpException(Response.error<Any>(code, body))
+    }
+
+    private fun rawHttpException(code: Int, rawBody: String): HttpException {
+        val body = rawBody.toResponseBody("application/json".toMediaType())
+        return HttpException(Response.error<Any>(code, body))
+    }
+
+    private fun createUserData(refreshToken: String?): UserData {
+        return UserData(
+            id = 10,
+            fullName = "Test User",
+            email = "user@example.com",
+            roleName = "staff",
+            positionName = "Engineer",
+            programName = "Program",
+            divisionName = "Division",
+            nipNim = "12345",
+            phone = "08123456789",
+            photo = "photo.jpg",
+            photoUpdatedAt = "2026-01-01T00:00:00Z",
+            location = LocationData(
+                latitude = -0.9,
+                longitude = 119.8,
+                radius = 100,
+                description = "Office",
+                categoryName = "WFO"
+            ),
+            token = "access-token",
+            refreshToken = refreshToken
+        )
+    }
+
+    private suspend fun unsupportedRefreshSession(): RefreshSessionResponse {
+        throw NotImplementedError("refreshSession not expected in this test")
+    }
+}
+
+private class FakeUserDao : UserDao {
+    override suspend fun insertOrUpdateUserProfile(userEntity: UserEntity) {
+        // no-op
+    }
+
+    override fun getUserProfileFlow(): Flow<UserEntity?> = flowOf(null)
+
+    override suspend fun getUserProfile(): UserEntity? = null
+
+    override suspend fun clearUserProfile() {
+        // no-op
+    }
+}
+
+private class CapturingUserDao : UserDao {
+    val insertedUsers = mutableListOf<UserEntity>()
+
+    override suspend fun insertOrUpdateUserProfile(userEntity: UserEntity) {
+        insertedUsers += userEntity
+    }
+
+    override fun getUserProfileFlow(): Flow<UserEntity?> = flowOf(null)
+
+    override suspend fun getUserProfile(): UserEntity? = null
+
+    override suspend fun clearUserProfile() {
+        // no-op
+    }
+}
+
+private class CachedUserDao(
+    private val cachedUser: UserEntity
+) : UserDao {
+    override suspend fun insertOrUpdateUserProfile(userEntity: UserEntity) {
+        // no-op
+    }
+
+    override fun getUserProfileFlow(): Flow<UserEntity?> = flowOf(cachedUser)
+
+    override suspend fun getUserProfile(): UserEntity? = cachedUser
+
+    override suspend fun clearUserProfile() {
+        // no-op
+    }
+}
+
+private class FakeApiService(
+    private val refreshSessionBlock: suspend () -> RefreshSessionResponse,
+    private val loginBlock: suspend (LoginRequest) -> LoginResponse = { throw NotImplementedError("login not configured in test") },
+    private val getUserProfileBlock: suspend () -> LoginResponse = { throw NotImplementedError("getUserProfile not configured in test") }
+) : ApiService {
+    var lastRefreshRequest: RefreshSessionRequest? = null
+
+    override suspend fun refreshSession(request: RefreshSessionRequest): RefreshSessionResponse {
+        lastRefreshRequest = request
+        return refreshSessionBlock()
+    }
+
+    override suspend fun login(loginRequest: LoginRequest): LoginResponse {
+        return loginBlock(loginRequest)
+    }
+
+    override suspend fun getUserProfile(): LoginResponse {
+        return getUserProfileBlock()
+    }
+
+    override suspend fun logout(): LogoutResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun checkIn(request: AttendanceRequest): AttendanceResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun checkOut(attendanceId: Int, request: CheckOutRequestDto): AttendanceResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getTodayStatus(): TodayStatusResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getAttendanceHistory(period: String, page: Int, limit: Int): AttendanceHistoryResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun updateUserProfile(userId: Int, request: ProfileUpdateRequest): ProfileUpdateResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun sendLocationEvent(request: LocationEventRequest): Response<Unit> {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getWfaRecommendations(latitude: Double, longitude: Double): WfaRecommendationResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun getBookingHistory(
+        status: String?,
+        page: Int,
+        limit: Int,
+        sortBy: String,
+        sortOrder: String
+    ): BookingHistoryResponse {
+        throw NotImplementedError()
+    }
+
+    override suspend fun submitWfaBooking(request: BookingRequest): BookingResponse {
+        throw NotImplementedError()
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
+++ b/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
@@ -166,6 +166,31 @@ class AuthRefreshInterceptorTest {
     }
 
     @Test
+    fun `401 on protected request with unexpected refresh exception returns original 401 without logout`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.onRefresh = {
+            throw IllegalStateException("boom")
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req -> okResponse(req, 401) }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(401, response.code)
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        assertEquals("token-a", fixture.userPreference.getAuthToken().first())
+        assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
+        response.close()
+    }
+
+    @Test
     fun `request retried at most once when retry response is still 401`() = runBlocking {
         val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
         fixture.userPreference.saveSession("old-access", "10", "old-refresh")

--- a/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
+++ b/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
@@ -1,0 +1,433 @@
+package com.example.infinite_track.di.auth
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Provider
+
+class AuthRefreshInterceptorTest {
+
+    @Test
+    fun `non 401 response returns normally without refresh`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req -> okResponse(req, 200) }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(200, response.code)
+        assertEquals(0, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        response.close()
+    }
+
+    @Test
+    fun `401 on protected request refreshes once and retries with latest token`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("old-access", "10", "old-refresh")
+        fixture.onRefresh = {
+            fixture.userPreference.saveSession("new-access", "10", "new-refresh")
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val proceedCalls = AtomicInteger(0)
+        val observedAuthHeaders = mutableListOf<String?>()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req ->
+                observedAuthHeaders += req.header("Authorization")
+                if (proceedCalls.incrementAndGet() == 1) {
+                    okResponse(req, 401)
+                } else {
+                    okResponse(req, 200)
+                }
+            }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(200, response.code)
+        assertEquals(2, proceedCalls.get())
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(listOf("Bearer old-access", "Bearer new-access"), observedAuthHeaders)
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        response.close()
+    }
+
+    @Test
+    fun `auth endpoints do not get authorization bearer injected`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        val interceptor = fixture.createInterceptor()
+
+        val requests = listOf(
+            request("https://example.com/api/auth/login"),
+            request("https://example.com/api/auth/refresh"),
+            request("https://example.com/api/auth/logout")
+        )
+
+        requests.forEach { original ->
+            var observedAuth: String? = null
+            val chain = FakeChain(
+                request = original,
+                proceedBlock = { req ->
+                    observedAuth = req.header("Authorization")
+                    okResponse(req, 401)
+                }
+            )
+
+            val response = interceptor.intercept(chain)
+            assertEquals(401, response.code)
+            assertEquals(null, observedAuth)
+            response.close()
+        }
+
+        assertEquals(0, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+    }
+
+    @Test
+    fun `401 on protected request with reauth required clears session and triggers forced reauth`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.ReAuthRequired.InvalidOrRevoked)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req -> okResponse(req, 401) }
+        )
+
+        val response = interceptor.intercept(chain)
+        delay(100)
+
+        assertEquals(401, response.code)
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(1, fixture.logoutCalls.get())
+        assertTrue(fixture.sessionManager.sessionExpired.value)
+        response.close()
+    }
+
+    @Test
+    fun `401 on protected request with temporary refresh failure keeps auth state and does not force reauth`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.TemporaryFailure("timeout"))
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req -> okResponse(req, 401) }
+        )
+
+        val response = interceptor.intercept(chain)
+        delay(100)
+
+        assertEquals(401, response.code)
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        assertEquals("token-a", fixture.userPreference.getAuthToken().first())
+        assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
+        response.close()
+    }
+
+    @Test
+    fun `request retried at most once when retry response is still 401`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("old-access", "10", "old-refresh")
+        fixture.onRefresh = {
+            fixture.userPreference.saveSession("new-access", "10", "new-refresh")
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val proceedCalls = AtomicInteger(0)
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req ->
+                proceedCalls.incrementAndGet()
+                okResponse(req, 401)
+            }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(401, response.code)
+        assertEquals(2, proceedCalls.get())
+        assertEquals(1, fixture.refreshCalls.get())
+        response.close()
+    }
+
+    @Test
+    fun `concurrent 401 protected requests use single refresh call and all retry`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.Success)
+        fixture.userPreference.saveSession("old-access", "10", "old-refresh")
+        fixture.onRefresh = {
+            delay(120)
+            fixture.userPreference.saveSession("new-access", "10", "new-refresh")
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val firstAttemptSeen = java.util.concurrent.ConcurrentHashMap.newKeySet<Int>()
+        val proceedCounts = java.util.concurrent.ConcurrentHashMap<Int, AtomicInteger>()
+        val threadPool = Executors.newFixedThreadPool(5)
+        val done = CountDownLatch(5)
+        val responses = java.util.Collections.synchronizedList(mutableListOf<Response>())
+        val failures = java.util.Collections.synchronizedList(mutableListOf<Throwable>())
+
+        try {
+            for (idx in 1..5) {
+                threadPool.execute {
+                    try {
+                        val chain = FakeChain(
+                            request = request("https://example.com/api/attendance/status-today?req=$idx"),
+                            proceedBlock = { req ->
+                                val count = proceedCounts.computeIfAbsent(idx) { AtomicInteger(0) }.incrementAndGet()
+                                if (count == 1) {
+                                    firstAttemptSeen.add(idx)
+                                    okResponse(req, 401)
+                                } else {
+                                    okResponse(req, 200)
+                                }
+                            }
+                        )
+                        responses += interceptor.intercept(chain)
+                    } catch (t: Throwable) {
+                        failures += t
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+
+            assertTrue(done.await(3, TimeUnit.SECONDS))
+            assertTrue(failures.isEmpty())
+            assertEquals(5, responses.size)
+            responses.forEach { response ->
+                assertEquals(200, response.code)
+                response.close()
+            }
+
+            assertEquals(5, firstAttemptSeen.size)
+            assertTrue(proceedCounts.values.all { it.get() == 2 })
+            assertEquals(1, fixture.refreshCalls.get())
+        } finally {
+            threadPool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `concurrent 401 protected requests with shared reauth required trigger logout once`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.ReAuthRequired.InvalidOrRevoked)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.onRefresh = {
+            delay(120)
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val threadPool = Executors.newFixedThreadPool(5)
+        val done = CountDownLatch(5)
+        val responses = java.util.Collections.synchronizedList(mutableListOf<Response>())
+        val failures = java.util.Collections.synchronizedList(mutableListOf<Throwable>())
+
+        try {
+            for (idx in 1..5) {
+                threadPool.execute {
+                    try {
+                        val chain = FakeChain(
+                            request = request("https://example.com/api/attendance/status-today?req=$idx"),
+                            proceedBlock = { req -> okResponse(req, 401) }
+                        )
+                        responses += interceptor.intercept(chain)
+                    } catch (t: Throwable) {
+                        failures += t
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+
+            assertTrue(done.await(3, TimeUnit.SECONDS))
+            assertTrue(failures.isEmpty())
+            assertEquals(5, responses.size)
+            responses.forEach { response ->
+                assertEquals(401, response.code)
+                response.close()
+            }
+
+            assertEquals(1, fixture.refreshCalls.get())
+            assertEquals(1, fixture.logoutCalls.get())
+            assertTrue(fixture.sessionManager.sessionExpired.value)
+        } finally {
+            threadPool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `after session-expired reset later reauth wave can trigger logout again`() = runBlocking {
+        val fixture = TestFixture(refreshResult = RefreshSessionResult.ReAuthRequired.InvalidOrRevoked)
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.onRefresh = {
+            delay(120)
+        }
+
+        val interceptor = fixture.createInterceptor()
+        val firstWavePool = Executors.newFixedThreadPool(3)
+        val firstWaveDone = CountDownLatch(3)
+
+        try {
+            repeat(3) {
+                firstWavePool.execute {
+                    try {
+                        val chain = FakeChain(
+                            request = request("https://example.com/api/attendance/status-today?wave=1&req=$it"),
+                            proceedBlock = { req -> okResponse(req, 401) }
+                        )
+                        interceptor.intercept(chain).close()
+                    } finally {
+                        firstWaveDone.countDown()
+                    }
+                }
+            }
+            assertTrue(firstWaveDone.await(3, TimeUnit.SECONDS))
+        } finally {
+            firstWavePool.shutdownNow()
+        }
+
+        assertEquals(1, fixture.logoutCalls.get())
+        assertTrue(fixture.sessionManager.sessionExpired.value)
+
+        fixture.sessionManager.resetSessionExpired()
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+
+        fixture.userPreference.saveSession("token-b", "10", "refresh-b")
+
+        val secondWaveResponse = interceptor.intercept(
+            FakeChain(
+                request = request("https://example.com/api/attendance/status-today?wave=2"),
+                proceedBlock = { req -> okResponse(req, 401) }
+            )
+        )
+        secondWaveResponse.close()
+
+        assertEquals(2, fixture.logoutCalls.get())
+        assertTrue(fixture.sessionManager.sessionExpired.value)
+    }
+
+    private fun request(url: String): Request = Request.Builder().url(url).build()
+
+    private fun okResponse(request: Request, code: Int): Response {
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .message("test")
+            .code(code)
+            .body("{}".toResponseBody("application/json".toMediaType()))
+            .build()
+    }
+}
+
+private class TestFixture(
+    private val refreshResult: RefreshSessionResult
+) {
+    val refreshCalls = AtomicInteger(0)
+    val logoutCalls = AtomicInteger(0)
+    var onRefresh: (suspend () -> Unit)? = null
+
+    val userPreference: UserPreference = run {
+        val testFile = File.createTempFile("user_prefs", ".preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(produceFile = { testFile })
+        UserPreference(dataStore)
+    }
+
+    val sessionManager = SessionManager()
+
+    private val authRepository = object : AuthRepository {
+        override suspend fun refreshSession(): RefreshSessionResult {
+            refreshCalls.incrementAndGet()
+            onRefresh?.invoke()
+            return refreshResult
+        }
+
+        override suspend fun logout(): Result<Unit> {
+            logoutCalls.incrementAndGet()
+            userPreference.clearAuthData()
+            return Result.success(Unit)
+        }
+
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> = Result.failure(NotImplementedError())
+        override suspend fun syncUserProfile(): Result<UserModel> = Result.failure(NotImplementedError())
+        override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> = Result.failure(NotImplementedError())
+    }
+
+    fun createInterceptor(): AuthRefreshInterceptor {
+        val coordinator = RefreshSingleFlightCoordinator(authRepositoryProvider = Provider { authRepository })
+        return AuthRefreshInterceptor(
+            userPreference = userPreference,
+            refreshSingleFlightCoordinator = coordinator,
+            logoutUseCaseProvider = Provider { LogoutUseCase(authRepository) },
+            sessionManagerProvider = Provider { sessionManager }
+        )
+    }
+}
+
+private class FakeChain(
+    private val request: Request,
+    private val proceedBlock: (Request) -> Response
+) : Interceptor.Chain {
+    override fun request(): Request = request
+
+    override fun proceed(request: Request): Response = proceedBlock(request)
+
+    override fun call(): Call {
+        throw NotImplementedError("Not used in tests")
+    }
+
+    override fun connection(): Connection? = null
+
+    override fun connectTimeoutMillis(): Int = 30_000
+
+    override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun readTimeoutMillis(): Int = 30_000
+
+    override fun withReadTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+
+    override fun writeTimeoutMillis(): Int = 30_000
+
+    override fun withWriteTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain = this
+}

--- a/app/src/test/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinatorTest.kt
+++ b/app/src/test/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinatorTest.kt
@@ -1,0 +1,53 @@
+package com.example.infinite_track.di.auth
+
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Provider
+
+class RefreshSingleFlightCoordinatorTest {
+
+    @Test
+    fun `concurrent refresh attempts share a single in flight refresh`() = runBlocking {
+        val refreshCalls = AtomicInteger(0)
+
+        val repository = object : AuthRepository {
+            override suspend fun refreshSession(): RefreshSessionResult {
+                refreshCalls.incrementAndGet()
+                delay(100)
+                return RefreshSessionResult.Success
+            }
+
+            override suspend fun login(loginRequest: LoginRequest): Result<UserModel> = Result.failure(NotImplementedError())
+            override suspend fun syncUserProfile(): Result<UserModel> = Result.failure(NotImplementedError())
+            override suspend fun logout(): Result<Unit> = Result.failure(NotImplementedError())
+            override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+            override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> = Result.failure(NotImplementedError())
+        }
+
+        val coordinator = RefreshSingleFlightCoordinator(
+            authRepositoryProvider = Provider { repository }
+        )
+
+        val results = coroutineScope {
+            (1..10).map {
+                async { coordinator.refreshOrJoin() }
+            }.awaitAll()
+        }
+
+        assertEquals(1, refreshCalls.get())
+        assertTrue(results.all { it is RefreshSessionResult.Success })
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -1,0 +1,207 @@
+package com.example.infinite_track.domain.use_case.auth
+
+import android.content.ContextWrapper
+import com.example.infinite_track.data.face.FaceProcessor
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.repository.UnauthorizedSyncFailure
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class CheckSessionUseCaseTest {
+
+    @Test
+    fun `bootstrap does not refresh after non-auth sync failure`() = runBlocking {
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(Result.failure(Exception("network down"))),
+            refreshSessionResult = RefreshSessionResult.TemporaryFailure("timeout")
+        )
+
+        val useCase = createUseCase(repository)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.TemporaryFailure)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `bootstrap refreshes after unauthorized sync failure`() = runBlocking {
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(Result.failure(UnauthorizedSyncFailure())),
+            refreshSessionResult = RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
+        )
+
+        val useCase = createUseCase(repository)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(
+            RefreshSessionResult.ReAuthRequired.InvalidOrRevoked,
+            (exception as SessionBootstrapFailure.ReAuthRequired).reason
+        )
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `retries sync after successful refresh and returns success`() = runBlocking {
+        val user = sampleUser()
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                Result.failure(UnauthorizedSyncFailure()),
+                Result.success(user)
+            ),
+            refreshSessionResult = RefreshSessionResult.Success,
+            loggedInUser = null
+        )
+
+        val useCase = createUseCase(repository)
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals(user, result.getOrNull())
+        assertEquals(2, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when second sync is still unauthorized after refresh success`() = runBlocking {
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                Result.failure(UnauthorizedSyncFailure()),
+                Result.failure(UnauthorizedSyncFailure())
+            ),
+            refreshSessionResult = RefreshSessionResult.Success,
+            loggedInUser = null
+        )
+
+        val useCase = createUseCase(repository)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(
+            RefreshSessionResult.ReAuthRequired.InvalidOrRevoked,
+            (exception as SessionBootstrapFailure.ReAuthRequired).reason
+        )
+        assertEquals(2, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns temporary bootstrap failure when embedding generation fails after successful sync`() = runBlocking {
+        val currentUser = sampleUser().copy(
+            photoUpdatedAt = "2025-12-01T00:00:00Z",
+            faceEmbedding = null
+        )
+        val syncedUser = sampleUser().copy(
+            photoUpdatedAt = "2026-01-01T00:00:00Z",
+            photoUrl = null
+        )
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(Result.success(syncedUser)),
+            refreshSessionResult = RefreshSessionResult.Success,
+            loggedInUser = currentUser
+        )
+
+        val useCase = createUseCase(repository)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.TemporaryFailure)
+    }
+
+    @Test
+    fun `rethrows cancellation exception from sync`() = runBlocking {
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(),
+            refreshSessionResult = RefreshSessionResult.Success,
+            syncThrowable = CancellationException("cancelled")
+        )
+        val useCase = createUseCase(repository)
+
+        try {
+            useCase()
+            fail("Expected CancellationException to be rethrown")
+        } catch (e: CancellationException) {
+            assertEquals("cancelled", e.message)
+        }
+    }
+
+    private fun createUseCase(repository: FakeAuthRepository): CheckSessionUseCase {
+        return CheckSessionUseCase(
+            authRepository = repository,
+            generateAndSaveEmbeddingUseCase = GenerateAndSaveEmbeddingUseCase(
+                faceProcessor = FaceProcessor(appContext = ContextWrapper(null)),
+                authRepository = repository
+            )
+        )
+    }
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "User",
+        email = "user@example.com",
+        roleName = "staff",
+        positionName = "Engineer",
+        programName = "Program",
+        divisionName = "Division",
+        nipNim = "123",
+        phone = "0812",
+        photoUrl = "https://example.com/photo.jpg",
+        photoUpdatedAt = "2026-01-01T00:00:00Z",
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
+        faceEmbedding = byteArrayOf(1, 2, 3)
+    )
+
+    private class FakeAuthRepository(
+        private val syncResults: MutableList<Result<UserModel>>,
+        private val refreshSessionResult: RefreshSessionResult,
+        private val loggedInUser: UserModel? = null,
+        private val syncThrowable: Throwable? = null
+    ) : AuthRepository {
+        var syncCallCount: Int = 0
+        var refreshCallCount: Int = 0
+
+        override suspend fun refreshSession(): RefreshSessionResult {
+            refreshCallCount += 1
+            return refreshSessionResult
+        }
+
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+            throw NotImplementedError()
+        }
+
+        override suspend fun syncUserProfile(): Result<UserModel> {
+            syncCallCount += 1
+            syncThrowable?.let { throw it }
+            return syncResults.removeFirst()
+        }
+
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
+
+        override fun getLoggedInUser(): Flow<UserModel?> = flowOf(loggedInUser)
+
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> = Result.success(Unit)
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
@@ -1,0 +1,208 @@
+package com.example.infinite_track.presentation.screen.splash
+
+import android.content.ContextWrapper
+import com.example.infinite_track.data.face.FaceProcessor
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
+import com.example.infinite_track.domain.repository.UnauthorizedSyncFailure
+import com.example.infinite_track.domain.use_case.auth.CheckSessionUseCase
+import com.example.infinite_track.domain.use_case.auth.GenerateAndSaveEmbeddingUseCase
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.SessionBootstrapFailure
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SplashViewModelTest {
+
+    @Test
+    fun `navigates to login and clears local session on non refreshable bootstrap failure`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repository = FakeAuthRepository(
+                syncResults = mutableListOf(Result.failure(UnauthorizedSyncFailure())),
+                refreshSessionResult = RefreshSessionResult.ReAuthRequired.InvalidOrRevoked
+            )
+
+            val viewModel = createViewModel(repository)
+
+            advanceUntilIdle()
+
+            assertEquals(SplashNavigationState.NavigateToLogin, viewModel.navigationState.value)
+            assertTrue(repository.logoutCalled)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `shows temporary failure state and preserves local session on temporary bootstrap failure`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repository = FakeAuthRepository(
+                syncResults = mutableListOf(Result.failure(Exception("network"))),
+                refreshSessionResult = RefreshSessionResult.TemporaryFailure("timeout")
+            )
+
+            val viewModel = createViewModel(repository)
+
+            advanceUntilIdle()
+
+            assertEquals(SplashNavigationState.TemporaryFailure, viewModel.navigationState.value)
+            assertFalse(repository.logoutCalled)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `generic bootstrap exception does not navigate to login and stays temporary failure`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repository = FakeAuthRepository(
+                syncResults = mutableListOf(
+                    Result.failure(Exception("initial sync failed")),
+                    Result.failure(Exception("post-refresh sync failed"))
+                ),
+                refreshSessionResult = RefreshSessionResult.Success
+            )
+
+            val viewModel = createViewModel(repository)
+
+            advanceUntilIdle()
+
+            assertEquals(SplashNavigationState.TemporaryFailure, viewModel.navigationState.value)
+            assertFalse(repository.logoutCalled)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `navigates to login and clears session when second sync stays unauthorized after refresh success`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repository = FakeAuthRepository(
+                syncResults = mutableListOf(
+                    Result.failure(UnauthorizedSyncFailure()),
+                    Result.failure(UnauthorizedSyncFailure())
+                ),
+                refreshSessionResult = RefreshSessionResult.Success
+            )
+
+            val viewModel = createViewModel(repository)
+
+            advanceUntilIdle()
+
+            assertEquals(SplashNavigationState.NavigateToLogin, viewModel.navigationState.value)
+            assertTrue(repository.logoutCalled)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `retry from temporary failure rechecks session and can navigate to home`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        try {
+            val repository = FakeAuthRepository(
+                syncResults = mutableListOf(
+                    Result.failure(Exception("network")),
+                    Result.success(sampleUser())
+                ),
+                refreshSessionResult = RefreshSessionResult.TemporaryFailure("timeout")
+            )
+
+            val viewModel = createViewModel(repository)
+            advanceUntilIdle()
+            assertEquals(SplashNavigationState.TemporaryFailure, viewModel.navigationState.value)
+
+            viewModel.retrySessionCheck()
+            advanceUntilIdle()
+
+            assertEquals(SplashNavigationState.NavigateToHome, viewModel.navigationState.value)
+            assertFalse(repository.logoutCalled)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun createViewModel(repository: FakeAuthRepository): SplashViewModel {
+        return SplashViewModel(
+            checkSessionUseCase = CheckSessionUseCase(
+                authRepository = repository,
+                generateAndSaveEmbeddingUseCase = GenerateAndSaveEmbeddingUseCase(
+                    faceProcessor = FaceProcessor(appContext = ContextWrapper(null)),
+                    authRepository = repository
+                )
+            ),
+            logoutUseCase = LogoutUseCase(repository),
+            context = ContextWrapper(null)
+        )
+    }
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "User",
+        email = "user@example.com",
+        roleName = "staff",
+        positionName = "Engineer",
+        programName = "Program",
+        divisionName = "Division",
+        nipNim = "123",
+        phone = "0812",
+        photoUrl = null,
+        photoUpdatedAt = null,
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
+        faceEmbedding = null
+    )
+
+    private class FakeAuthRepository(
+        private val syncResults: MutableList<Result<UserModel>>,
+        private val refreshSessionResult: RefreshSessionResult
+    ) : AuthRepository {
+
+        var logoutCalled: Boolean = false
+
+        override suspend fun refreshSession(): RefreshSessionResult = refreshSessionResult
+
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+            throw NotImplementedError()
+        }
+
+        override suspend fun syncUserProfile(): Result<UserModel> = syncResults.removeFirst()
+
+        override suspend fun logout(): Result<Unit> {
+            logoutCalled = true
+            return Result.success(Unit)
+        }
+
+        override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+            return Result.success(Unit)
+        }
+    }
+}

--- a/docs/adr/ADR-007-refresh-session-and-bootstrap-truthfulness.md
+++ b/docs/adr/ADR-007-refresh-session-and-bootstrap-truthfulness.md
@@ -1,0 +1,88 @@
+# ADR-007: Refresh session and bootstrap truthfulness for Android
+
+- Status: Accepted
+- Date: 2026-04-22
+
+## Context
+
+Android previously treated `401` as an immediate logout signal and allowed bootstrap session continuity to rely on local state more than backend confirmation. That behavior was no longer acceptable once backend-authored refresh-session semantics were introduced.
+
+This change is governance-significant because it touches:
+- session/token contract interpretation
+- source-of-truth handling between Android and backend
+- retry/idempotency-sensitive networking behavior
+- bootstrap behavior at cold start and app resume
+
+## Decision
+
+### 1. Backend remains the source of truth
+Android does not treat cached local user/profile state as proof that a backend session is still valid. Bootstrap only enters the authenticated flow after backend validity is re-established.
+
+### 2. Android uses an explicit mobile refresh contract
+Android consumes the backend refresh endpoint through:
+- `POST /api/auth/refresh`
+- header: `X-Client-Type: android`
+- request body containing the stored `refresh_token`
+
+Android does not rely on an implicit cookie-only assumption for the mobile refresh path.
+
+### 3. Refresh-token presence is a session invariant
+A login response must contain a usable refresh token for Android to persist a logged-in session. Android does not store a session that cannot satisfy the refresh contract.
+
+### 4. Refresh outcomes are classified explicitly
+Android classifies refresh into four outcomes:
+- `Success`
+- `ReAuthRequired.InvalidOrRevoked`
+- `ReAuthRequired.InactivityExceeded`
+- `TemporaryFailure`
+
+This classification is used to keep auth/session behavior truthful:
+- `InvalidOrRevoked` and `InactivityExceeded` trigger cleanup and full re-auth.
+- `TemporaryFailure` preserves local session state and must not be treated as auth invalidity.
+
+### 5. Protected request refresh uses single-flight orchestration
+For protected Android API requests:
+1. attach the current bearer token
+2. execute the request
+3. if the response is `401` on a protected non-auth endpoint, refresh once through a shared single-flight coordinator
+4. if refresh succeeds, retry the original request exactly once with the latest access token
+5. if refresh requires re-auth, clear session and trigger the forced re-auth path
+6. if refresh fails temporarily, do not clear session and do not trigger forced re-auth
+
+Android excludes login, logout, and refresh endpoints from bearer injection and refresh recursion.
+
+### 6. Forced re-auth side effects are de-duplicated per wave
+Concurrent requests that share the same `ReAuthRequired` refresh result must not fan out repeated logout/session-expired side effects. Android guards forced re-auth handling so one wave of concurrent 401s triggers logout/session-expired once, and the guard resets after the UI acknowledges the session-expired state.
+
+### 7. Bootstrap failure handling is bounded and truthful
+At bootstrap:
+- unauthorized sync failure may attempt refresh
+- non-auth sync failure must not consume refresh-session state
+- if refresh succeeds but the follow-up backend sync is still unauthorized, Android treats that as re-auth required
+- post-sync local side-effect failures (for example face-embedding generation) are treated as temporary bootstrap failures, not as proof that backend session is invalid
+
+Android uses a bounded temporary bootstrap failure state with user actions to retry or go to login. It does not remain in indefinite splash loading and does not force logout for temporary bootstrap failure.
+
+## Consequences
+
+### Positive
+- Android session continuity now follows backend truth more closely.
+- Temporary transport/server failures no longer masquerade as invalid session.
+- Concurrent 401 handling avoids refresh storms.
+- Bootstrap no longer silently trusts cached local state as authenticated truth.
+
+### Trade-offs
+- Android now depends on a stricter auth/session contract from backend.
+- Login is stricter because refresh-token availability is mandatory for a persisted session.
+- Temporary bootstrap failures surface a bounded retry/login UX instead of silently entering the app.
+
+## Verification expectations
+
+The following scenarios must remain verifiable:
+- login -> access token expired -> refresh succeeds
+- active protected request -> refresh succeeds -> retry once
+- invalid/revoked refresh -> cleanup + login
+- inactivity `> 48 jam` -> full re-auth required
+- temporary refresh failure -> preserve local session, no forced logout
+- concurrent 401s -> one refresh wave, no refresh storm
+- bootstrap temporary failure -> bounded retry/login state, not cached-user continuity and not forced logout

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,3 @@
+# ADR Index
+
+- [ADR-007: Refresh session and bootstrap truthfulness for Android](ADR-007-refresh-session-and-bootstrap-truthfulness.md)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ roomCompiler = "2.6.1"
 roomRuntime = "2.6.1"
 workRuntimeKtx = "2.9.0"
 androidxHiltCompiler = "1.0.0"
+kotlinxCoroutinesTest = "1.8.1"
 
 [libraries]
 face-detection = { module = "com.google.mlkit:face-detection", version.ref = "faceDetection" }
@@ -116,6 +117,7 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHiltCompiler" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- adopt the Android refresh-session contract with explicit refresh token persistence, typed refresh outcomes, and single-flight 401 refresh orchestration
- make bootstrap truthfulness backend-authoritative by distinguishing re-auth-required vs temporary bootstrap failure and adding bounded splash retry/login handling
- add focused unit coverage for refresh contract, interceptor concurrency/retry behavior, bootstrap classification, and document the contract in ADR-007

## Test Plan
- [x] ./gradlew app:testDebugUnitTest
- [x] ./gradlew app:assembleDebug
- [x] ./gradlew app:assembleRelease
- [x] ./gradlew app:testReleaseUnitTest
- [x] Runtime verification against backend for invalid/revoked refresh, inactivity > 48 jam, and real offline/server failure handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)