### PR TITLE
feat: add local geofence notification flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 ./memory-bank
+/.worktrees/

--- a/app/src/androidTest/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryNotificationStateTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryNotificationStateTest.kt
@@ -1,0 +1,187 @@
+package com.example.infinite_track.data.repository.attendance
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.infinite_track.data.soucre.local.preferences.AttendancePreference
+import com.example.infinite_track.data.soucre.network.request.AttendanceRequest
+import com.example.infinite_track.data.soucre.network.request.BookingRequest
+import com.example.infinite_track.data.soucre.network.request.CheckOutRequestDto
+import com.example.infinite_track.data.soucre.network.request.LocationEventRequest
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.data.soucre.network.request.ProfileUpdateRequest
+import com.example.infinite_track.data.soucre.network.response.AttendanceData
+import com.example.infinite_track.data.soucre.network.response.AttendanceHistoryResponse
+import com.example.infinite_track.data.soucre.network.response.AttendanceResponse
+import com.example.infinite_track.data.soucre.network.response.LoginResponse
+import com.example.infinite_track.data.soucre.network.response.LogoutResponse
+import com.example.infinite_track.data.soucre.network.response.ProfileUpdateResponse
+import com.example.infinite_track.data.soucre.network.response.TodayStatusResponse
+import com.example.infinite_track.data.soucre.network.response.WfaRecommendationResponse
+import com.example.infinite_track.data.soucre.network.response.booking.BookingHistoryResponse
+import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
+import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.domain.model.attendance.AttendanceRequestModel
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import retrofit2.Response
+
+@RunWith(AndroidJUnit4::class)
+class AttendanceRepositoryNotificationStateTest {
+
+    private lateinit var attendancePreference: AttendancePreference
+    private lateinit var repository: AttendanceRepositoryImpl
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        attendancePreference = AttendancePreference(context)
+        runBlocking {
+            attendancePreference.clearActiveAttendanceId()
+            attendancePreference.clearNotificationSessionState()
+        }
+        repository = AttendanceRepositoryImpl(FakeApiService(), attendancePreference)
+    }
+
+    @Test
+    fun checkIn_resetsNotificationFlags_and_savesAttendanceId() = runBlocking {
+        attendancePreference.setUserInsideGeofence(true)
+        attendancePreference.setHasEnteredActiveSessionArea(true)
+
+        val request = AttendanceRequestModel(
+            categoryId = 1,
+            latitude = -6.2,
+            longitude = 106.8,
+            notes = "Check in",
+            bookingId = null,
+            type = "WFO"
+        )
+
+        val result = repository.checkIn(request)
+
+        assertNotNull(result.getOrNull())
+        assertEquals(101, attendancePreference.getActiveAttendanceId().first())
+        assertFalse(attendancePreference.isUserInsideGeofence().first())
+        assertFalse(attendancePreference.hasEnteredActiveSessionArea().first())
+    }
+
+    @Test
+    fun checkOut_clearsAttendanceId_and_resetsNotificationFlags() = runBlocking {
+        attendancePreference.saveActiveAttendanceId(101)
+        attendancePreference.setUserInsideGeofence(true)
+        attendancePreference.setHasEnteredActiveSessionArea(true)
+
+        val result = repository.checkOut(
+            attendanceId = 101,
+            latitude = -6.2,
+            longitude = 106.8
+        )
+
+        assertNotNull(result.getOrNull())
+        assertNull(attendancePreference.getActiveAttendanceId().first())
+        assertFalse(attendancePreference.isUserInsideGeofence().first())
+        assertFalse(attendancePreference.hasEnteredActiveSessionArea().first())
+    }
+
+    private class FakeApiService : ApiService {
+        override suspend fun login(loginRequest: LoginRequest): LoginResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun getUserProfile(): LoginResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun logout(): LogoutResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun checkIn(request: AttendanceRequest): AttendanceResponse {
+            return AttendanceResponse(
+                success = true,
+                message = "ok",
+                data = sampleAttendanceData(idAttendance = 101, timeOut = null)
+            )
+        }
+
+        override suspend fun checkOut(
+            attendanceId: Int,
+            request: CheckOutRequestDto
+        ): AttendanceResponse {
+            return AttendanceResponse(
+                success = true,
+                message = "ok",
+                data = sampleAttendanceData(idAttendance = attendanceId, timeOut = "17:00:00")
+            )
+        }
+
+        override suspend fun getTodayStatus(): TodayStatusResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun getAttendanceHistory(
+            period: String,
+            page: Int,
+            limit: Int
+        ): AttendanceHistoryResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun updateUserProfile(
+            userId: Int,
+            request: ProfileUpdateRequest
+        ): ProfileUpdateResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun sendLocationEvent(request: LocationEventRequest): Response<Unit> {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun getWfaRecommendations(
+            latitude: Double,
+            longitude: Double
+        ): WfaRecommendationResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): BookingHistoryResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        override suspend fun submitWfaBooking(request: BookingRequest): BookingResponse {
+            throw UnsupportedOperationException("Not needed for this test")
+        }
+
+        private fun sampleAttendanceData(idAttendance: Int, timeOut: String?): AttendanceData {
+            return AttendanceData(
+                idAttendance = idAttendance,
+                userId = 1,
+                categoryId = 1,
+                statusId = 1,
+                locationId = 1,
+                bookingId = null,
+                timeIn = "08:00:00",
+                timeOut = timeOut,
+                workHour = "08:00",
+                attendanceDate = "2026-04-23",
+                notes = "test",
+                createdAt = null,
+                updatedAt = null
+            )
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreferenceNotificationStateTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreferenceNotificationStateTest.kt
@@ -1,0 +1,72 @@
+package com.example.infinite_track.data.soucre.local.preferences
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AttendancePreferenceNotificationStateTest {
+
+    @Test
+    fun clearNotificationSessionState_keepsAttendanceId_andResetsNotificationFlags() = runBlocking {
+        val attendancePreference = AttendancePreference(ApplicationProvider.getApplicationContext())
+
+        attendancePreference.clearActiveAttendanceId()
+        attendancePreference.clearNotificationSessionState()
+
+        attendancePreference.saveActiveAttendanceId(123)
+        attendancePreference.setUserInsideGeofence(true)
+        attendancePreference.setHasEnteredActiveSessionArea(true)
+
+        attendancePreference.clearNotificationSessionState()
+
+        assertEquals(123, attendancePreference.getActiveAttendanceId().first())
+        assertEquals(false, attendancePreference.isUserInsideGeofence().first())
+        assertEquals(false, attendancePreference.hasEnteredActiveSessionArea().first())
+
+        attendancePreference.clearActiveAttendanceId()
+        attendancePreference.clearNotificationSessionState()
+    }
+
+    @Test
+    fun getLastGeofenceParams_preservesFloatRadius() = runBlocking {
+        val attendancePreference = AttendancePreference(ApplicationProvider.getApplicationContext())
+
+        attendancePreference.clearLastGeofenceParams()
+        attendancePreference.saveLastGeofenceParams("office", -0.845f.toDouble(), 119.891f.toDouble(), 123.75f)
+
+        val params = attendancePreference.getLastGeofenceParams().first()!!
+
+        assertEquals("office", params.first)
+        assertEquals(123.75f, params.third, 0.0001f)
+
+        attendancePreference.clearLastGeofenceParams()
+    }
+
+    @Test
+    fun addReminderGeofences_replacesExistingEntryWithSameId() = runBlocking {
+        val attendancePreference = AttendancePreference(ApplicationProvider.getApplicationContext())
+
+        attendancePreference.clearReminderGeofences()
+        attendancePreference.addReminderGeofences(
+            listOf(ReminderGeofence("reminder:office", -0.845, 119.891, 100f))
+        )
+        attendancePreference.addReminderGeofences(
+            listOf(ReminderGeofence("reminder:office", -0.846, 119.892, 120.5f))
+        )
+
+        val reminders = attendancePreference.getReminderGeofences().first()
+
+        assertEquals(1, reminders.size)
+        assertEquals("reminder:office", reminders[0].id)
+        assertEquals(-0.846, reminders[0].latitude, 0.0001)
+        assertEquals(119.892, reminders[0].longitude, 0.0001)
+        assertEquals(120.5f, reminders[0].radiusMeters, 0.0001f)
+
+        attendancePreference.clearReminderGeofences()
+    }
+}

--- a/app/src/androidTest/java/com/example/infinite_track/utils/NotificationHelperIntentTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/utils/NotificationHelperIntentTest.kt
@@ -1,0 +1,27 @@
+package com.example.infinite_track.utils
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.infinite_track.presentation.main.MainActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NotificationHelperIntentTest {
+
+    @Test
+    fun buildLaunchAppIntent_opensMainActivity_withExpectedFlags_withoutAttendanceExtra() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val intent = NotificationHelper.buildLaunchAppIntent(context)
+
+        assertEquals(MainActivity::class.java.name, intent.component?.className)
+        assertEquals(
+            android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK,
+            intent.flags
+        )
+        assertFalse(intent.hasExtra("navigate_to_attendance"))
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -87,6 +87,7 @@ class AttendanceRepositoryImpl @Inject constructor(
             if (response.success) {
                 // Save the attendance ID for later checkout
                 attendancePreference.saveActiveAttendanceId(response.data.idAttendance)
+                attendancePreference.clearNotificationSessionState()
                 Log.d(
                     TAG,
                     "Check-in successful, saved attendance ID: ${response.data.idAttendance}"
@@ -129,6 +130,7 @@ class AttendanceRepositoryImpl @Inject constructor(
             if (response.success) {
                 // Clear the active attendance ID
                 attendancePreference.clearActiveAttendanceId()
+                attendancePreference.clearNotificationSessionState()
                 Log.d(TAG, "Check-out successful, cleared attendance ID")
 
                 // Convert DTO to ActiveAttendanceSession domain model using mapper

--- a/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreference.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreference.kt
@@ -27,6 +27,7 @@ class AttendancePreference @Inject constructor(
 	companion object {
 		private val ACTIVE_ATTENDANCE_ID_KEY = intPreferencesKey("active_attendance_id")
 		private val IS_INSIDE_GEOFENCE_KEY = booleanPreferencesKey("is_inside_geofence")
+		private val HAS_ENTERED_ACTIVE_SESSION_AREA_KEY = booleanPreferencesKey("has_entered_active_session_area")
 		private val LAST_GEOFENCE_REQUEST_ID_KEY = stringPreferencesKey("last_geofence_request_id")
 		private val LAST_GEOFENCE_LAT_KEY = floatPreferencesKey("last_geofence_lat")
 		private val LAST_GEOFENCE_LNG_KEY = floatPreferencesKey("last_geofence_lng")
@@ -96,14 +97,14 @@ class AttendancePreference @Inject constructor(
 	/**
 	 * Retrieve last geofence parameters as Triple(requestId, Pair(lat,lng), radiusMeters)
 	 */
-	fun getLastGeofenceParams(): Flow<Triple<String, Pair<Double, Double>, Int>?> {
+	fun getLastGeofenceParams(): Flow<Triple<String, Pair<Double, Double>, Float>?> {
 		return dataStore.data.map { preferences ->
 			val requestId = preferences[LAST_GEOFENCE_REQUEST_ID_KEY]
 			val lat = preferences[LAST_GEOFENCE_LAT_KEY]
 			val lng = preferences[LAST_GEOFENCE_LNG_KEY]
 			val radius = preferences[LAST_GEOFENCE_RADIUS_KEY]
 			if (requestId != null && lat != null && lng != null && radius != null) {
-				Triple(requestId, Pair(lat.toDouble(), lng.toDouble()), radius.toInt())
+				Triple(requestId, Pair(lat.toDouble(), lng.toDouble()), radius)
 			} else {
 				null
 			}
@@ -149,6 +150,25 @@ class AttendancePreference @Inject constructor(
 		}
 	}
 
+	fun hasEnteredActiveSessionArea(): Flow<Boolean> {
+		return dataStore.data.map { preferences ->
+			preferences[HAS_ENTERED_ACTIVE_SESSION_AREA_KEY] ?: false
+		}
+	}
+
+	suspend fun setHasEnteredActiveSessionArea(hasEntered: Boolean) {
+		dataStore.edit { preferences ->
+			preferences[HAS_ENTERED_ACTIVE_SESSION_AREA_KEY] = hasEntered
+		}
+	}
+
+	suspend fun clearNotificationSessionState() {
+		dataStore.edit { preferences ->
+			preferences[IS_INSIDE_GEOFENCE_KEY] = false
+			preferences[HAS_ENTERED_ACTIVE_SESSION_AREA_KEY] = false
+		}
+	}
+
 	/**
 	 * Reminder geofences - multi-store helpers
 	 */
@@ -156,7 +176,10 @@ class AttendancePreference @Inject constructor(
 		dataStore.edit { preferences ->
 			val current = preferences[REMINDER_GEOFENCES_KEY] ?: emptySet()
 			val merged = current.toMutableSet()
-			geofences.forEach { merged.add(it.serialize()) }
+			geofences.forEach { geofence ->
+				merged.removeAll { it.startsWith("${geofence.id}|") }
+				merged.add(geofence.serialize())
+			}
 			preferences[REMINDER_GEOFENCES_KEY] = merged
 		}
 	}

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/BootCompletedReceiver.kt
@@ -25,6 +25,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        val pendingResult = goAsync()
         val entryPoint = EntryPointAccessors.fromApplication(
             context.applicationContext,
             BootReceiverEntryPoint::class.java
@@ -35,23 +36,22 @@ class BootCompletedReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val params = attendancePreference.getLastGeofenceParams().firstOrNull()
-                if (params != null) {
-                    val (requestId, latLng, radius) = params
-                    val (lat, lng) = latLng
-                    Log.d("BootCompletedReceiver", "Re-registering monitoring geofence after boot: $requestId")
-                    geofenceManager.addGeofence(requestId, lat, lng, radius.toFloat())
-                } else {
-                    Log.d("BootCompletedReceiver", "No monitoring geofence to restore.")
+                val reminders = attendancePreference.getReminderGeofences().firstOrNull().orEmpty()
+
+                if (params == null && reminders.isEmpty()) {
+                    Log.d("BootCompletedReceiver", "No geofences to restore after boot.")
+                    return@launch
                 }
 
-                // Restore reminder geofences
-                val reminders = attendancePreference.getReminderGeofences().firstOrNull().orEmpty()
-                reminders.forEach { r ->
-                    Log.d("BootCompletedReceiver", "Re-registering reminder geofence after boot: ${'$'}{r.id}")
-                    geofenceManager.addReminderGeofence(r.id, r.latitude, r.longitude, r.radiusMeters)
-                }
+                Log.d("BootCompletedReceiver", "Restoring persisted geofences after boot")
+                geofenceManager.restoreGeofencesAfterBoot(
+                    monitoringGeofence = params,
+                    reminderGeofences = reminders
+                )
             } catch (e: Exception) {
                 Log.e("BootCompletedReceiver", "Failed to re-register geofence after boot", e)
+            } finally {
+                pendingResult.finish()
             }
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceBroadcastReceiver.kt
@@ -28,8 +28,8 @@ import java.util.Locale
 import java.util.TimeZone
 
 /**
- * BroadcastReceiver untuk menangani events geofence secara cerdas
- * Hanya memproses event jika ada sesi kerja yang aktif
+ * BroadcastReceiver untuk menangani event geofence untuk reminder check-in
+ * dan warning keluar area berdasarkan state sesi attendance lokal.
  */
 class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
@@ -53,7 +53,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val geofenceTransition = geofencingEvent?.geofenceTransition
         val triggeringGeofences = geofencingEvent?.triggeringGeofences ?: return
 
-        // Convert transition type to string
         val eventType = when (geofenceTransition) {
             Geofence.GEOFENCE_TRANSITION_ENTER -> "ENTER"
             Geofence.GEOFENCE_TRANSITION_EXIT -> "EXIT"
@@ -63,23 +62,21 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             }
         }
 
-        // Get dependencies using Hilt EntryPoint
+        val pendingResult = goAsync()
         val entryPoint = EntryPointAccessors.fromApplication(
             context.applicationContext,
             GeofenceReceiverEntryPoint::class.java
         )
         val attendancePreference = entryPoint.attendancePreference()
 
-        // Use coroutine to check active session
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                // Check if there's an active attendance session
                 val activeAttendanceId = attendancePreference.getActiveAttendanceId().first()
 
                 if (activeAttendanceId == null) {
-                    Log.d(TAG, "No active session. Handling as reminder mode for event: $eventType")
+                    attendancePreference.clearNotificationSessionState()
+                    Log.d(TAG, "No active session. Handling reminder-only path for event: $eventType")
 
-                    // In reminder mode, only act on ENTER to nudge user to check-in
                     if (eventType == "ENTER") {
                         triggeringGeofences.forEach { geofence ->
                             val locationId = geofence.requestId
@@ -93,71 +90,72 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                     return@launch
                 }
 
-                Log.d(
-                    TAG,
-                    "Active session found (ID: $activeAttendanceId). Processing geofence event: $eventType"
-                )
+                val hasEnteredActiveSessionArea = attendancePreference.hasEnteredActiveSessionArea().first()
 
-                // Update geofence status in preferences based on event type
-                when (eventType) {
-                    "ENTER" -> attendancePreference.setUserInsideGeofence(true)
-                    "EXIT" -> attendancePreference.setUserInsideGeofence(false)
-                }
-
-                // Process each triggered geofence
                 triggeringGeofences.forEach { geofence ->
                     val requestId = geofence.requestId
-                    // Ignore reminder geofences (prefixed) during active session
                     if (requestId.startsWith("reminder:")) {
                         Log.d(TAG, "Ignoring reminder geofence during active session: $requestId")
                         return@forEach
                     }
-                    processGeofenceEvent(context, geofence, eventType)
-                }
 
+                    when (eventType) {
+                        "ENTER" -> {
+                            attendancePreference.setUserInsideGeofence(true)
+                            attendancePreference.setHasEnteredActiveSessionArea(true)
+                        }
+                        "EXIT" -> attendancePreference.setUserInsideGeofence(false)
+                    }
+
+                    val action = GeofenceNotificationPolicy.decide(
+                        eventType = eventType,
+                        hasActiveSession = true,
+                        hasEnteredActiveSessionArea = hasEnteredActiveSessionArea
+                    )
+
+                    val friendlyLabel = when {
+                        requestId.startsWith("wfa:") -> "Lokasi WFA"
+                        else -> requestId
+                    }
+
+                    if (action == GeofenceNotificationAction.SHOW_EXIT_WARNING) {
+                        NotificationHelper.showExitAreaWarningNotification(context, friendlyLabel)
+                    }
+
+                    enqueueLocationEvent(context, geofence, eventType)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing geofence event", e)
+            } finally {
+                pendingResult.finish()
             }
         }
     }
 
-    private fun processGeofenceEvent(context: Context, geofence: Geofence, eventType: String) {
-        try {
-            val locationId = geofence.requestId // String: supports numeric and WFA ids
-
-            val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                timeZone = TimeZone.getTimeZone("UTC")
-            }
-            val timestamp = formatter.format(Date())
-
-            // Derive a user-friendly label for notification
-            val friendlyLabel = when {
-                locationId.startsWith("wfa:") -> "Lokasi WFA"
-                else -> locationId
-            }
-            NotificationHelper.showGeofenceNotification(context, eventType, friendlyLabel)
-
-            val workData = Data.Builder()
-                .putString(LocationEventWorker.KEY_EVENT_TYPE, eventType)
-                .putString(LocationEventWorker.KEY_LOCATION_ID, locationId)
-                .putString(LocationEventWorker.KEY_EVENT_TIMESTAMP, timestamp)
-                .build()
-
-            val constraints = androidx.work.Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
-
-            val workRequest = OneTimeWorkRequestBuilder<LocationEventWorker>()
-                .setInputData(workData)
-                .setConstraints(constraints)
-                .addTag("location_event_$locationId")
-                .build()
-
-            WorkManager.getInstance(context).enqueue(workRequest)
-
-            Log.d(TAG, "Location event enqueued: $eventType for $locationId at $timestamp")
-        } catch (e: Exception) {
-            Log.e(TAG, "Error processing geofence event for ${geofence.requestId}", e)
+    private fun enqueueLocationEvent(context: Context, geofence: Geofence, eventType: String) {
+        val locationId = geofence.requestId
+        val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
         }
+        val timestamp = formatter.format(Date())
+
+        val workData = Data.Builder()
+            .putString(LocationEventWorker.KEY_EVENT_TYPE, eventType)
+            .putString(LocationEventWorker.KEY_LOCATION_ID, locationId)
+            .putString(LocationEventWorker.KEY_EVENT_TIMESTAMP, timestamp)
+            .build()
+
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val workRequest = OneTimeWorkRequestBuilder<LocationEventWorker>()
+            .setInputData(workData)
+            .setConstraints(constraints)
+            .addTag("location_event_$locationId")
+            .build()
+
+        WorkManager.getInstance(context).enqueue(workRequest)
+        Log.d(TAG, "Location event enqueued: $eventType for $locationId at $timestamp")
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.example.infinite_track.data.soucre.local.preferences.AttendancePreference
+import com.example.infinite_track.data.soucre.local.preferences.ReminderGeofence
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofenceStatusCodes
@@ -232,6 +233,90 @@ class GeofenceManager @Inject constructor(
                 Log.e(TAG, "Gagal menambahkan reminder geofence: $id (${status ?: "?"}: ${statusText ?: exception.message})", exception)
             }
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun restoreGeofencesAfterBoot(
+        monitoringGeofence: Triple<String, Pair<Double, Double>, Float>?,
+        reminderGeofences: List<ReminderGeofence>
+    ) {
+        if (!hasForegroundLocationPermission()) {
+            Log.e(TAG, "Tidak ada izin ACCESS_FINE_LOCATION. Geofence tidak dapat dipulihkan setelah reboot.")
+            return
+        }
+        if (!hasBackgroundLocationPermission()) {
+            Log.e(TAG, "Tidak ada izin ACCESS_BACKGROUND_LOCATION. Geofence gagal dipulihkan setelah reboot (API 29+).")
+            return
+        }
+
+        val geofences = mutableListOf<Geofence>()
+        monitoringGeofence?.let { (requestId, latLng, radius) ->
+            val (lat, lng) = latLng
+            geofences.add(
+                Geofence.Builder()
+                    .setRequestId(requestId)
+                    .setCircularRegion(lat, lng, radius)
+                    .setExpirationDuration(Geofence.NEVER_EXPIRE)
+                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
+                    .build()
+            )
+        }
+        reminderGeofences.forEach { reminder ->
+            geofences.add(
+                Geofence.Builder()
+                    .setRequestId(reminder.id)
+                    .setCircularRegion(reminder.latitude, reminder.longitude, reminder.radiusMeters)
+                    .setExpirationDuration(Geofence.NEVER_EXPIRE)
+                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
+                    .build()
+            )
+        }
+
+        if (geofences.isEmpty()) {
+            Log.d(TAG, "No geofences to restore after boot.")
+            return
+        }
+
+        val locationRequest = LocationRequest.Builder(Priority.PRIORITY_BALANCED_POWER_ACCURACY, 10_000L)
+            .setMinUpdateIntervalMillis(5_000L)
+            .build()
+        val settingsRequest = LocationSettingsRequest.Builder()
+            .addLocationRequest(locationRequest)
+            .build()
+
+        settingsClient.checkLocationSettings(settingsRequest)
+            .addOnSuccessListener {
+                Log.d(TAG, "Membersihkan semua geofence sebelum memulihkan setelah reboot...")
+                geofencingClient.removeGeofences(geofencePendingIntent).run {
+                    addOnSuccessListener {
+                        val geofencingRequestBuilder = GeofencingRequest.Builder()
+                            .setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER)
+                        geofences.forEach { geofencingRequestBuilder.addGeofence(it) }
+
+                        geofencingClient.addGeofences(
+                            geofencingRequestBuilder.build(),
+                            geofencePendingIntent
+                        ).run {
+                            addOnSuccessListener {
+                                Log.d(TAG, "Berhasil memulihkan ${geofences.size} geofence setelah reboot")
+                            }
+                            addOnFailureListener { exception ->
+                                val status = (exception as? ApiException)?.statusCode
+                                val statusText = status?.let { GeofenceStatusCodes.getStatusCodeString(it) }
+                                Log.e(TAG, "Gagal memulihkan geofence setelah reboot (${status ?: "?"}: ${statusText ?: exception.message})", exception)
+                            }
+                        }
+                    }
+                    addOnFailureListener { exception ->
+                        Log.e(TAG, "Gagal menghapus geofence lama sebelum restore reboot", exception)
+                    }
+                }
+            }
+            .addOnFailureListener { exception ->
+                val status = (exception as? ApiException)?.statusCode
+                val statusText = status?.let { GeofenceStatusCodes.getStatusCodeString(it) }
+                Log.e(TAG, "Location settings tidak memenuhi syarat untuk memulihkan Geofencing (${status ?: "?"}: ${statusText ?: exception.message}). Pastikan Location diaktifkan.")
+            }
     }
 
     fun removeReminderGeofence(id: String) {

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceNotificationPolicy.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceNotificationPolicy.kt
@@ -1,0 +1,37 @@
+package com.example.infinite_track.presentation.geofencing
+
+import java.util.Locale
+
+enum class GeofenceNotificationAction {
+    SHOW_CHECK_IN_REMINDER,
+    SHOW_EXIT_WARNING,
+    NO_NOTIFICATION
+}
+
+object GeofenceNotificationPolicy {
+    fun decide(
+        eventType: String,
+        hasActiveSession: Boolean,
+        hasEnteredActiveSessionArea: Boolean
+    ): GeofenceNotificationAction {
+        return when (eventType.uppercase(Locale.ROOT)) {
+            "ENTER" -> {
+                if (hasActiveSession) {
+                    GeofenceNotificationAction.NO_NOTIFICATION
+                } else {
+                    GeofenceNotificationAction.SHOW_CHECK_IN_REMINDER
+                }
+            }
+
+            "EXIT" -> {
+                if (hasActiveSession && hasEnteredActiveSessionArea) {
+                    GeofenceNotificationAction.SHOW_EXIT_WARNING
+                } else {
+                    GeofenceNotificationAction.NO_NOTIFICATION
+                }
+            }
+
+            else -> GeofenceNotificationAction.NO_NOTIFICATION
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -1,16 +1,14 @@
 package com.example.infinite_track.presentation.main
 
 import android.Manifest
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
-import androidx.camera.core.ExperimentalGetImage
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.camera.core.ExperimentalGetImage
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.example.infinite_track.domain.manager.SessionManager
@@ -27,18 +25,14 @@ import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-	// Get SplashViewModel instance
 	private val viewModel: SplashViewModel by viewModels()
 
-	// Inject AppNavigator untuk navigasi dari Activity
 	@Inject
 	lateinit var appNavigator: AppNavigator
 
-	// Inject SessionManager untuk menangani session expiration
 	@Inject
 	lateinit var sessionManager: SessionManager
 
-	// Inject LocalizationRepository untuk mendapatkan bahasa tersimpan
 	@Inject
 	lateinit var localizationRepository: LocalizationRepository
 
@@ -47,10 +41,7 @@ class MainActivity : ComponentActivity() {
 
 	@ExperimentalGetImage
 	override fun onCreate(savedInstanceState: Bundle?) {
-		// Install splash screen BEFORE super.onCreate()
 		val splashScreen = installSplashScreen()
-
-		// Set keep on screen condition - keep splash screen visible while in Loading state
 		splashScreen.setKeepOnScreenCondition {
 			viewModel.navigationState.value is SplashNavigationState.Loading
 		}
@@ -58,7 +49,6 @@ class MainActivity : ComponentActivity() {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 
-		// Apply saved language before composing UI
 		runBlocking {
 			val savedLanguage = localizationRepository.getSelectedLanguage().first()
 			updateAppLanguage(this@MainActivity, savedLanguage)
@@ -73,24 +63,6 @@ class MainActivity : ComponentActivity() {
 					sessionManager = sessionManager
 				)
 			}
-		}
-
-		// Handle intent saat aplikasi pertama kali dibuka dari notifikasi
-		handleIntent(intent)
-	}
-
-	override fun onNewIntent(intent: Intent) {
-		super.onNewIntent(intent)
-		// Handle intent saat aplikasi sudah berjalan di background dan notifikasi diklik
-		handleIntent(intent)
-	}
-
-	private fun handleIntent(intent: Intent?) {
-		// Periksa apakah intent memiliki extra yang kita kirim dari NotificationHelper
-		if (intent?.getBooleanExtra("navigate_to_attendance", false) == true) {
-			// Gunakan AppNavigator untuk navigasi ke AttendanceScreen
-			appNavigator.navigateToAttendance()
-			Log.d("MainActivity", "Navigating to AttendanceScreen via AppNavigator")
 		}
 	}
 

--- a/app/src/main/java/com/example/infinite_track/utils/NotificationHelper.kt
+++ b/app/src/main/java/com/example/infinite_track/utils/NotificationHelper.kt
@@ -25,33 +25,31 @@ object NotificationHelper {
         notificationManager.createNotificationChannel(channel)
     }
 
-    fun showGeofenceNotification(context: Context, eventType: String, locationName: String) {
+    fun buildLaunchAppIntent(context: Context): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+    }
+
+    private fun buildLaunchAppPendingIntent(context: Context): PendingIntent {
+        return PendingIntent.getActivity(
+            context,
+            0,
+            buildLaunchAppIntent(context),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    fun showExitAreaWarningNotification(context: Context, locationName: String) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        // Generate message based on event type and location name
-        val message = when (eventType) {
-            "ENTER" -> "Anda telah memasuki area: $locationName"
-            "EXIT" -> "Anda telah meninggalkan area: $locationName"
-            else -> "Terdeteksi event lokasi."
-        }
-
-        // Intent untuk membuka MainActivity dan menavigasi ke AttendanceScreen
-        val intent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            // Add extra to indicate we should navigate to attendance screen
-            putExtra("navigate_to_attendance", true)
-        }
-        val pendingIntent = PendingIntent.getActivity(
-            context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.notifications_24px)
-            .setContentTitle("Pemberitahuan Area Presensi")
-            .setContentText(message)
+            .setContentTitle("Peringatan Keluar Area")
+            .setContentText("Anda telah meninggalkan area: $locationName")
             .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(buildLaunchAppPendingIntent(context))
             .setAutoCancel(true)
             .build()
 
@@ -62,20 +60,12 @@ object NotificationHelper {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        val intent = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            putExtra("navigate_to_attendance", true)
-        }
-        val pendingIntent = PendingIntent.getActivity(
-            context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.notifications_24px)
             .setContentTitle("Pengingat Check-in")
             .setContentText("Anda berada di area: $locationName. Jangan lupa check-in.")
             .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(buildLaunchAppPendingIntent(context))
             .setAutoCancel(true)
             .build()
 

--- a/app/src/test/java/com/example/infinite_track/presentation/geofencing/GeofenceNotificationPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/geofencing/GeofenceNotificationPolicyTest.kt
@@ -1,0 +1,84 @@
+package com.example.infinite_track.presentation.geofencing
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GeofenceNotificationPolicyTest {
+
+    @Test
+    fun noActiveSession_enter_returnsShowCheckInReminder() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "ENTER",
+            hasActiveSession = false,
+            hasEnteredActiveSessionArea = false
+        )
+
+        assertEquals(GeofenceNotificationAction.SHOW_CHECK_IN_REMINDER, action)
+    }
+
+    @Test
+    fun noActiveSession_exit_returnsNoNotification() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "EXIT",
+            hasActiveSession = false,
+            hasEnteredActiveSessionArea = false
+        )
+
+        assertEquals(GeofenceNotificationAction.NO_NOTIFICATION, action)
+    }
+
+    @Test
+    fun activeSession_enter_returnsNoNotification() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "ENTER",
+            hasActiveSession = true,
+            hasEnteredActiveSessionArea = false
+        )
+
+        assertEquals(GeofenceNotificationAction.NO_NOTIFICATION, action)
+    }
+
+    @Test
+    fun activeSession_exit_afterEnteringArea_returnsShowExitWarning() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "EXIT",
+            hasActiveSession = true,
+            hasEnteredActiveSessionArea = true
+        )
+
+        assertEquals(GeofenceNotificationAction.SHOW_EXIT_WARNING, action)
+    }
+
+    @Test
+    fun activeSession_exit_withoutEnteringArea_returnsNoNotification() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "EXIT",
+            hasActiveSession = true,
+            hasEnteredActiveSessionArea = false
+        )
+
+        assertEquals(GeofenceNotificationAction.NO_NOTIFICATION, action)
+    }
+
+    @Test
+    fun noActiveSession_lowercaseEnter_returnsShowCheckInReminder() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "enter",
+            hasActiveSession = false,
+            hasEnteredActiveSessionArea = false
+        )
+
+        assertEquals(GeofenceNotificationAction.SHOW_CHECK_IN_REMINDER, action)
+    }
+
+    @Test
+    fun activeSession_lowercaseExit_afterEnteringArea_returnsShowExitWarning() {
+        val action = GeofenceNotificationPolicy.decide(
+            eventType = "exit",
+            hasActiveSession = true,
+            hasEnteredActiveSessionArea = true
+        )
+
+        assertEquals(GeofenceNotificationAction.SHOW_EXIT_WARNING, action)
+    }
+}


### PR DESCRIPTION
## Summary
- add local-only geofence notification policy for check-in reminders and exit warnings
- persist notification session state, reset it on attendance lifecycle transitions, and open the app normally from notification taps
- harden boot geofence restore and receiver async lifecycle handling, with unit/instrumented coverage for policy, state, and notification intent behavior

## Test Plan
- [x] ./gradlew --no-daemon :app:testDebugUnitTest
- [x] ./gradlew --no-daemon :app:testDebugUnitTest --tests \"com.example.infinite_track.presentation.geofencing.GeofenceNotificationPolicyTest\"
- [x] ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.example.infinite_track.data.soucre.local.preferences.AttendancePreferenceNotificationStateTest
- [x] ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.example.infinite_track.data.repository.attendance.AttendanceRepositoryNotificationStateTest
- [x] ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.example.infinite_track.utils.NotificationHelperIntentTest

🤖 Generated with [Claude Code](https://claude.com/claude-code)