### PR TITLE
fix: allow Android login without refresh token

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -76,21 +76,19 @@ class AuthRepositoryImpl @Inject constructor(
      */
     override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
         return try {
-            val response = apiService.login(loginRequest)
-            val refreshToken = response.data.refreshToken?.takeIf { it.isNotBlank() }
-                ?: return Result.failure(IllegalStateException("Login response missing usable refresh token"))
+            val loginResponse = apiService.login(loginRequest)
+            val loginData = loginResponse.data
+            val accessToken = loginData.token.takeIf { it.isNotBlank() }
+                ?: return Result.failure(IllegalStateException("Login response missing usable access token"))
+            val refreshToken = loginData.refreshToken?.takeIf { it.isNotBlank() }
 
-            // Save token and user ID to DataStore
             userPreference.saveSession(
-                token = response.data.token,
-                userId = response.data.id.toString(),
+                token = accessToken,
+                userId = loginData.id.toString(),
                 refreshToken = refreshToken
             )
 
-            // Convert network response to domain model
-            val user = response.data.toDomain()
-
-            // Save user data to Room database
+            val user = loginData.toDomain()
             val userEntity = user.toEntity(userDao.getUserProfile()?.faceEmbedding)
             userDao.insertOrUpdateUserProfile(userEntity)
 

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -48,61 +48,59 @@ import java.util.Locale
 class AuthRepositoryImplRefreshSessionTest {
 
     @Test
-    fun `login fails when refresh token is null in login response`() = runBlocking {
+    fun `login succeeds when refresh token is null in login response`() = runBlocking {
         val userPreference = createUserPreference()
         val userDao = CapturingUserDao()
-        val repository = AuthRepositoryImpl(
+        val repository = createLoginRepository(
             userPreference = userPreference,
-            apiService = FakeApiService(
-                loginBlock = {
-                    LoginResponse(
-                        success = true,
-                        message = "ok",
-                        data = createUserData(refreshToken = null)
-                    )
-                }
-            ),
-            authSessionApiService = FakeAuthSessionApiService(
-                refreshSessionBlock = { unsupportedRefreshSession() }
-            ),
-            userDao = userDao
+            userDao = userDao,
+            userData = createUserData(refreshToken = null)
         )
 
         val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
 
-        assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull()?.message?.contains("refresh token", ignoreCase = true) == true)
-        assertTrue(userPreference.getAuthToken().first().isBlank())
+        assertTrue(result.isSuccess)
+        assertEquals("user@example.com", result.getOrNull()?.email)
+        assertEquals("access-token", userPreference.getAuthToken().first())
         assertTrue(userPreference.getRefreshToken().first().isBlank())
-        assertTrue(userPreference.getUserId().first().isBlank())
-        assertTrue(userDao.insertedUsers.isEmpty())
+        assertEquals("10", userPreference.getUserId().first())
+        assertEquals(1, userDao.insertedUsers.size)
     }
 
     @Test
-    fun `login fails when refresh token is blank in login response`() = runBlocking {
+    fun `login succeeds when refresh token is blank in login response`() = runBlocking {
         val userPreference = createUserPreference()
         val userDao = CapturingUserDao()
-        val repository = AuthRepositoryImpl(
+        val repository = createLoginRepository(
             userPreference = userPreference,
-            apiService = FakeApiService(
-                loginBlock = {
-                    LoginResponse(
-                        success = true,
-                        message = "ok",
-                        data = createUserData(refreshToken = "   ")
-                    )
-                }
-            ),
-            authSessionApiService = FakeAuthSessionApiService(
-                refreshSessionBlock = { unsupportedRefreshSession() }
-            ),
-            userDao = userDao
+            userDao = userDao,
+            userData = createUserData(refreshToken = "   ")
+        )
+
+        val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
+
+        assertTrue(result.isSuccess)
+        assertEquals("user@example.com", result.getOrNull()?.email)
+        assertEquals("access-token", userPreference.getAuthToken().first())
+        assertTrue(userPreference.getRefreshToken().first().isBlank())
+        assertEquals("10", userPreference.getUserId().first())
+        assertEquals(1, userDao.insertedUsers.size)
+    }
+
+    @Test
+    fun `login fails when access token is blank in login response`() = runBlocking {
+        val userPreference = createUserPreference()
+        val userDao = CapturingUserDao()
+        val repository = createLoginRepository(
+            userPreference = userPreference,
+            userDao = userDao,
+            userData = createUserData(refreshToken = "refresh-token").copy(token = "   ")
         )
 
         val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
 
         assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull()?.message?.contains("refresh token", ignoreCase = true) == true)
+        assertTrue(result.exceptionOrNull()?.message?.contains("access token", ignoreCase = true) == true)
         assertTrue(userPreference.getAuthToken().first().isBlank())
         assertTrue(userPreference.getRefreshToken().first().isBlank())
         assertTrue(userPreference.getUserId().first().isBlank())
@@ -226,6 +224,30 @@ class AuthRepositoryImplRefreshSessionTest {
         assertTrue(userPreference.getAuthToken().first().isBlank())
         assertTrue(userPreference.getRefreshToken().first().isBlank())
         assertTrue(userPreference.getUserId().first().isBlank())
+    }
+
+    @Test
+    fun `refresh session returns reauth required without calling backend when refresh token is missing locally`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "existing-access", userId = "10", refreshToken = null)
+        }
+        val fakeAuthSessionApi = FakeAuthSessionApiService(
+            refreshSessionBlock = { unsupportedRefreshSession() }
+        )
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(),
+            authSessionApiService = fakeAuthSessionApi,
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result is RefreshSessionResult.ReAuthRequired.InvalidOrRevoked)
+        assertEquals(null, fakeAuthSessionApi.lastRefreshRequest)
+        assertEquals("existing-access", userPreference.getAuthToken().first())
+        assertTrue(userPreference.getRefreshToken().first().isBlank())
+        assertEquals("10", userPreference.getUserId().first())
     }
 
     @Test
@@ -546,6 +568,29 @@ class AuthRepositoryImplRefreshSessionTest {
             apiService = apiService,
             authSessionApiService = refreshApiService,
             userDao = FakeUserDao()
+        )
+    }
+
+    private fun createLoginRepository(
+        userPreference: UserPreference,
+        userDao: UserDao,
+        userData: UserData
+    ): AuthRepositoryImpl {
+        return AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                loginBlock = {
+                    LoginResponse(
+                        success = true,
+                        message = "ok",
+                        data = userData
+                    )
+                }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = userDao
         )
     }
 


### PR DESCRIPTION
## Summary
- allow Android login to succeed when backend returns a usable access token without `refresh_token`
- keep persisting `refresh_token` when present, while making login compatibility-safe when it is omitted or blank
- add regression tests for access-token-only login and deterministic refresh-session behavior when no local refresh token is stored

## Test plan
- [x] `.\gradlew.bat :app:testDebugUnitTest --tests "com.example.infinite_track.data.repository.auth.AuthRepositoryImplRefreshSessionTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)