### PR TITLE
fix: harden WFA booking submit and prefill state

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt
@@ -10,7 +10,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -58,13 +59,11 @@ class WfaBookingViewModel @Inject constructor(
 
     private suspend fun loadUserData() {
         try {
-            val user = getLoggedInUserUseCase().firstOrNull()
-            user?.let {
-                _uiState.value = _uiState.value.copy(
-                    fullName = it.fullName,
-                    division = it.divisionName ?: ""
-                )
-            }
+            val user = getLoggedInUserUseCase().filterNotNull().first()
+            _uiState.value = _uiState.value.copy(
+                fullName = user.fullName,
+                division = user.divisionName ?: ""
+            )
         } catch (e: Exception) {
             _uiState.value = _uiState.value.copy(
                 error = "Failed to load user data: ${e.message}"

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -57,13 +58,12 @@ class WfaBookingViewModel @Inject constructor(
 
     private suspend fun loadUserData() {
         try {
-            getLoggedInUserUseCase().collect { user ->
-                user?.let {
-                    _uiState.value = _uiState.value.copy(
-                        fullName = it.fullName,
-                        division = it.divisionName?: "",
-                    )
-                }
+            val user = getLoggedInUserUseCase().firstOrNull()
+            user?.let {
+                _uiState.value = _uiState.value.copy(
+                    fullName = it.fullName,
+                    division = it.divisionName ?: ""
+                )
             }
         } catch (e: Exception) {
             _uiState.value = _uiState.value.copy(
@@ -112,12 +112,13 @@ class WfaBookingViewModel @Inject constructor(
     }
 
     fun onSubmitBooking() {
+        val currentState = _uiState.value
+        if (currentState.isLoading) return
+
+        _uiState.value = currentState.copy(isLoading = true, error = null)
+
         viewModelScope.launch {
             try {
-                _uiState.value = _uiState.value.copy(isLoading = true, error = null)
-
-                val currentState = _uiState.value
-
                 // Format schedule date to DD-MM-YYYY
                 val formattedDate = formatDate(currentState.scheduleDate)
 

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
@@ -8,6 +8,7 @@ import com.example.infinite_track.domain.model.location.LocationResult
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.BookingRepository
 import com.example.infinite_track.domain.repository.LocationRepository
+import com.example.infinite_track.domain.repository.RefreshSessionResult
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
@@ -39,9 +40,10 @@ class WfaBookingViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun init_prefillsUserDataFromSingleSnapshot() = runTest {
+    fun init_prefillsUserDataFromFirstNonNullSnapshot() = runTest {
         val authRepository = FakeAuthRepository(
             flow {
+                emit(null)
                 emit(testUser(fullName = "Febri", divisionName = "Android"))
                 emit(testUser(fullName = "Updated", divisionName = "Changed"))
             }
@@ -163,6 +165,10 @@ class WfaBookingViewModelTest {
     private class FakeAuthRepository(
         private val userFlow: Flow<UserModel?>
     ) : AuthRepository {
+        override suspend fun refreshSession(): RefreshSessionResult {
+            throw UnsupportedOperationException()
+        }
+
         override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
             throw UnsupportedOperationException()
         }

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
@@ -1,0 +1,263 @@
+package com.example.infinite_track.presentation.screen.attendance.booking
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.model.booking.BookingHistoryPage
+import com.example.infinite_track.domain.model.location.LocationResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.BookingRepository
+import com.example.infinite_track.domain.repository.LocationRepository
+import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
+import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
+import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WfaBookingViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun init_prefillsUserDataFromSingleSnapshot() = runTest {
+        val authRepository = FakeAuthRepository(
+            flow {
+                emit(testUser(fullName = "Febri", divisionName = "Android"))
+                emit(testUser(fullName = "Updated", divisionName = "Changed"))
+            }
+        )
+        val bookingRepository = FakeBookingRepository()
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+
+        assertEquals("Febri", viewModel.uiState.value.fullName)
+        assertEquals("Android", viewModel.uiState.value.division)
+    }
+
+    @Test
+    fun submit_ignoresRepeatedTapWhileRequestIsInFlight() = runTest {
+        val authRepository = FakeAuthRepository(MutableStateFlow(testUser()))
+        val bookingRepository = FakeBookingRepository(submitDelayMs = 1_000)
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+        viewModel.onScheduleDateChanged("2026-04-23")
+        viewModel.onDescriptionChanged("WFH dekat kantor")
+        viewModel.onNotesChanged("Catatan")
+
+        viewModel.onSubmitBooking()
+        viewModel.onSubmitBooking()
+        runCurrent()
+
+        assertTrue(viewModel.uiState.value.isLoading)
+        assertEquals(1, bookingRepository.submitCalls)
+    }
+
+    @Test
+    fun submit_allowsRetryAfterFailureCompletes() = runTest {
+        val authRepository = FakeAuthRepository(MutableStateFlow(testUser()))
+        val bookingRepository = FakeBookingRepository(
+            submitResults = mutableListOf(
+                Result.failure(Exception("gagal pertama")),
+                Result.success(Unit)
+            )
+        )
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+        viewModel.onScheduleDateChanged("2026-04-23")
+        viewModel.onDescriptionChanged("WFH dekat kantor")
+
+        viewModel.onSubmitBooking()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals(1, bookingRepository.submitCalls)
+
+        viewModel.onSubmitBooking()
+        advanceUntilIdle()
+
+        assertEquals(2, bookingRepository.submitCalls)
+    }
+
+    private fun buildViewModel(
+        authRepository: AuthRepository,
+        bookingRepository: BookingRepository,
+        locationRepository: LocationRepository
+    ): WfaBookingViewModel {
+        return WfaBookingViewModel(
+            submitWfaBookingUseCase = SubmitWfaBookingUseCase(bookingRepository),
+            getLoggedInUserUseCase = GetLoggedInUserUseCase(authRepository),
+            reverseGeocodeUseCase = ReverseGeocodeUseCase(locationRepository),
+            savedStateHandle = SavedStateHandle(
+                mapOf(
+                    "latitude" to 1.23f,
+                    "longitude" to 4.56f
+                )
+            )
+        )
+    }
+
+    private fun testUser(
+        fullName: String = "Febriyadi",
+        divisionName: String? = "Engineering"
+    ) = UserModel(
+        id = 1,
+        fullName = fullName,
+        email = "febri@example.com",
+        roleName = "Staff",
+        positionName = "Android Developer",
+        programName = null,
+        divisionName = divisionName,
+        nipNim = "12345",
+        phone = null,
+        photoUrl = null,
+        photoUpdatedAt = null,
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
+        faceEmbedding = null
+    )
+
+    private class FakeAuthRepository(
+        private val userFlow: Flow<UserModel?>
+    ) : AuthRepository {
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun syncUserProfile(): Result<UserModel> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun logout(): Result<Unit> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun getLoggedInUser(): Flow<UserModel?> = userFlow
+
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    private class FakeLocationRepository : LocationRepository {
+        override suspend fun getCurrentAddress(): Result<String> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun getCurrentCoordinates(): Result<Pair<Double, Double>> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun searchLocation(
+            query: String,
+            userLatitude: Double?,
+            userLongitude: Double?
+        ): Result<List<LocationResult>> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun reverseGeocode(latitude: Double, longitude: Double): Result<LocationResult> {
+            return Result.success(
+                LocationResult(
+                    placeName = "Test Place",
+                    address = "Test Address",
+                    latitude = latitude,
+                    longitude = longitude
+                )
+            )
+        }
+    }
+
+    private class FakeBookingRepository(
+        private val submitDelayMs: Long = 0,
+        private val submitResults: MutableList<Result<Unit>> = mutableListOf(Result.success(Unit))
+    ) : BookingRepository {
+        var submitCalls: Int = 0
+            private set
+
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): Result<BookingHistoryPage> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun submitBooking(
+            scheduleDate: String,
+            latitude: Double,
+            longitude: Double,
+            radius: Int,
+            description: String,
+            notes: String
+        ): Result<Unit> {
+            submitCalls += 1
+            if (submitDelayMs > 0) {
+                delay(submitDelayMs)
+            }
+            return if (submitResults.isNotEmpty()) {
+                submitResults.removeAt(0)
+            } else {
+                Result.success(Unit)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/docs/superpowers/plans/2026-04-23-wfa-booking-guard-prefill.md
+++ b/docs/superpowers/plans/2026-04-23-wfa-booking-guard-prefill.md
@@ -1,0 +1,579 @@
+# WFA Booking Guard & Prefill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the WFA booking screen duplicate-safe during in-flight submit and change booking prefill to a one-shot user snapshot instead of a long-lived profile stream.
+
+**Architecture:** Keep the change local to the booking flow. Add a focused unit test suite for `WfaBookingViewModel`, then minimally change the ViewModel so user prefill is read once during init and repeated submit attempts are ignored while `isLoading` is true. Only touch booking UI files if needed to keep submit behavior aligned with the ViewModel guard.
+
+**Tech Stack:** Kotlin, Android ViewModel, StateFlow, JUnit4, Gradle Kotlin DSL
+
+---
+
+## File map
+
+### Production files
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt`
+  - Replace streaming user prefill with a bounded snapshot read
+  - Add early-return submit guard using existing `isLoading`
+- Review-only unless needed: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingScreen.kt`
+  - Confirm submit callback path remains aligned with `isLoading`
+- Review-only unless needed: `app/src/main/java/com/example/infinite_track/presentation/components/dialog/WfaBookingDialog.kt`
+  - Only change if submit UI path can bypass loading alignment in a meaningful way
+
+### Test and test-support files
+- Modify: `app/build.gradle.kts`
+  - Add the minimum local unit-test support dependencies needed to instantiate and test the ViewModel predictably
+- Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt`
+  - Add focused unit tests for snapshot prefill and duplicate-submit guard behavior
+
+---
+
+### Task 1: Add the minimum unit-test support for ViewModel tests
+
+**Files:**
+- Modify: `app/build.gradle.kts:180-188`
+
+- [ ] **Step 1: Write the dependency change in `app/build.gradle.kts`**
+
+Add the minimum local unit-test dependencies directly under the existing `testImplementation(libs.junit)` line:
+
+```kotlin
+    testImplementation(libs.junit)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
+```
+
+Keep the rest of the test block unchanged.
+
+- [ ] **Step 2: Verify Gradle can resolve the new test dependencies**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --dry-run
+```
+
+Expected:
+- Gradle prints the `:app:testDebugUnitTest` task graph
+- No dependency-resolution error for `kotlinx-coroutines-test` or `core-testing`
+
+- [ ] **Step 3: Commit the dependency setup**
+
+Run:
+
+```bash
+git add app/build.gradle.kts
+git commit -m "test: add booking viewmodel unit test support"
+```
+
+Expected:
+- New commit created with only the Gradle test dependency change
+
+---
+
+### Task 2: Add failing tests for snapshot prefill and duplicate-submit guard
+
+**Files:**
+- Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/domain/model/auth/UserModel.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/domain/model/location/LocationResult.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/domain/use_case/auth/GetLoggedInUserUseCase.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/domain/use_case/booking/SubmitWfaBookingUseCase.kt`
+- Read for reference: `app/src/main/java/com/example/infinite_track/domain/use_case/location/ReverseGeocodeUseCase.kt`
+
+- [ ] **Step 1: Create the test file with fakes, dispatcher rule, and the first failing test**
+
+Create `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt` with this content:
+
+```kotlin
+package com.example.infinite_track.presentation.screen.attendance.booking
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.model.location.LocationResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.BookingRepository
+import com.example.infinite_track.domain.repository.LocationRepository
+import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
+import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
+import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WfaBookingViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun init_prefillsUserDataFromSingleSnapshot() = runTest {
+        val authRepository = FakeAuthRepository(
+            flow {
+                emit(testUser(fullName = "Febri", divisionName = "Android"))
+                emit(testUser(fullName = "Updated", divisionName = "Changed"))
+            }
+        )
+        val bookingRepository = FakeBookingRepository()
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+
+        assertEquals("Febri", viewModel.uiState.value.fullName)
+        assertEquals("Android", viewModel.uiState.value.division)
+    }
+
+    @Test
+    fun submit_ignoresRepeatedTapWhileRequestIsInFlight() = runTest {
+        val authRepository = FakeAuthRepository(MutableStateFlow(testUser()))
+        val bookingRepository = FakeBookingRepository(submitDelayMs = 1_000)
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+        viewModel.onScheduleDateChanged("2026-04-23")
+        viewModel.onDescriptionChanged("WFH dekat kantor")
+        viewModel.onNotesChanged("Catatan")
+
+        viewModel.onSubmitBooking()
+        viewModel.onSubmitBooking()
+        runCurrent()
+
+        assertTrue(viewModel.uiState.value.isLoading)
+        assertEquals(1, bookingRepository.submitCalls)
+    }
+
+    @Test
+    fun submit_allowsRetryAfterFailureCompletes() = runTest {
+        val authRepository = FakeAuthRepository(MutableStateFlow(testUser()))
+        val bookingRepository = FakeBookingRepository(
+            submitResults = mutableListOf(
+                Result.failure(Exception("gagal pertama")),
+                Result.success(Unit)
+            )
+        )
+        val locationRepository = FakeLocationRepository()
+
+        val viewModel = buildViewModel(
+            authRepository = authRepository,
+            bookingRepository = bookingRepository,
+            locationRepository = locationRepository
+        )
+
+        runCurrent()
+        viewModel.onScheduleDateChanged("2026-04-23")
+        viewModel.onDescriptionChanged("WFH dekat kantor")
+
+        viewModel.onSubmitBooking()
+        runCurrent()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals(1, bookingRepository.submitCalls)
+
+        viewModel.onSubmitBooking()
+        runCurrent()
+
+        assertEquals(2, bookingRepository.submitCalls)
+    }
+
+    private fun buildViewModel(
+        authRepository: AuthRepository,
+        bookingRepository: BookingRepository,
+        locationRepository: LocationRepository
+    ): WfaBookingViewModel {
+        return WfaBookingViewModel(
+            submitWfaBookingUseCase = SubmitWfaBookingUseCase(bookingRepository),
+            getLoggedInUserUseCase = GetLoggedInUserUseCase(authRepository),
+            reverseGeocodeUseCase = ReverseGeocodeUseCase(locationRepository),
+            savedStateHandle = SavedStateHandle(
+                mapOf(
+                    "latitude" to 1.23f,
+                    "longitude" to 4.56f
+                )
+            )
+        )
+    }
+
+    private fun testUser(
+        fullName: String = "Febriyadi",
+        divisionName: String? = "Engineering"
+    ) = UserModel(
+        id = 1,
+        fullName = fullName,
+        email = "febri@example.com",
+        roleName = "Staff",
+        positionName = "Android Developer",
+        programName = null,
+        divisionName = divisionName,
+        nipNim = "12345",
+        phone = null,
+        photoUrl = null,
+        photoUpdatedAt = null,
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
+        faceEmbedding = null
+    )
+
+    private class FakeAuthRepository(
+        private val userFlow: Flow<UserModel?>
+    ) : AuthRepository {
+        override suspend fun login(loginRequest: com.example.infinite_track.data.soucre.network.request.LoginRequest): Result<UserModel> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun syncUserProfile(): Result<UserModel> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun logout(): Result<Unit> {
+            throw UnsupportedOperationException()
+        }
+
+        override fun getLoggedInUser(): Flow<UserModel?> = userFlow
+
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    private class FakeLocationRepository : LocationRepository {
+        override suspend fun getCurrentAddress(): Result<String> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun getCurrentCoordinates(): Result<Pair<Double, Double>> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun searchLocation(
+            query: String,
+            userLatitude: Double?,
+            userLongitude: Double?
+        ): Result<List<LocationResult>> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun reverseGeocode(latitude: Double, longitude: Double): Result<LocationResult> {
+            return Result.success(
+                LocationResult(
+                    placeName = "Test Place",
+                    address = "Test Address",
+                    latitude = latitude,
+                    longitude = longitude
+                )
+            )
+        }
+    }
+
+    private class FakeBookingRepository(
+        private val submitDelayMs: Long = 0,
+        private val submitResults: MutableList<Result<Unit>> = mutableListOf(Result.success(Unit))
+    ) : BookingRepository {
+        var submitCalls: Int = 0
+            private set
+
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): Result<com.example.infinite_track.domain.model.booking.BookingHistoryPage> {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun submitBooking(
+            scheduleDate: String,
+            latitude: Double,
+            longitude: Double,
+            radius: Int,
+            description: String,
+            notes: String
+        ): Result<Unit> {
+            submitCalls += 1
+            if (submitDelayMs > 0) {
+                delay(submitDelayMs)
+            }
+            return if (submitResults.isNotEmpty()) {
+                submitResults.removeAt(0)
+            } else {
+                Result.success(Unit)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test file and confirm the first two behaviors fail against current production code**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModelTest"
+```
+
+Expected:
+- `init_prefillsUserDataFromSingleSnapshot` fails because the current ViewModel keeps collecting and ends up with the later emitted user value
+- `submit_ignoresRepeatedTapWhileRequestIsInFlight` fails because repeated submit increments `submitCalls` beyond 1
+- `submit_allowsRetryAfterFailureCompletes` may already pass or fail depending on current state timing; do not change the test yet
+
+- [ ] **Step 3: Commit the failing test suite**
+
+Run:
+
+```bash
+git add app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
+git commit -m "test: cover booking prefill and submit guard"
+```
+
+Expected:
+- New commit created with the test file only
+
+---
+
+### Task 3: Implement bounded prefill snapshot and duplicate-submit guard
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt:10-13`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt:58-73`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt:114-150`
+- Review-only: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingScreen.kt`
+- Review-only: `app/src/main/java/com/example/infinite_track/presentation/components/dialog/WfaBookingDialog.kt`
+
+- [ ] **Step 1: Replace the long-lived `collect` import usage with one-shot Flow retrieval imports**
+
+In `WfaBookingViewModel.kt`, replace the current Flow import block:
+
+```kotlin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+```
+
+with:
+
+```kotlin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+```
+
+- [ ] **Step 2: Rewrite `loadUserData()` to use a one-shot snapshot**
+
+Replace the current `loadUserData()` implementation:
+
+```kotlin
+    private suspend fun loadUserData() {
+        try {
+            getLoggedInUserUseCase().collect { user ->
+                user?.let {
+                    _uiState.value = _uiState.value.copy(
+                        fullName = it.fullName,
+                        division = it.divisionName?: "",
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            _uiState.value = _uiState.value.copy(
+                error = "Failed to load user data: ${e.message}"
+            )
+        }
+    }
+```
+
+with this bounded snapshot version:
+
+```kotlin
+    private suspend fun loadUserData() {
+        try {
+            val user = getLoggedInUserUseCase().firstOrNull()
+            user?.let {
+                _uiState.value = _uiState.value.copy(
+                    fullName = it.fullName,
+                    division = it.divisionName ?: ""
+                )
+            }
+        } catch (e: Exception) {
+            _uiState.value = _uiState.value.copy(
+                error = "Failed to load user data: ${e.message}"
+            )
+        }
+    }
+```
+
+- [ ] **Step 3: Add an early-return guard at the top of `onSubmitBooking()`**
+
+Replace the current method body start:
+
+```kotlin
+    fun onSubmitBooking() {
+        viewModelScope.launch {
+            try {
+                _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+
+                val currentState = _uiState.value
+```
+
+with:
+
+```kotlin
+    fun onSubmitBooking() {
+        if (_uiState.value.isLoading) return
+
+        viewModelScope.launch {
+            try {
+                val currentState = _uiState.value
+                _uiState.value = currentState.copy(isLoading = true, error = null)
+```
+
+This keeps the guard outside the coroutine launch and uses a single captured state snapshot before submit.
+
+- [ ] **Step 4: Verify no other production change is needed in the booking UI path**
+
+Read these files without editing unless necessary:
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/components/dialog/WfaBookingDialog.kt`
+
+Acceptance for this step:
+- Confirm the UI path still routes submit through `viewModel::onSubmitBooking`
+- Do not add extra UI state unless a concrete bug is found that bypasses the ViewModel guard
+
+- [ ] **Step 5: Run the targeted ViewModel test suite**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModelTest"
+```
+
+Expected:
+- `init_prefillsUserDataFromSingleSnapshot` passes
+- `submit_ignoresRepeatedTapWhileRequestIsInFlight` passes
+- `submit_allowsRetryAfterFailureCompletes` passes
+
+- [ ] **Step 6: Run the broader local unit test task**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest
+```
+
+Expected:
+- Existing local unit tests still pass
+- No new failure outside the booking test suite
+
+- [ ] **Step 7: Commit the production implementation**
+
+Run:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt
+git commit -m "fix: harden wfa booking submit and prefill state"
+```
+
+If UI files changed after the review-only check, include them explicitly in `git add`:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt \
+        app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingScreen.kt \
+        app/src/main/java/com/example/infinite_track/presentation/components/dialog/WfaBookingDialog.kt
+```
+
+Expected:
+- New commit created containing only the WFA booking production fix
+
+---
+
+### Task 4: Final verification against the approved scope
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-04-23-wfa-booking-guard-prefill-design.md`
+- Review: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt`
+- Review: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt`
+
+- [ ] **Step 1: Re-check the final code against the spec boundaries**
+
+Verify these conditions by reading the final code:
+- prefill is snapshot-only, not stream-based
+- duplicate submit is ignored while loading
+- retry is still possible after a completed failure
+- no accidental changes were made to `booking_id` behavior
+- no accidental changes were made to downstream refresh behavior after success
+
+- [ ] **Step 2: Run the booking-focused test command one more time**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModelTest"
+```
+
+Expected:
+- PASS for the full WFA booking ViewModel test class
+
+- [ ] **Step 3: Commit any final plan-alignment fix if needed**
+
+If no additional code changes were needed after verification, do not create an extra commit.
+
+If a tiny alignment fix was needed, run:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt \
+        app/src/test/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModelTest.kt
+git commit -m "test: align booking guard implementation with spec"
+```
+
+Expected:
+- Either no commit because everything already aligns, or one tiny cleanup commit

--- a/docs/superpowers/specs/2026-04-23-wfa-booking-guard-prefill-design.md
+++ b/docs/superpowers/specs/2026-04-23-wfa-booking-guard-prefill-design.md
@@ -1,0 +1,165 @@
+# WFA Booking Guard & Prefill Design
+
+Tanggal: 2026-04-23
+Status: Draft — approved in discussion, pending written spec review
+
+## Ringkasan
+Perubahan ini menyelesaikan dua issue Android Foundation pada flow WFA booking:
+- `INF-84` — duplicate-submit guard
+- `INF-85` — bounded snapshot read untuk user prefill
+
+Desain ini mempertahankan scope tetap kecil. Perubahan hanya menyentuh disiplin state pada layar booking agar submit tidak bisa dipicu berulang saat request masih berjalan, dan agar prefill `fullName` / `division` dibaca sekali saat layar dibuka alih-alih mengikuti stream profile yang hidup terus.
+
+## Tujuan
+- Mencegah duplicate submit pada transaksi booking WFA saat request masih in-flight
+- Mengubah prefill user menjadi snapshot sekali baca saat screen dibuka
+- Menjaga state layar booking tetap bounded dan mudah dipahami
+- Mempertahankan perilaku UI yang ada sejauh tidak bertentangan dengan dua tujuan di atas
+
+## Non-goals
+- Tidak mengubah contract booking inti seperti `booking_id`
+- Tidak mengubah downstream refresh behavior setelah booking sukses
+- Tidak merombak state machine layar booking menjadi arsitektur baru
+- Tidak mengubah UX dialog sukses/gagal selain penyelarasan minimal dengan state submit
+
+## Konteks implementasi saat ini
+Implementasi saat ini berada di `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/booking/WfaBookingViewModel.kt`.
+
+Temuan utama:
+- `loadUserData()` masih memakai `getLoggedInUserUseCase().collect { ... }`
+- `onSubmitBooking()` langsung memulai request baru tanpa early-return guard eksplisit saat `isLoading == true`
+- UI layar booking di `WfaBookingScreen.kt` sudah membaca `uiState` dan meneruskan `onSendClick = viewModel::onSubmitBooking`
+
+Konfirmasi desain dari diskusi:
+- prefill `fullName` dan `division` harus dibaca sekali saat screen dibuka
+- perubahan profile di background tidak perlu mengubah layar booking yang sudah terbuka
+
+## Pendekatan yang dipilih
+Desain memilih pendekatan minimal pada ViewModel.
+
+Alasan:
+- Dua issue ini sama-sama menyasar disiplin state layar booking
+- `isLoading` yang sudah ada cukup untuk menjadi sumber guard submit
+- Tidak perlu menambah submit state baru karena scope task hanya hardening kecil, bukan redesign flow
+
+## Keputusan desain
+
+### 1. Prefill user menjadi one-shot snapshot
+`WfaBookingViewModel` akan memuat data user sekali saat inisialisasi layar, lalu menyalin `fullName` dan `division` ke `uiState`.
+
+Perilaku final:
+- screen dibuka
+- ViewModel mengambil snapshot user login sekali
+- `fullName` dan `division` diisi ke state
+- tidak ada long-lived collection yang tetap aktif untuk prefill ini
+
+Konsekuensi yang disengaja:
+- jika profile user berubah saat layar booking sedang terbuka, field prefill di layar ini tidak ikut berubah
+- layar booking diperlakukan sebagai transactional surface dengan snapshot state yang bounded
+
+### 2. Duplicate-submit guard memakai `isLoading`
+`onSubmitBooking()` akan memiliki guard paling awal:
+- jika `uiState.isLoading == true`, submit baru diabaikan
+- jika `uiState.isLoading == false`, submit boleh lanjut
+
+Perilaku final:
+- tap pertama memulai submit dan mengubah `isLoading = true`
+- repeated tap selama request berjalan tidak memicu request tambahan
+- saat result kembali, `isLoading` kembali `false`
+- setelah itu submit baru boleh dilakukan lagi bila user masih berada di layar
+
+### 3. UI tetap selaras dengan state submit
+`WfaBookingScreen.kt` dan komponen dialog terkait akan dicek agar path submit benar-benar selaras dengan guard ini.
+
+Target minimal:
+- tombol kirim atau callback submit tidak menghasilkan multiple request saat loading
+- guard utama tetap berada di ViewModel, bukan hanya bergantung pada disabled state di UI
+
+Ini penting agar transactional safety tidak tergantung timing render Compose atau repeated tap behavior pada device.
+
+## Perubahan file yang diharapkan
+
+### `WfaBookingViewModel.kt`
+Perubahan utama ada di file ini.
+
+Yang akan diubah:
+- ganti pattern prefill dari stream collection menjadi one-shot retrieval
+- tambahkan early-return duplicate-submit guard di `onSubmitBooking()`
+- pertahankan alur success / failure yang sudah ada kecuali penyesuaian kecil yang diperlukan agar state tetap konsisten
+
+Yang tidak diubah:
+- contract `SubmitWfaBookingUseCase`
+- format payload booking selain yang sudah ada
+- struktur `WfaBookingState` kecuali jika ada kebutuhan kecil yang benar-benar langsung mendukung dua issue ini
+
+### `WfaBookingScreen.kt`
+File ini akan ditinjau untuk memastikan path submit UI selaras dengan `isLoading`.
+
+Perubahan hanya dilakukan bila perlu untuk menjaga konsistensi perilaku tombol kirim terhadap state loading.
+
+### `WfaBookingDialog.kt`
+File ini hanya akan disentuh jika komponen submit belum menghormati state loading dengan baik. Jika perilaku saat ini sudah cukup selaras, file ini tidak perlu diubah.
+
+## Data flow final
+
+### Initial load
+1. ViewModel dibuat
+2. koordinat dari `SavedStateHandle` dimasukkan ke state
+3. prefill user dibaca sekali
+4. reverse geocode tetap berjalan untuk mengisi alamat
+5. `fullName`, `division`, dan `address` terisi ke state sesuai hasil load masing-masing
+
+### Submit pertama
+1. user menekan tombol kirim
+2. ViewModel membaca state saat ini
+3. jika `isLoading == false`, ViewModel set `isLoading = true`
+4. tanggal diformat seperti perilaku saat ini
+5. request booking dikirim sekali
+6. result success/failure mengembalikan `isLoading = false`
+
+### Rapid repeated tap
+1. user menekan tombol kirim lagi saat request pertama belum selesai
+2. ViewModel melihat `isLoading == true`
+3. submit kedua langsung diabaikan
+4. tidak ada request kedua ke backend
+
+## Error handling
+Desain ini tidak mengubah taxonomy error booking yang lebih besar.
+
+Perilaku yang dipertahankan:
+- failure dari repository/use case tetap masuk ke `uiState.error`
+- dialog error tetap menggunakan path yang sudah ada
+- exception tak terduga tetap dikonversi ke error message umum
+
+Perubahan yang diwajibkan:
+- duplicate-submit yang diabaikan tidak boleh dianggap error
+- ignored repeated submit tidak perlu memunculkan dialog atau toast
+
+## Verification
+Verification minimum untuk task ini:
+
+### INF-84
+- repeated tap saat request submit masih berjalan tidak menghasilkan multiple request
+- `isLoading` menahan submit lanjutan sampai result pertama selesai
+- setelah success, state kembali stabil dan success path tetap berjalan
+- setelah failure, `isLoading` kembali `false` dan user bisa submit ulang
+
+### INF-85
+- `fullName` dan `division` tetap terisi saat screen dibuka
+- prefill tidak lagi bergantung pada `collect` yang hidup terus
+- tidak ada repeated state update yang tidak perlu dari stream profile selama layar terbuka
+
+## Risiko dan batas perubahan
+Risiko utama task ini kecil karena perubahan terlokalisasi pada layar booking.
+
+Hal yang perlu dijaga:
+- one-shot prefill tidak boleh memutus kemampuan layar untuk mengisi `fullName` dan `division`
+- guard submit tidak boleh memblokir retry setelah request selesai
+- perubahan tidak boleh melebar ke issue lain seperti `booking_id` contract atau downstream refresh contract
+
+## Hasil akhir yang diharapkan
+Setelah implementasi:
+- layar WFA booking punya prefill snapshot yang bounded
+- submit booking menjadi duplicate-safe selama request in-flight
+- reasoning state layar booking lebih sederhana
+- scope perubahan tetap kecil dan fokus pada INF-84 + INF-85

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ hiltAndroid = "2.48"
 hiltAndroidCompiler = "2.48"
 hiltNavigationCompose = "1.0.0"
 kotlin = "1.9.0"
+kotlinxCoroutinesTest = "1.8.1"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -85,6 +86,7 @@ converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroidCompiler" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ roomCompiler = "2.6.1"
 roomRuntime = "2.6.1"
 workRuntimeKtx = "2.9.0"
 androidxHiltCompiler = "1.0.0"
-kotlinxCoroutinesTest = "1.8.1"
 
 [libraries]
 face-detection = { module = "com.google.mlkit:face-detection", version.ref = "faceDetection" }
@@ -119,7 +118,6 @@ firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHiltCompiler" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- harden WFA booking submit flow so repeated taps are ignored while a request is in flight
- replace WFA booking user prefill stream collection with a bounded one-shot snapshot read
- add focused ViewModel unit tests plus the minimum test dependency wiring for booking flow verification

## Test Plan
- [x] ./gradlew :app:testDebugUnitTest --tests \"com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModelTest\"
- [x] ./gradlew :app:testDebugUnitTest
- [ ] Manual QA on emulator: rapid tap submit, failed submit then retry, success dialog then Home navigation, invalid/empty schedule behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)