### PR TITLE
fix: stabilize Android auth bootstrap session contract

### DIFF
--- a/app/src/androidTest/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenFaceResultRescueTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenFaceResultRescueTest.kt
@@ -21,8 +21,10 @@ import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.model.location.LocationResult
 import com.example.infinite_track.domain.model.wfa.WfaRecommendation
 import com.example.infinite_track.domain.repository.AttendanceRepository
+import com.example.infinite_track.domain.repository.AuthRefreshResult
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.LocationRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
 import com.example.infinite_track.domain.repository.WfaRepository
 import com.example.infinite_track.domain.use_case.attendance.CheckInUseCase
 import com.example.infinite_track.domain.use_case.attendance.CheckOutUseCase
@@ -397,11 +399,15 @@ class AttendanceScreenFaceResultRescueTest {
     }
 
     private class FakeAuthRepository : AuthRepository {
+        override suspend fun refreshSession(): Result<AuthRefreshResult> {
+            throw UnsupportedOperationException("Session refresh is outside this regression")
+        }
+
         override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
             throw UnsupportedOperationException("Login is outside this regression")
         }
 
-        override suspend fun syncUserProfile(): Result<UserModel> {
+        override suspend fun syncUserProfile(): ProfileSyncResult {
             throw UnsupportedOperationException("Profile sync is outside this regression")
         }
 

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -151,6 +151,14 @@ class AuthRepositoryImpl @Inject constructor(
      * @return Explicit sync outcome for success, unauthorized, or temporary failure
      */
     override suspend fun syncUserProfile(): ProfileSyncResult {
+        return syncUserProfile(bootstrapAuthRequest = null)
+    }
+
+    override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+        return syncUserProfile(bootstrapAuthRequest = ApiService.BOOTSTRAP_AUTH_REQUEST_VALUE)
+    }
+
+    private suspend fun syncUserProfile(bootstrapAuthRequest: String?): ProfileSyncResult {
         return try {
             val token = userPreference.getAuthToken().first()
 
@@ -159,7 +167,7 @@ class AuthRepositoryImpl @Inject constructor(
                 return ProfileSyncResult.Unauthorized
             }
 
-            val response = apiService.getUserProfile()
+            val response = apiService.getUserProfile(bootstrapAuthRequest)
             val user = response.data.toDomain()
             val userEntity = user.toEntity(userDao.getUserProfile()?.faceEmbedding)
             userDao.insertOrUpdateUserProfile(userEntity)

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -164,7 +164,7 @@ class AuthRepositoryImpl @Inject constructor(
 
             if (token.isBlank()) {
                 safeLogDebug("Profile sync skipped because auth token is missing")
-                return ProfileSyncResult.Unauthorized
+                return ProfileSyncResult.Unauthorized()
             }
 
             val response = apiService.getUserProfile(bootstrapAuthRequest)
@@ -177,8 +177,9 @@ class AuthRepositoryImpl @Inject constructor(
             throw e
         } catch (e: HttpException) {
             if (e.code() == 401 || e.code() == 403) {
+                val reason = authFailureReasonFor(parseHttpErrorBodySafely(e)?.code)
                 safeLogDebug("Profile sync unauthorized: HTTP ${e.code()}")
-                ProfileSyncResult.Unauthorized
+                ProfileSyncResult.Unauthorized(reason)
             } else {
                 safeLogError("Profile sync failed with HTTP ${e.code()}", e)
                 ProfileSyncResult.TemporaryFailure(
@@ -287,31 +288,20 @@ class AuthRepositoryImpl @Inject constructor(
         val normalizedCode = errorBody?.code?.uppercase(Locale.ROOT)
         val message = errorBody?.message ?: "HTTP $statusCode"
 
-        val exception = when (normalizedCode) {
-            "AUTH_ACCESS_TOKEN_EXPIRED" -> AuthRefreshException(
+        val reason = authFailureReasonFor(normalizedCode)
+        val exception = when (reason) {
+            AuthRefreshFailureReason.ACCESS_EXPIRED -> AuthRefreshException(
                 kind = AuthRefreshFailureKind.TRANSIENT,
-                reason = AuthRefreshFailureReason.ACCESS_EXPIRED,
+                reason = reason,
                 message = message,
                 cause = httpException
             )
 
-            "AUTH_REFRESH_TOKEN_INVALID" -> AuthRefreshException(
+            AuthRefreshFailureReason.REFRESH_INVALID,
+            AuthRefreshFailureReason.REFRESH_REVOKED,
+            AuthRefreshFailureReason.INACTIVITY_EXPIRED -> AuthRefreshException(
                 kind = AuthRefreshFailureKind.NON_REFRESHABLE,
-                reason = AuthRefreshFailureReason.REFRESH_INVALID,
-                message = message,
-                cause = httpException
-            )
-
-            "AUTH_REFRESH_TOKEN_REVOKED" -> AuthRefreshException(
-                kind = AuthRefreshFailureKind.NON_REFRESHABLE,
-                reason = AuthRefreshFailureReason.REFRESH_REVOKED,
-                message = message,
-                cause = httpException
-            )
-
-            "AUTH_SESSION_INACTIVE", "INACTIVITY_TIMEOUT_48H" -> AuthRefreshException(
-                kind = AuthRefreshFailureKind.NON_REFRESHABLE,
-                reason = AuthRefreshFailureReason.INACTIVITY_EXPIRED,
+                reason = reason,
                 message = message,
                 cause = httpException
             )
@@ -326,6 +316,16 @@ class AuthRepositoryImpl @Inject constructor(
 
         safeLogDebug("Refresh session rejected: HTTP $statusCode, code=${normalizedCode ?: "UNKNOWN"}")
         return Result.failure(exception)
+    }
+
+    private fun authFailureReasonFor(code: String?): AuthRefreshFailureReason? {
+        return when (code?.uppercase(Locale.ROOT)) {
+            "AUTH_ACCESS_TOKEN_EXPIRED" -> AuthRefreshFailureReason.ACCESS_EXPIRED
+            "AUTH_REFRESH_TOKEN_INVALID" -> AuthRefreshFailureReason.REFRESH_INVALID
+            "AUTH_REFRESH_TOKEN_REVOKED" -> AuthRefreshFailureReason.REFRESH_REVOKED
+            "AUTH_SESSION_INACTIVE", "INACTIVITY_TIMEOUT_48H" -> AuthRefreshFailureReason.INACTIVITY_EXPIRED
+            else -> null
+        }
     }
 
     private fun parseHttpErrorBodySafely(httpException: HttpException): ErrorResponse? {

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
@@ -20,6 +20,7 @@ import com.example.infinite_track.data.soucre.network.response.booking.BookingHi
 import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -32,7 +33,9 @@ interface ApiService {
     suspend fun login(@Body loginRequest: LoginRequest): LoginResponse
 
     @GET("api/auth/me")
-    suspend fun getUserProfile(): LoginResponse
+    suspend fun getUserProfile(
+        @Header(HEADER_BOOTSTRAP_AUTH_REQUEST) bootstrapAuthRequest: String? = null
+    ): LoginResponse
 
     @POST("api/auth/logout")
     suspend fun logout(): LogoutResponse
@@ -94,4 +97,9 @@ interface ApiService {
     suspend fun submitWfaBooking(
         @Body request: BookingRequest
     ): BookingResponse
+
+    companion object {
+        const val HEADER_BOOTSTRAP_AUTH_REQUEST = "X-Bootstrap-Auth-Request"
+        const val BOOTSTRAP_AUTH_REQUEST_VALUE = "1"
+    }
 }

--- a/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
+++ b/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
@@ -110,6 +110,10 @@ class AuthRefreshInterceptor @Inject constructor(
 
     private fun triggerForcedReauth(reason: SessionManager.ReauthReason) {
         val sessionManager = sessionManagerProvider.get()
+        if (sessionManager.isBootstrapSessionInProgress) {
+            return
+        }
+
         if (sessionManager.beginSessionExpiryHandling()) {
             runBlocking {
                 logoutUseCaseProvider.get().invoke()

--- a/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
+++ b/app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt
@@ -2,6 +2,7 @@ package com.example.infinite_track.di.auth
 
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
+import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.repository.AuthRefreshException
 import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
@@ -29,9 +30,11 @@ class AuthRefreshInterceptor @Inject constructor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
+        val isBootstrapAuthRequest = originalRequest.header(HEADER_BOOTSTRAP_AUTH_REQUEST) == BOOTSTRAP_AUTH_REQUEST_VALUE
         val token = runBlocking { userPreference.getAuthToken().first() }
 
         val requestWithToken = originalRequest.newBuilder()
+            .removeHeader(HEADER_BOOTSTRAP_AUTH_REQUEST)
             .header(HEADER_CLIENT_TYPE, CLIENT_TYPE_MOBILE)
             .apply {
                 if (!token.isNullOrBlank() && !isAuthEndpoint(originalRequest)) {
@@ -52,7 +55,7 @@ class AuthRefreshInterceptor @Inject constructor(
 
         val authCode = parseAuthCode(response)
         forcedReauthReasonFor(authCode)?.let { reason ->
-            triggerForcedReauth(reason)
+            triggerForcedReauth(reason, suppressGlobalHandling = isBootstrapAuthRequest)
             return response
         }
 
@@ -73,6 +76,7 @@ class AuthRefreshInterceptor @Inject constructor(
                 response.close()
                 val newToken = runBlocking { userPreference.getAuthToken().first() }
                 val retriedRequest = originalRequest.newBuilder()
+                    .removeHeader(HEADER_BOOTSTRAP_AUTH_REQUEST)
                     .header(HEADER_CLIENT_TYPE, CLIENT_TYPE_MOBILE)
                     .header(HEADER_RETRY_MARKER, RETRY_MARKER_VALUE)
                     .apply {
@@ -88,7 +92,10 @@ class AuthRefreshInterceptor @Inject constructor(
             onFailure = { throwable ->
                 val refreshException = throwable as? AuthRefreshException
                 if (refreshException?.kind == AuthRefreshFailureKind.NON_REFRESHABLE) {
-                    triggerForcedReauth(reauthReasonFor(refreshException.reason))
+                    triggerForcedReauth(
+                        reason = reauthReasonFor(refreshException.reason),
+                        suppressGlobalHandling = isBootstrapAuthRequest
+                    )
                 }
                 response
             }
@@ -108,12 +115,15 @@ class AuthRefreshInterceptor @Inject constructor(
         return hasBearerToken && (authCode == null || authCode == AUTH_ACCESS_TOKEN_EXPIRED)
     }
 
-    private fun triggerForcedReauth(reason: SessionManager.ReauthReason) {
-        val sessionManager = sessionManagerProvider.get()
-        if (sessionManager.isBootstrapSessionInProgress) {
+    private fun triggerForcedReauth(
+        reason: SessionManager.ReauthReason,
+        suppressGlobalHandling: Boolean
+    ) {
+        if (suppressGlobalHandling) {
             return
         }
 
+        val sessionManager = sessionManagerProvider.get()
         if (sessionManager.beginSessionExpiryHandling()) {
             runBlocking {
                 logoutUseCaseProvider.get().invoke()
@@ -178,6 +188,8 @@ class AuthRefreshInterceptor @Inject constructor(
         private const val HEADER_AUTHORIZATION = "Authorization"
         private const val HEADER_CLIENT_TYPE = "X-Client-Type"
         private const val CLIENT_TYPE_MOBILE = "mobile"
+        private const val HEADER_BOOTSTRAP_AUTH_REQUEST = ApiService.HEADER_BOOTSTRAP_AUTH_REQUEST
+        private const val BOOTSTRAP_AUTH_REQUEST_VALUE = ApiService.BOOTSTRAP_AUTH_REQUEST_VALUE
         private const val HEADER_RETRY_MARKER = "X-Refresh-Retry"
         private const val RETRY_MARKER_VALUE = "1"
         private const val MAX_ERROR_BODY_BYTES = 1024 * 1024L

--- a/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
@@ -47,6 +47,10 @@ class SessionManager @Inject constructor() {
         _sessionExpired.value = true
     }
 
+    fun recordBootstrapReauth(reason: ReauthReason) {
+        _reauthReason.value = reason
+    }
+
     /**
      * Trigger session expiration
      * Dipanggil oleh AuthInterceptor ketika mendapat 401 error

--- a/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/manager/SessionManager.kt
@@ -27,6 +27,22 @@ class SessionManager @Inject constructor() {
     val reauthReason: StateFlow<ReauthReason?> = _reauthReason.asStateFlow()
 
     private var sessionExpiryHandlingInProgress: Boolean = false
+    private var bootstrapSessionDepth: Int = 0
+
+    val isBootstrapSessionInProgress: Boolean
+        @Synchronized get() = bootstrapSessionDepth > 0
+
+    @Synchronized
+    fun beginBootstrapSession() {
+        bootstrapSessionDepth += 1
+    }
+
+    @Synchronized
+    fun endBootstrapSession() {
+        if (bootstrapSessionDepth > 0) {
+            bootstrapSessionDepth -= 1
+        }
+    }
 
     /**
      * Try to acquire single-flight guard for session-expired handling.

--- a/app/src/main/java/com/example/infinite_track/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/repository/AuthRepository.kt
@@ -31,6 +31,13 @@ interface AuthRepository {
     suspend fun syncUserProfile(): ProfileSyncResult
 
     /**
+     * Sync user profile as part of startup bootstrap.
+     * Implementations may mark the underlying request so interceptor-level forced reauth
+     * handling stays scoped to the bootstrap owner instead of the global dialog path.
+     */
+    suspend fun syncUserProfileForBootstrap(): ProfileSyncResult = syncUserProfile()
+
+    /**
      * Logout the current user
      * @return Result indicating success or failure
      */

--- a/app/src/main/java/com/example/infinite_track/domain/repository/ProfileSyncResult.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/repository/ProfileSyncResult.kt
@@ -4,7 +4,7 @@ import com.example.infinite_track.domain.model.auth.UserModel
 
 sealed interface ProfileSyncResult {
     data class Success(val user: UserModel) : ProfileSyncResult
-    data object Unauthorized : ProfileSyncResult
+    data class Unauthorized(val reason: AuthRefreshFailureReason? = null) : ProfileSyncResult
     data class TemporaryFailure(
         val cause: Throwable? = null,
         val message: String? = cause?.message

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -157,11 +157,19 @@ class CheckSessionUseCase @Inject constructor(
     ): AuthRefreshFailureReason {
         return when {
             initialReason == null -> refreshFailureReason
-            refreshFailureReason == AuthRefreshFailureReason.REFRESH_INVALID ||
-                refreshFailureReason == AuthRefreshFailureReason.MISSING_REFRESH_TOKEN ||
-                refreshFailureReason == AuthRefreshFailureReason.UNKNOWN -> initialReason
+            initialReason.isTerminalBootstrapReason() && refreshFailureReason.isGenericRefreshFailureReason() -> initialReason
             else -> refreshFailureReason
         }
+    }
+
+    private fun AuthRefreshFailureReason.isTerminalBootstrapReason(): Boolean {
+        return this == AuthRefreshFailureReason.INACTIVITY_EXPIRED ||
+            this == AuthRefreshFailureReason.REFRESH_REVOKED
+    }
+
+    private fun AuthRefreshFailureReason.isGenericRefreshFailureReason(): Boolean {
+        return this == AuthRefreshFailureReason.REFRESH_INVALID ||
+            this == AuthRefreshFailureReason.UNKNOWN
     }
 
     private fun reauthReasonFor(reason: AuthRefreshFailureReason): SessionManager.ReauthReason {

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -102,11 +102,7 @@ class CheckSessionUseCase @Inject constructor(
             return when (val retrySyncResult = authRepository.syncUserProfileForBootstrap()) {
                 is ProfileSyncResult.Success -> Result.success(retrySyncResult.user)
                 is ProfileSyncResult.Unauthorized -> {
-                    val reason = reauthReasonFor(
-                        retrySyncResult.reason
-                            ?: initialReason
-                            ?: AuthRefreshFailureReason.REFRESH_INVALID
-                    )
+                    val reason = reauthReasonFor(preferredUnauthorizedReason(retrySyncResult.reason, initialReason))
                     sessionManager.recordBootstrapReauth(reason)
                     Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
                 }
@@ -152,13 +148,14 @@ class CheckSessionUseCase @Inject constructor(
     }
 
     private fun preferredUnauthorizedReason(
-        refreshFailureReason: AuthRefreshFailureReason,
+        laterReason: AuthRefreshFailureReason?,
         initialReason: AuthRefreshFailureReason?
     ): AuthRefreshFailureReason {
+        val fallbackReason = laterReason ?: AuthRefreshFailureReason.REFRESH_INVALID
         return when {
-            initialReason == null -> refreshFailureReason
-            initialReason.isTerminalBootstrapReason() && refreshFailureReason.isGenericRefreshFailureReason() -> initialReason
-            else -> refreshFailureReason
+            initialReason == null -> fallbackReason
+            initialReason.isTerminalBootstrapReason() && fallbackReason.isGenericRefreshFailureReason() -> initialReason
+            else -> fallbackReason
         }
     }
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -100,7 +100,7 @@ class CheckSessionUseCase @Inject constructor(
                 is ProfileSyncResult.Success -> Result.success(retrySyncResult.user)
                 ProfileSyncResult.Unauthorized -> {
                     val reason = SessionManager.ReauthReason.REFRESH_INVALID
-                    sessionManager.triggerForcedReauth(reason)
+                    sessionManager.recordBootstrapReauth(reason)
                     Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
                 }
                 is ProfileSyncResult.TemporaryFailure -> Result.failure(
@@ -123,7 +123,7 @@ class CheckSessionUseCase @Inject constructor(
         return when (refreshException?.kind) {
             AuthRefreshFailureKind.NON_REFRESHABLE -> {
                 val reason = reauthReasonFor(refreshException.reason)
-                sessionManager.triggerForcedReauth(reason)
+                sessionManager.recordBootstrapReauth(reason)
                 Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
             }
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -19,14 +19,14 @@ class CheckSessionUseCase @Inject constructor(
     private val sessionManager: SessionManager
 ) {
     suspend operator fun invoke(): Result<UserModel> {
+        sessionManager.beginBootstrapSession()
         return try {
-            val cachedUser = authRepository.getLoggedInUser().first()
-            val bootstrapRefreshResult = validateRefreshSessionIfAvailable(cachedUser)
+            val bootstrapRefreshResult = validateRefreshSessionIfAvailable()
             if (bootstrapRefreshResult != null) {
                 return bootstrapRefreshResult
             }
 
-            val syncResult = resolveSyncResult(authRepository.syncUserProfile(), cachedUser)
+            val syncResult = resolveSyncResult(authRepository.syncUserProfile())
 
             if (syncResult.isFailure) {
                 return syncResult
@@ -59,10 +59,12 @@ class CheckSessionUseCase @Inject constructor(
             Result.failure(e)
         } catch (e: Exception) {
             Result.failure(e)
+        } finally {
+            sessionManager.endBootstrapSession()
         }
     }
 
-    private suspend fun validateRefreshSessionIfAvailable(cachedUser: UserModel?): Result<UserModel>? {
+    private suspend fun validateRefreshSessionIfAvailable(): Result<UserModel>? {
         val token = userPreference.getAuthToken().first()
         val refreshToken = userPreference.getRefreshToken().first()
         if (token.isBlank() || refreshToken.isBlank()) {
@@ -74,16 +76,15 @@ class CheckSessionUseCase @Inject constructor(
             return null
         }
 
-        return handleFailedRefresh(refreshResult, cachedUser)
+        return handleFailedRefresh(refreshResult)
     }
 
     private suspend fun resolveSyncResult(
-        syncResult: ProfileSyncResult,
-        cachedUser: UserModel?
+        syncResult: ProfileSyncResult
     ): Result<UserModel> {
         return when (syncResult) {
             is ProfileSyncResult.Success -> Result.success(syncResult.user)
-            ProfileSyncResult.Unauthorized -> handleUnauthorizedSync(cachedUser)
+            ProfileSyncResult.Unauthorized -> handleUnauthorizedSync()
             is ProfileSyncResult.TemporaryFailure -> Result.failure(
                 SessionBootstrapFailure.TemporaryFailure(
                     cause = syncResult.cause,
@@ -93,7 +94,7 @@ class CheckSessionUseCase @Inject constructor(
         }
     }
 
-    private suspend fun handleUnauthorizedSync(cachedUser: UserModel?): Result<UserModel> {
+    private suspend fun handleUnauthorizedSync(): Result<UserModel> {
         val refreshResult = authRepository.refreshSession()
         if (refreshResult.isSuccess) {
             return when (val retrySyncResult = authRepository.syncUserProfile()) {
@@ -112,12 +113,11 @@ class CheckSessionUseCase @Inject constructor(
             }
         }
 
-        return handleFailedRefresh(refreshResult, cachedUser)
+        return handleFailedRefresh(refreshResult)
     }
 
     private fun handleFailedRefresh(
-        refreshResult: Result<*>,
-        cachedUser: UserModel?
+        refreshResult: Result<*>
     ): Result<UserModel> {
         val refreshException = refreshResult.exceptionOrNull() as? AuthRefreshException
         return when (refreshException?.kind) {
@@ -127,13 +127,12 @@ class CheckSessionUseCase @Inject constructor(
                 Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
             }
 
-            AuthRefreshFailureKind.TRANSPORT -> cachedUser?.let { Result.success(it) }
-                ?: Result.failure(
-                    SessionBootstrapFailure.TemporaryFailure(
-                        cause = refreshException,
-                        message = refreshException.message
-                    )
+            AuthRefreshFailureKind.TRANSPORT -> Result.failure(
+                SessionBootstrapFailure.TemporaryFailure(
+                    cause = refreshException,
+                    message = refreshException.message
                 )
+            )
 
             AuthRefreshFailureKind.TRANSIENT,
             null -> Result.failure(

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -26,7 +26,7 @@ class CheckSessionUseCase @Inject constructor(
                 return bootstrapRefreshResult
             }
 
-            val syncResult = resolveSyncResult(authRepository.syncUserProfile())
+            val syncResult = resolveSyncResult(authRepository.syncUserProfileForBootstrap())
 
             if (syncResult.isFailure) {
                 return syncResult
@@ -97,7 +97,7 @@ class CheckSessionUseCase @Inject constructor(
     private suspend fun handleUnauthorizedSync(): Result<UserModel> {
         val refreshResult = authRepository.refreshSession()
         if (refreshResult.isSuccess) {
-            return when (val retrySyncResult = authRepository.syncUserProfile()) {
+            return when (val retrySyncResult = authRepository.syncUserProfileForBootstrap()) {
                 is ProfileSyncResult.Success -> Result.success(retrySyncResult.user)
                 ProfileSyncResult.Unauthorized -> {
                     val reason = SessionManager.ReauthReason.REFRESH_INVALID

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -84,7 +84,7 @@ class CheckSessionUseCase @Inject constructor(
     ): Result<UserModel> {
         return when (syncResult) {
             is ProfileSyncResult.Success -> Result.success(syncResult.user)
-            is ProfileSyncResult.Unauthorized -> handleUnauthorizedSync()
+            is ProfileSyncResult.Unauthorized -> handleUnauthorizedSync(syncResult.reason)
             is ProfileSyncResult.TemporaryFailure -> Result.failure(
                 SessionBootstrapFailure.TemporaryFailure(
                     cause = syncResult.cause,
@@ -94,14 +94,19 @@ class CheckSessionUseCase @Inject constructor(
         }
     }
 
-    private suspend fun handleUnauthorizedSync(): Result<UserModel> {
+    private suspend fun handleUnauthorizedSync(
+        initialReason: AuthRefreshFailureReason?
+    ): Result<UserModel> {
         val refreshResult = authRepository.refreshSession()
         if (refreshResult.isSuccess) {
             return when (val retrySyncResult = authRepository.syncUserProfileForBootstrap()) {
                 is ProfileSyncResult.Success -> Result.success(retrySyncResult.user)
                 is ProfileSyncResult.Unauthorized -> {
-                    val reason = retrySyncResult.reason?.let(::reauthReasonFor)
-                        ?: SessionManager.ReauthReason.REFRESH_INVALID
+                    val reason = reauthReasonFor(
+                        retrySyncResult.reason
+                            ?: initialReason
+                            ?: AuthRefreshFailureReason.REFRESH_INVALID
+                    )
                     sessionManager.recordBootstrapReauth(reason)
                     Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
                 }
@@ -114,16 +119,17 @@ class CheckSessionUseCase @Inject constructor(
             }
         }
 
-        return handleFailedRefresh(refreshResult)
+        return handleFailedRefresh(refreshResult, initialReason)
     }
 
     private fun handleFailedRefresh(
-        refreshResult: Result<*>
+        refreshResult: Result<*>,
+        initialReason: AuthRefreshFailureReason? = null
     ): Result<UserModel> {
         val refreshException = refreshResult.exceptionOrNull() as? AuthRefreshException
         return when (refreshException?.kind) {
             AuthRefreshFailureKind.NON_REFRESHABLE -> {
-                val reason = reauthReasonFor(refreshException.reason)
+                val reason = reauthReasonFor(preferredUnauthorizedReason(refreshException.reason, initialReason))
                 sessionManager.recordBootstrapReauth(reason)
                 Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
             }
@@ -142,6 +148,19 @@ class CheckSessionUseCase @Inject constructor(
                     message = refreshException?.message
                 )
             )
+        }
+    }
+
+    private fun preferredUnauthorizedReason(
+        refreshFailureReason: AuthRefreshFailureReason,
+        initialReason: AuthRefreshFailureReason?
+    ): AuthRefreshFailureReason {
+        return when {
+            initialReason == null -> refreshFailureReason
+            refreshFailureReason == AuthRefreshFailureReason.REFRESH_INVALID ||
+                refreshFailureReason == AuthRefreshFailureReason.MISSING_REFRESH_TOKEN ||
+                refreshFailureReason == AuthRefreshFailureReason.UNKNOWN -> initialReason
+            else -> refreshFailureReason
         }
     }
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt
@@ -84,7 +84,7 @@ class CheckSessionUseCase @Inject constructor(
     ): Result<UserModel> {
         return when (syncResult) {
             is ProfileSyncResult.Success -> Result.success(syncResult.user)
-            ProfileSyncResult.Unauthorized -> handleUnauthorizedSync()
+            is ProfileSyncResult.Unauthorized -> handleUnauthorizedSync()
             is ProfileSyncResult.TemporaryFailure -> Result.failure(
                 SessionBootstrapFailure.TemporaryFailure(
                     cause = syncResult.cause,
@@ -99,8 +99,9 @@ class CheckSessionUseCase @Inject constructor(
         if (refreshResult.isSuccess) {
             return when (val retrySyncResult = authRepository.syncUserProfileForBootstrap()) {
                 is ProfileSyncResult.Success -> Result.success(retrySyncResult.user)
-                ProfileSyncResult.Unauthorized -> {
-                    val reason = SessionManager.ReauthReason.REFRESH_INVALID
+                is ProfileSyncResult.Unauthorized -> {
+                    val reason = retrySyncResult.reason?.let(::reauthReasonFor)
+                        ?: SessionManager.ReauthReason.REFRESH_INVALID
                     sessionManager.recordBootstrapReauth(reason)
                     Result.failure(SessionBootstrapFailure.ReAuthRequired(reason))
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/InfiniteTrackApp.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/InfiniteTrackApp.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.zIndex
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -33,6 +32,7 @@ import com.example.infinite_track.presentation.navigation.AppNavigator
 import com.example.infinite_track.presentation.navigation.NavigationEvent
 import com.example.infinite_track.presentation.navigation.Screen
 import com.example.infinite_track.presentation.navigation.appNavGraph
+import com.example.infinite_track.presentation.screen.splash.SplashViewModel
 import com.example.infinite_track.utils.DialogHelper
 import com.example.infinite_track.utils.LocalLocationPermissionHelper
 import com.example.infinite_track.utils.LocationPermissionHelper
@@ -45,7 +45,8 @@ fun InfiniteTrackApp(
     modifier: Modifier = Modifier,
     appNavigator: AppNavigator? = null,
     sessionManager: SessionManager? = null,
-    locationPermissionHelper: LocationPermissionHelper? = null
+    locationPermissionHelper: LocationPermissionHelper? = null,
+    splashViewModel: SplashViewModel
 ) {
     // Root level NavController - handles top-level navigation
     val navController = rememberNavController()
@@ -170,7 +171,10 @@ fun InfiniteTrackApp(
                             }
                         )
                     }
-                    appNavGraph(navController)
+                    appNavGraph(
+                        navController = navController,
+                        splashViewModel = splashViewModel
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -66,6 +66,8 @@ class MainActivity : ComponentActivity() {
 		}
 
 		super.onCreate(savedInstanceState)
+		notificationPermissionRequestedThisLaunch =
+			restoreNotificationPermissionRequestedThisLaunch(savedInstanceState)
 		enableEdgeToEdge()
 
 		// Apply saved language before composing UI
@@ -97,6 +99,14 @@ class MainActivity : ComponentActivity() {
 
 		// Handle intent saat aplikasi pertama kali dibuka dari notifikasi
 		handleIntent(intent)
+	}
+
+	override fun onSaveInstanceState(outState: Bundle) {
+		super.onSaveInstanceState(outState)
+		saveNotificationPermissionRequestedThisLaunch(
+			outState,
+			notificationPermissionRequestedThisLaunch
+		)
 	}
 
 	override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -92,7 +92,8 @@ class MainActivity : ComponentActivity() {
 				InfiniteTrackApp(
 					appNavigator = appNavigator,
 					sessionManager = sessionManager,
-					locationPermissionHelper = locationPermissionHelper
+					locationPermissionHelper = locationPermissionHelper,
+					splashViewModel = viewModel
 				)
 			}
 		}

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.example.infinite_track.presentation.main
 
 import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -13,6 +14,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.repository.LocalizationRepository
 import com.example.infinite_track.presentation.navigation.AppNavigator
@@ -25,6 +27,7 @@ import com.example.infinite_track.utils.updateAppLanguage
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
@@ -49,6 +52,8 @@ class MainActivity : ComponentActivity() {
 
 	private val requestNotificationPermission =
 		registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+
+	private var notificationPermissionRequestedThisLaunch = false
 
 	@ExperimentalGetImage
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,7 +83,7 @@ class MainActivity : ComponentActivity() {
 		// Create notification channel untuk geofencing
 		NotificationHelper.createNotificationChannel(this)
 
-		requestPostNotificationsIfNeeded()
+		observeStartupNotificationPermissionPrompt()
 
 		setContent {
 			Infinite_TrackTheme {
@@ -109,15 +114,28 @@ class MainActivity : ComponentActivity() {
 		}
 	}
 
-	private fun requestPostNotificationsIfNeeded() {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-			val granted = ContextCompat.checkSelfPermission(
-				this,
-				Manifest.permission.POST_NOTIFICATIONS
-			) == android.content.pm.PackageManager.PERMISSION_GRANTED
-			if (!granted) {
-				requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+	private fun observeStartupNotificationPermissionPrompt() {
+		lifecycleScope.launch {
+			viewModel.navigationState.collect { navigationState ->
+				requestPostNotificationsIfPolicyAllows(navigationState)
 			}
+		}
+	}
+
+	private fun requestPostNotificationsIfPolicyAllows(navigationState: SplashNavigationState) {
+		val granted = ContextCompat.checkSelfPermission(
+			this,
+			Manifest.permission.POST_NOTIFICATIONS
+		) == PackageManager.PERMISSION_GRANTED
+
+		if (shouldRequestPostNotifications(
+				sdkInt = Build.VERSION.SDK_INT,
+				alreadyRequestedThisLaunch = notificationPermissionRequestedThisLaunch,
+				isGranted = granted,
+				navigationState = navigationState
+			)) {
+			notificationPermissionRequestedThisLaunch = true
+			requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
 		}
 	}
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
@@ -1,7 +1,32 @@
 package com.example.infinite_track.presentation.main
 
 import android.os.Build
+import android.os.Bundle
 import com.example.infinite_track.presentation.screen.splash.SplashNavigationState
+
+private const val NOTIFICATION_PERMISSION_REQUESTED_THIS_LAUNCH_KEY =
+    "notification_permission_requested_this_launch"
+
+fun restoreNotificationPermissionRequestedThisLaunch(savedInstanceState: Bundle?): Boolean =
+    restoreNotificationPermissionRequestedThisLaunch(
+        savedAlreadyRequestedThisLaunch = savedInstanceState?.getBoolean(
+            NOTIFICATION_PERMISSION_REQUESTED_THIS_LAUNCH_KEY
+        )
+    )
+
+fun restoreNotificationPermissionRequestedThisLaunch(
+    savedAlreadyRequestedThisLaunch: Boolean?
+): Boolean = savedAlreadyRequestedThisLaunch ?: false
+
+fun saveNotificationPermissionRequestedThisLaunch(
+    outState: Bundle,
+    alreadyRequestedThisLaunch: Boolean
+) {
+    outState.putBoolean(
+        NOTIFICATION_PERMISSION_REQUESTED_THIS_LAUNCH_KEY,
+        alreadyRequestedThisLaunch
+    )
+}
 
 fun shouldRequestPostNotifications(
     sdkInt: Int,

--- a/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
@@ -1,0 +1,14 @@
+package com.example.infinite_track.presentation.main
+
+import android.os.Build
+import com.example.infinite_track.presentation.screen.splash.SplashNavigationState
+
+fun shouldRequestPostNotifications(
+    sdkInt: Int,
+    alreadyRequestedThisLaunch: Boolean,
+    isGranted: Boolean,
+    navigationState: SplashNavigationState
+): Boolean = sdkInt >= Build.VERSION_CODES.TIRAMISU &&
+    !alreadyRequestedThisLaunch &&
+    !isGranted &&
+    navigationState is SplashNavigationState.NavigateToHome

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/AppNavGraph.kt
@@ -12,13 +12,18 @@ import com.example.infinite_track.presentation.screen.auth.LoginScreen
 import com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingScreen
 import com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModel
 import com.example.infinite_track.presentation.screen.splash.SplashScreen
+import com.example.infinite_track.presentation.screen.splash.SplashViewModel
 
 fun NavGraphBuilder.appNavGraph(
-    navController: NavHostController
+    navController: NavHostController,
+    splashViewModel: SplashViewModel
 ) {
     // Splash Screen - entry point of the app
     composable(Screen.Splash.route) {
-        SplashScreen(navController = navController)
+        SplashScreen(
+            navController = navController,
+            splashViewModel = splashViewModel
+        )
     }
 
     // Auth graph - contains login screen

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
@@ -1,0 +1,29 @@
+package com.example.infinite_track.presentation.screen.splash
+
+import com.example.infinite_track.domain.manager.SessionManager
+
+internal class SplashBootstrapGate(
+    private val sessionManager: SessionManager
+) {
+    private var bootstrapRunning: Boolean = false
+
+    @Synchronized
+    fun beginBootstrap(): Boolean {
+        if (bootstrapRunning) {
+            return false
+        }
+        bootstrapRunning = true
+        return true
+    }
+
+    @Synchronized
+    fun finishBootstrap() {
+        bootstrapRunning = false
+    }
+
+    suspend fun runTerminalLogoutIfOwner(logout: suspend () -> Unit) {
+        if (sessionManager.beginSessionExpiryHandling()) {
+            logout()
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
@@ -7,8 +7,22 @@ internal class SplashBootstrapGate(
 ) {
     private var bootstrapRunning: Boolean = false
 
+    suspend fun runBootstrapIfIdle(block: suspend () -> Unit): Boolean {
+        if (!acquireBootstrap()) {
+            return false
+        }
+
+        try {
+            block()
+        } finally {
+            releaseBootstrap()
+        }
+
+        return true
+    }
+
     @Synchronized
-    fun beginBootstrap(): Boolean {
+    private fun acquireBootstrap(): Boolean {
         if (bootstrapRunning) {
             return false
         }
@@ -17,7 +31,7 @@ internal class SplashBootstrapGate(
     }
 
     @Synchronized
-    fun finishBootstrap() {
+    private fun releaseBootstrap() {
         bootstrapRunning = false
     }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt
@@ -1,11 +1,8 @@
 package com.example.infinite_track.presentation.screen.splash
 
-import com.example.infinite_track.domain.manager.SessionManager
-
-internal class SplashBootstrapGate(
-    private val sessionManager: SessionManager
-) {
+internal class SplashBootstrapGate {
     private var bootstrapRunning: Boolean = false
+    private var terminalLogoutCompleted: Boolean = false
 
     suspend fun runBootstrapIfIdle(block: suspend () -> Unit): Boolean {
         if (!acquireBootstrap()) {
@@ -27,6 +24,7 @@ internal class SplashBootstrapGate(
             return false
         }
         bootstrapRunning = true
+        terminalLogoutCompleted = false
         return true
     }
 
@@ -36,8 +34,17 @@ internal class SplashBootstrapGate(
     }
 
     suspend fun runTerminalLogoutIfOwner(logout: suspend () -> Unit) {
-        if (sessionManager.beginSessionExpiryHandling()) {
+        if (acquireTerminalLogout()) {
             logout()
         }
+    }
+
+    @Synchronized
+    private fun acquireTerminalLogout(): Boolean {
+        if (terminalLogoutCompleted) {
+            return false
+        }
+        terminalLogoutCompleted = true
+        return true
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -31,7 +30,7 @@ import com.example.infinite_track.presentation.theme.Blue_500
 @Composable
 fun SplashScreen(
     navController: NavHostController,
-    splashViewModel: SplashViewModel = hiltViewModel()
+    splashViewModel: SplashViewModel
 ) {
     // Get the composition for the Lottie animation
     val composition by rememberLottieComposition(spec = LottieCompositionSpec.RawRes(R.raw.profile_sync))

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
@@ -1,13 +1,12 @@
 package com.example.infinite_track.presentation.screen.splash
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.use_case.auth.CheckSessionUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.SessionBootstrapFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,8 +25,10 @@ sealed class SplashNavigationState {
 class SplashViewModel @Inject constructor(
     private val checkSessionUseCase: CheckSessionUseCase,
     private val logoutUseCase: LogoutUseCase,
-    @ApplicationContext private val context: Context
+    sessionManager: SessionManager
 ) : ViewModel() {
+
+    private val bootstrapGate = SplashBootstrapGate(sessionManager)
 
     // Private mutable state flow for navigation state
     private val _navigationState =
@@ -47,28 +48,30 @@ class SplashViewModel @Inject constructor(
 
     private fun checkSession() {
         viewModelScope.launch {
-            checkSessionUseCase()
-                .onSuccess {
-                    // Session is valid and embedding generation (if needed) successful, navigate to home
-                    _navigationState.value = SplashNavigationState.NavigateToHome
-                }
-                .onFailure { exception ->
-                    // Session is invalid or embedding generation failed
-                    // DON'T show dialog in splash screen - directly navigate to login
-                    processSessionFailure(exception)
-                }
+            bootstrapGate.runBootstrapIfIdle {
+                checkSessionUseCase()
+                    .onSuccess {
+                        // Session is valid and embedding generation (if needed) successful, navigate to home
+                        _navigationState.value = SplashNavigationState.NavigateToHome
+                    }
+                    .onFailure { exception ->
+                        // Session is invalid or embedding generation failed
+                        // DON'T show dialog in splash screen - directly navigate to login
+                        processSessionFailure(exception)
+                    }
+            }
         }
     }
 
-    private fun processSessionFailure(exception: Throwable) {
+    private suspend fun processSessionFailure(exception: Throwable) {
         when (exception) {
             is SessionBootstrapFailure.ReAuthRequired -> {
-                viewModelScope.launch {
-                    try {
+                try {
+                    bootstrapGate.runTerminalLogoutIfOwner {
                         logoutUseCase()
-                    } finally {
-                        _navigationState.value = SplashNavigationState.NavigateToLogin
                     }
+                } finally {
+                    _navigationState.value = SplashNavigationState.NavigateToLogin
                 }
             }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashViewModel.kt
@@ -2,7 +2,6 @@ package com.example.infinite_track.presentation.screen.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.use_case.auth.CheckSessionUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.SessionBootstrapFailure
@@ -24,11 +23,10 @@ sealed class SplashNavigationState {
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val checkSessionUseCase: CheckSessionUseCase,
-    private val logoutUseCase: LogoutUseCase,
-    sessionManager: SessionManager
+    private val logoutUseCase: LogoutUseCase
 ) : ViewModel() {
 
-    private val bootstrapGate = SplashBootstrapGate(sessionManager)
+    private val bootstrapGate = SplashBootstrapGate()
 
     // Private mutable state flow for navigation state
     private val _navigationState =

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplLogoutFallbackTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplLogoutFallbackTest.kt
@@ -113,7 +113,7 @@ private class LogoutFallbackFakeApiService(
     }
 
     override suspend fun login(loginRequest: LoginRequest): LoginResponse = throw NotImplementedError()
-    override suspend fun getUserProfile(): LoginResponse = throw NotImplementedError()
+    override suspend fun getUserProfile(bootstrapAuthRequest: String?): LoginResponse = throw NotImplementedError()
     override suspend fun logout(): LogoutResponse = throw NotImplementedError()
     override suspend fun refresh(request: RefreshRequest): RefreshResponse = throw NotImplementedError()
     override suspend fun checkIn(request: AttendanceRequest): AttendanceResponse = throw NotImplementedError()

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -238,6 +238,75 @@ class AuthRepositoryImplRefreshSessionTest {
         val result = repository.syncUserProfile()
 
         assertTrue(result is ProfileSyncResult.Unauthorized)
+        assertEquals(null, (result as ProfileSyncResult.Unauthorized).reason)
+    }
+
+    @Test
+    fun `bootstrap profile sync preserves inactive session unauthorized reason from 401 auth code`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        }
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                getUserProfileBlock = { _ ->
+                    throw httpException(
+                        code = 401,
+                        error = ErrorResponse(
+                            success = false,
+                            message = "session inactive for more than 48 hours",
+                            code = "AUTH_SESSION_INACTIVE"
+                        )
+                    )
+                }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.syncUserProfileForBootstrap()
+
+        assertTrue(result is ProfileSyncResult.Unauthorized)
+        assertEquals(
+            AuthRefreshFailureReason.INACTIVITY_EXPIRED,
+            (result as ProfileSyncResult.Unauthorized).reason
+        )
+    }
+
+    @Test
+    fun `bootstrap profile sync preserves revoked refresh unauthorized reason from 401 auth code`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        }
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                getUserProfileBlock = { _ ->
+                    throw httpException(
+                        code = 401,
+                        error = ErrorResponse(
+                            success = false,
+                            message = "refresh token revoked",
+                            code = "AUTH_REFRESH_TOKEN_REVOKED"
+                        )
+                    )
+                }
+            ),
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.syncUserProfileForBootstrap()
+
+        assertTrue(result is ProfileSyncResult.Unauthorized)
+        assertEquals(
+            AuthRefreshFailureReason.REFRESH_REVOKED,
+            (result as ProfileSyncResult.Unauthorized).reason
+        )
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -142,7 +142,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     LoginResponse(
                         success = true,
                         message = "ok",
@@ -166,11 +166,40 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
+    fun `bootstrap sync marks profile request with bootstrap header value`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession(token = "access-token", userId = "10", refreshToken = "refresh-token")
+        }
+        val apiService = FakeApiService(
+            getUserProfileBlock = { bootstrapMarker ->
+                assertEquals(ApiService.BOOTSTRAP_AUTH_REQUEST_VALUE, bootstrapMarker)
+                LoginResponse(
+                    success = true,
+                    message = "ok",
+                    data = createUserData(refreshToken = "refresh-token")
+                )
+            }
+        )
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = apiService,
+            authSessionApiService = FakeAuthSessionApiService(
+                refreshSessionBlock = { unsupportedRefreshSession() }
+            ),
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.syncUserProfileForBootstrap()
+
+        assertTrue(result is ProfileSyncResult.Success)
+    }
+
+    @Test
     fun `sync user profile returns unauthorized when token is missing locally`() = runBlocking {
         val repository = AuthRepositoryImpl(
             userPreference = createUserPreference(),
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw AssertionError("Profile endpoint should not be called without a local access token")
                 }
             ),
@@ -193,7 +222,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw httpException(
                         code = 401,
                         error = ErrorResponse(success = false, message = "unauthorized", code = "UNAUTHORIZED")
@@ -240,7 +269,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw httpException(
                         code = 500,
                         error = ErrorResponse(success = false, message = "server down", code = "SERVER_ERROR")
@@ -287,7 +316,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw IOException("timeout")
                 }
             ),
@@ -310,7 +339,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw IllegalStateException("boom")
                 }
             ),
@@ -336,7 +365,7 @@ class AuthRepositoryImplRefreshSessionTest {
         val repository = AuthRepositoryImpl(
             userPreference = userPreference,
             apiService = FakeApiService(
-                getUserProfileBlock = {
+                getUserProfileBlock = { _ ->
                     throw throwingRawHttpException(code = 500, error = IOException("body read failed"))
                 }
             ),
@@ -953,7 +982,7 @@ private class CachedUserDao(
 
 private class FakeApiService(
     private val loginBlock: suspend (LoginRequest) -> LoginResponse = { throw NotImplementedError("login not configured in test") },
-    private val getUserProfileBlock: suspend () -> LoginResponse = { throw NotImplementedError("getUserProfile not configured in test") },
+    private val getUserProfileBlock: suspend (String?) -> LoginResponse = { throw NotImplementedError("getUserProfile not configured in test") },
     private val refreshBlock: suspend (RefreshSessionRequest) -> RefreshSessionResponse = { throw NotImplementedError("refresh not configured in test") }
 ) : ApiService {
     var lastRefreshRequest: RefreshSessionRequest? = null
@@ -962,8 +991,8 @@ private class FakeApiService(
         return loginBlock(loginRequest)
     }
 
-    override suspend fun getUserProfile(): LoginResponse {
-        return getUserProfileBlock()
+    override suspend fun getUserProfile(bootstrapAuthRequest: String?): LoginResponse {
+        return getUserProfileBlock(bootstrapAuthRequest)
     }
 
     override suspend fun logout(): LogoutResponse {

--- a/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
+++ b/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.example.infinite_track.di.auth
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.repository.AuthRefreshException
@@ -178,14 +179,13 @@ class AuthRefreshInterceptorTest {
     }
 
     @Test
-    fun `bootstrap owned protected 401 does not arm global forced reauth`() = runBlocking {
+    fun `bootstrap marked protected 401 does not arm global forced reauth`() = runBlocking {
         val fixture = TestFixture(refreshResult = nonRefreshable(AuthRefreshFailureReason.REFRESH_INVALID))
         fixture.userPreference.saveSession("token-a", "10", "refresh-a")
-        fixture.sessionManager.beginBootstrapSession()
 
         val interceptor = fixture.createInterceptor()
         val chain = FakeChain(
-            request = request("https://example.com/api/user/profile"),
+            request = bootstrapRequest("https://example.com/api/user/profile"),
             proceedBlock = { req ->
                 Response.Builder()
                     .request(req)
@@ -210,18 +210,16 @@ class AuthRefreshInterceptorTest {
         assertEquals("token-a", fixture.userPreference.getAuthToken().first())
         assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
         response.close()
-        fixture.sessionManager.endBootstrapSession()
     }
 
     @Test
-    fun `bootstrap owned non refreshable refresh failure does not arm global forced reauth`() = runBlocking {
+    fun `bootstrap marked non refreshable refresh failure does not arm global forced reauth`() = runBlocking {
         val fixture = TestFixture(refreshResult = nonRefreshable(AuthRefreshFailureReason.REFRESH_INVALID))
         fixture.userPreference.saveSession("token-a", "10", "refresh-a")
-        fixture.sessionManager.beginBootstrapSession()
 
         val interceptor = fixture.createInterceptor()
         val chain = FakeChain(
-            request = request("https://example.com/api/user/profile"),
+            request = bootstrapRequest("https://example.com/api/user/profile"),
             proceedBlock = { req -> okResponse(req, 401) }
         )
 
@@ -234,6 +232,27 @@ class AuthRefreshInterceptorTest {
         assertEquals(null, fixture.sessionManager.reauthReason.value)
         assertEquals("token-a", fixture.userPreference.getAuthToken().first())
         assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
+        response.close()
+    }
+
+    @Test
+    fun `process wide bootstrap state without request marker still arms global forced reauth`() = runBlocking {
+        val fixture = TestFixture(refreshResult = nonRefreshable(AuthRefreshFailureReason.REFRESH_INVALID))
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.sessionManager.beginBootstrapSession()
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/attendance/status-today"),
+            proceedBlock = { req -> okResponse(req, 401) }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(401, response.code)
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(1, fixture.logoutCalls.get())
+        assertTrue(fixture.sessionManager.sessionExpired.value)
         response.close()
         fixture.sessionManager.endBootstrapSession()
     }
@@ -469,6 +488,11 @@ class AuthRefreshInterceptorTest {
     }
 
     private fun request(url: String): Request = Request.Builder().url(url).build()
+
+    private fun bootstrapRequest(url: String): Request = Request.Builder()
+        .url(url)
+        .header(ApiService.HEADER_BOOTSTRAP_AUTH_REQUEST, ApiService.BOOTSTRAP_AUTH_REQUEST_VALUE)
+        .build()
 
     private fun okResponse(request: Request, code: Int): Response {
         return Response.Builder()

--- a/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
+++ b/app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt
@@ -178,6 +178,67 @@ class AuthRefreshInterceptorTest {
     }
 
     @Test
+    fun `bootstrap owned protected 401 does not arm global forced reauth`() = runBlocking {
+        val fixture = TestFixture(refreshResult = nonRefreshable(AuthRefreshFailureReason.REFRESH_INVALID))
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.sessionManager.beginBootstrapSession()
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/user/profile"),
+            proceedBlock = { req ->
+                Response.Builder()
+                    .request(req)
+                    .protocol(Protocol.HTTP_1_1)
+                    .message("test")
+                    .code(401)
+                    .body(
+                        "{\"success\":false,\"code\":\"AUTH_REFRESH_TOKEN_INVALID\",\"message\":\"invalid\"}"
+                            .toResponseBody("application/json".toMediaType())
+                    )
+                    .build()
+            }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(401, response.code)
+        assertEquals(0, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        assertEquals(null, fixture.sessionManager.reauthReason.value)
+        assertEquals("token-a", fixture.userPreference.getAuthToken().first())
+        assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
+        response.close()
+        fixture.sessionManager.endBootstrapSession()
+    }
+
+    @Test
+    fun `bootstrap owned non refreshable refresh failure does not arm global forced reauth`() = runBlocking {
+        val fixture = TestFixture(refreshResult = nonRefreshable(AuthRefreshFailureReason.REFRESH_INVALID))
+        fixture.userPreference.saveSession("token-a", "10", "refresh-a")
+        fixture.sessionManager.beginBootstrapSession()
+
+        val interceptor = fixture.createInterceptor()
+        val chain = FakeChain(
+            request = request("https://example.com/api/user/profile"),
+            proceedBlock = { req -> okResponse(req, 401) }
+        )
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(401, response.code)
+        assertEquals(1, fixture.refreshCalls.get())
+        assertEquals(0, fixture.logoutCalls.get())
+        assertFalse(fixture.sessionManager.sessionExpired.value)
+        assertEquals(null, fixture.sessionManager.reauthReason.value)
+        assertEquals("token-a", fixture.userPreference.getAuthToken().first())
+        assertEquals("refresh-a", fixture.userPreference.getRefreshToken().first())
+        response.close()
+        fixture.sessionManager.endBootstrapSession()
+    }
+
+    @Test
     fun `401 on protected request with temporary refresh failure keeps auth state and does not force reauth`() = runBlocking {
         val fixture = TestFixture(refreshResult = transportFailure())
         fixture.userPreference.saveSession("token-a", "10", "refresh-a")

--- a/app/src/test/java/com/example/infinite_track/domain/manager/SessionManagerTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/manager/SessionManagerTest.kt
@@ -32,6 +32,7 @@ class SessionManagerTest {
         assertTrue(sessionManager.beginSessionExpiryHandling())
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `legacy triggerSessionExpired maps to unknown reauth reason`() {
         val sessionManager = SessionManager()
@@ -40,5 +41,34 @@ class SessionManagerTest {
 
         assertTrue(sessionManager.sessionExpired.value)
         assertEquals(ReauthReason.UNKNOWN, sessionManager.reauthReason.value)
+    }
+
+    @Test
+    fun `bootstrap session guard stays active until all owners end`() {
+        val sessionManager = SessionManager()
+
+        assertFalse(sessionManager.isBootstrapSessionInProgress)
+
+        sessionManager.beginBootstrapSession()
+        sessionManager.beginBootstrapSession()
+
+        assertTrue(sessionManager.isBootstrapSessionInProgress)
+
+        sessionManager.endBootstrapSession()
+
+        assertTrue(sessionManager.isBootstrapSessionInProgress)
+
+        sessionManager.endBootstrapSession()
+
+        assertFalse(sessionManager.isBootstrapSessionInProgress)
+    }
+
+    @Test
+    fun `extra bootstrap end is harmless`() {
+        val sessionManager = SessionManager()
+
+        sessionManager.endBootstrapSession()
+
+        assertFalse(sessionManager.isBootstrapSessionInProgress)
     }
 }

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -79,14 +79,14 @@ class CheckSessionUseCaseTest {
     }
 
     @Test
-    fun `bootstrap retry sync unauthorized preserves reason without global session expired dialog flag`() = runBlocking {
+    fun `bootstrap retry sync unauthorized preserves refresh revoked reason without global session expired dialog flag`() = runBlocking {
         val userPreference = createUserPreference().also {
             it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
         }
         val repository = FakeAuthRepository(
             syncResults = mutableListOf(
-                ProfileSyncResult.Unauthorized,
-                ProfileSyncResult.Unauthorized
+                ProfileSyncResult.Unauthorized(),
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_REVOKED)
             ),
             refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
             loggedInUser = sampleUser()
@@ -97,7 +97,33 @@ class CheckSessionUseCaseTest {
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
-        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
+    fun `bootstrap retry sync unauthorized preserves inactivity reason without global session expired dialog flag`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(),
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED)
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(2, repository.refreshCallCount)
         assertEquals(0, repository.syncCallCount)

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -28,7 +28,7 @@ import java.io.File
 class CheckSessionUseCaseTest {
 
     @Test
-    fun `bootstrap validates refresh once then syncs profile`() = runBlocking {
+    fun `bootstrap validates refresh once then uses bootstrap scoped profile sync`() = runBlocking {
         val user = sampleUser()
         val userPreference = createUserPreference().also {
             it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -45,7 +45,8 @@ class CheckSessionUseCaseTest {
         assertTrue(result.isSuccess)
         assertEquals(user, result.getOrNull())
         assertEquals(1, repository.refreshCallCount)
-        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(1, repository.bootstrapSyncCallCount)
         assertEquals(null, sessionManager.reauthReason.value)
     }
 
@@ -99,7 +100,8 @@ class CheckSessionUseCaseTest {
         assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(2, repository.refreshCallCount)
-        assertEquals(2, repository.syncCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
     }
 
     @Test
@@ -201,6 +203,7 @@ class CheckSessionUseCaseTest {
         private val refreshThrowable: Throwable? = null
     ) : AuthRepository {
         var syncCallCount: Int = 0
+        var bootstrapSyncCallCount: Int = 0
         var refreshCallCount: Int = 0
 
         override suspend fun refreshSession(): Result<AuthRefreshResult> {
@@ -215,6 +218,12 @@ class CheckSessionUseCaseTest {
 
         override suspend fun syncUserProfile(): ProfileSyncResult {
             syncCallCount += 1
+            syncThrowable?.let { throw it }
+            return syncResults.removeFirst()
+        }
+
+        override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+            bootstrapSyncCallCount += 1
             syncThrowable?.let { throw it }
             return syncResults.removeFirst()
         }

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -183,6 +183,58 @@ class CheckSessionUseCaseTest {
     }
 
     @Test
+    fun `bootstrap retry sync unauthorized keeps initial inactivity reason when retry reason is generic invalid`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED),
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
+    fun `bootstrap retry sync unauthorized keeps initial refresh revoked reason when retry reason is generic unknown`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_REVOKED),
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.UNKNOWN)
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
     fun `bootstrap unauthorized uses initial inactivity reason when refresh failure is generic invalid`() = runBlocking {
         val userPreference = createUserPreference()
         val repository = FakeAuthRepository(

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -70,8 +71,34 @@ class CheckSessionUseCaseTest {
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
         assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
         assertEquals(1, repository.refreshCallCount)
         assertEquals(0, repository.syncCallCount)
+    }
+
+    @Test
+    fun `bootstrap retry sync unauthorized preserves reason without global session expired dialog flag`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized,
+                ProfileSyncResult.Unauthorized
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(2, repository.syncCallCount)
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -131,6 +131,87 @@ class CheckSessionUseCaseTest {
     }
 
     @Test
+    fun `bootstrap retry sync unauthorized falls back to initial inactivity reason when retry omits reason`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED),
+                ProfileSyncResult.Unauthorized()
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
+    fun `bootstrap retry sync unauthorized falls back to initial refresh revoked reason when retry omits reason`() = runBlocking {
+        val userPreference = createUserPreference().also {
+            it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_REVOKED),
+                ProfileSyncResult.Unauthorized()
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1")),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(2, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(2, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
+    fun `bootstrap unauthorized uses initial inactivity reason when refresh failure is generic invalid`() = runBlocking {
+        val userPreference = createUserPreference()
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED)
+            ),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = AuthRefreshFailureReason.REFRESH_INVALID,
+                    message = "invalid"
+                )
+            ),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(1, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(1, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
     fun `bootstrap reports temporary failure on refresh transport failure while preserving cached session`() = runBlocking {
         val cachedUser = sampleUser()
         val userPreference = createUserPreference().also {

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -15,6 +15,7 @@ import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.ProfileSyncResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -102,7 +103,7 @@ class CheckSessionUseCaseTest {
     }
 
     @Test
-    fun `bootstrap keeps cached session on refresh transport failure`() = runBlocking {
+    fun `bootstrap reports temporary failure on refresh transport failure while preserving cached session`() = runBlocking {
         val cachedUser = sampleUser()
         val userPreference = createUserPreference().also {
             it.saveSession("old-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -122,9 +123,12 @@ class CheckSessionUseCaseTest {
 
         val result = createUseCase(repository, userPreference, sessionManager)()
 
-        assertTrue(result.isSuccess)
-        assertEquals(cachedUser, result.getOrNull())
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.TemporaryFailure)
         assertEquals(null, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals("old-access", userPreference.getAuthToken().first())
+        assertEquals("refresh", userPreference.getRefreshToken().first())
         assertEquals(1, repository.refreshCallCount)
         assertEquals(0, repository.syncCallCount)
     }

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCaseTest.kt
@@ -212,6 +212,35 @@ class CheckSessionUseCaseTest {
     }
 
     @Test
+    fun `bootstrap unauthorized uses refresh missing token reason over generic initial access expired`() = runBlocking {
+        val userPreference = createUserPreference()
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.ACCESS_EXPIRED)
+            ),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = AuthRefreshFailureReason.MISSING_REFRESH_TOKEN,
+                    message = "missing refresh token"
+                )
+            ),
+            loggedInUser = sampleUser()
+        )
+        val sessionManager = SessionManager()
+
+        val result = createUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is SessionBootstrapFailure.ReAuthRequired)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(1, repository.refreshCallCount)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(1, repository.bootstrapSyncCallCount)
+    }
+
+    @Test
     fun `bootstrap reports temporary failure on refresh transport failure while preserving cached session`() = runBlocking {
         val cachedUser = sampleUser()
         val userPreference = createUserPreference().also {

--- a/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.example.infinite_track.presentation.main
+
+import android.os.Build
+import com.example.infinite_track.presentation.screen.splash.SplashNavigationState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StartupNotificationPermissionPolicyTest {
+
+    @Test
+    fun `requests post notifications only after authenticated startup on Android 13 plus`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU,
+            alreadyRequestedThisLaunch = false,
+            isGranted = false,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertTrue(shouldRequest)
+    }
+
+    @Test
+    fun `does not request post notifications when startup resolves to login`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU,
+            alreadyRequestedThisLaunch = false,
+            isGranted = false,
+            navigationState = SplashNavigationState.NavigateToLogin
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun `does not request post notifications twice in the same launch`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU,
+            alreadyRequestedThisLaunch = true,
+            isGranted = false,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun `does not request post notifications before Android 13`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU - 1,
+            alreadyRequestedThisLaunch = false,
+            isGranted = false,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun `does not request post notifications when already granted`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU,
+            alreadyRequestedThisLaunch = false,
+            isGranted = true,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertFalse(shouldRequest)
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
@@ -43,4 +43,28 @@ class StartupNotificationPermissionPolicyTest {
 
         assertFalse(shouldRequest)
     }
+
+    @Test
+    fun `does not request post notifications below Android 13`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.S_V2,
+            alreadyRequestedThisLaunch = false,
+            isGranted = false,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun `does not request post notifications when already granted`() {
+        val shouldRequest = shouldRequestPostNotifications(
+            sdkInt = Build.VERSION_CODES.TIRAMISU,
+            alreadyRequestedThisLaunch = false,
+            isGranted = true,
+            navigationState = SplashNavigationState.NavigateToHome
+        )
+
+        assertFalse(shouldRequest)
+    }
 }

--- a/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
@@ -43,28 +43,4 @@ class StartupNotificationPermissionPolicyTest {
 
         assertFalse(shouldRequest)
     }
-
-    @Test
-    fun `does not request post notifications before Android 13`() {
-        val shouldRequest = shouldRequestPostNotifications(
-            sdkInt = Build.VERSION_CODES.TIRAMISU - 1,
-            alreadyRequestedThisLaunch = false,
-            isGranted = false,
-            navigationState = SplashNavigationState.NavigateToHome
-        )
-
-        assertFalse(shouldRequest)
-    }
-
-    @Test
-    fun `does not request post notifications when already granted`() {
-        val shouldRequest = shouldRequestPostNotifications(
-            sdkInt = Build.VERSION_CODES.TIRAMISU,
-            alreadyRequestedThisLaunch = false,
-            isGranted = true,
-            navigationState = SplashNavigationState.NavigateToHome
-        )
-
-        assertFalse(shouldRequest)
-    }
 }

--- a/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
@@ -67,4 +67,22 @@ class StartupNotificationPermissionPolicyTest {
 
         assertFalse(shouldRequest)
     }
+
+    @Test
+    fun `restores already requested guard after activity recreation`() {
+        val alreadyRequested = restoreNotificationPermissionRequestedThisLaunch(
+            savedAlreadyRequestedThisLaunch = true
+        )
+
+        assertTrue(alreadyRequested)
+    }
+
+    @Test
+    fun `defaults already requested guard to false without saved value`() {
+        val alreadyRequested = restoreNotificationPermissionRequestedThisLaunch(
+            savedAlreadyRequestedThisLaunch = null
+        )
+
+        assertFalse(alreadyRequested)
+    }
 }

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
@@ -14,7 +14,7 @@ class SplashBootstrapGateTest {
 
     @Test
     fun `second bootstrap start is ignored until current cycle finishes`() = runTest {
-        val gate = SplashBootstrapGate(SessionManager())
+        val gate = SplashBootstrapGate()
         var bootstrapCalls = 0
 
         val firstRunStarted = gate.runBootstrapIfIdle {
@@ -38,7 +38,7 @@ class SplashBootstrapGateTest {
 
     @Test
     fun `bootstrap gate releases when block throws`() = runTest {
-        val gate = SplashBootstrapGate(SessionManager())
+        val gate = SplashBootstrapGate()
         val failure = IllegalStateException("boom")
         var bootstrapCalls = 0
 
@@ -62,7 +62,7 @@ class SplashBootstrapGateTest {
 
     @Test
     fun `bootstrap gate releases when block is cancelled`() = runTest {
-        val gate = SplashBootstrapGate(SessionManager())
+        val gate = SplashBootstrapGate()
         val cancellation = CancellationException("cancelled")
         var bootstrapCalls = 0
 
@@ -85,26 +85,35 @@ class SplashBootstrapGateTest {
     }
 
     @Test
-    fun `terminal logout runs only once when gate owns session expiry handling`() = runTest {
-        val gate = SplashBootstrapGate(SessionManager())
+    fun `terminal logout runs once per bootstrap cycle`() = runTest {
+        val gate = SplashBootstrapGate()
         var logoutCalls = 0
 
-        gate.runTerminalLogoutIfOwner { logoutCalls++ }
-        gate.runTerminalLogoutIfOwner { logoutCalls++ }
+        gate.runBootstrapIfIdle {
+            gate.runTerminalLogoutIfOwner { logoutCalls++ }
+            gate.runTerminalLogoutIfOwner { logoutCalls++ }
+        }
+        gate.runBootstrapIfIdle {
+            gate.runTerminalLogoutIfOwner { logoutCalls++ }
+        }
 
-        assertEquals(1, logoutCalls)
+        assertEquals(2, logoutCalls)
     }
 
     @Test
-    fun `terminal logout is skipped when another path already owns session expiry handling`() = runTest {
+    fun `bootstrap terminal logout does not consume runtime forced reauth guard`() = runTest {
         val sessionManager = SessionManager()
-        val gate = SplashBootstrapGate(sessionManager)
+        val gate = SplashBootstrapGate()
         var logoutCalls = 0
 
+        gate.runBootstrapIfIdle {
+            gate.runTerminalLogoutIfOwner { logoutCalls++ }
+        }
+
+        assertEquals(1, logoutCalls)
         assertTrue(sessionManager.beginSessionExpiryHandling())
-
-        gate.runTerminalLogoutIfOwner { logoutCalls++ }
-
-        assertEquals(0, logoutCalls)
+        sessionManager.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_REVOKED)
+        assertTrue(sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
     }
 }

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
@@ -1,24 +1,87 @@
 package com.example.infinite_track.presentation.screen.splash
 
 import com.example.infinite_track.domain.manager.SessionManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class SplashBootstrapGateTest {
 
     @Test
-    fun `second bootstrap start is ignored until current cycle finishes`() {
+    fun `second bootstrap start is ignored until current cycle finishes`() = runTest {
         val gate = SplashBootstrapGate(SessionManager())
+        var bootstrapCalls = 0
 
-        assertTrue(gate.beginBootstrap())
-        assertFalse(gate.beginBootstrap())
+        val firstRunStarted = gate.runBootstrapIfIdle {
+            bootstrapCalls++
 
-        gate.finishBootstrap()
+            val secondRunStarted = gate.runBootstrapIfIdle {
+                bootstrapCalls++
+            }
 
-        assertTrue(gate.beginBootstrap())
+            assertFalse(secondRunStarted)
+        }
+
+        val thirdRunStarted = gate.runBootstrapIfIdle {
+            bootstrapCalls++
+        }
+
+        assertTrue(firstRunStarted)
+        assertTrue(thirdRunStarted)
+        assertEquals(2, bootstrapCalls)
+    }
+
+    @Test
+    fun `bootstrap gate releases when block throws`() = runTest {
+        val gate = SplashBootstrapGate(SessionManager())
+        val failure = IllegalStateException("boom")
+        var bootstrapCalls = 0
+
+        try {
+            gate.runBootstrapIfIdle {
+                bootstrapCalls++
+                throw failure
+            }
+            fail("Expected bootstrap failure to be rethrown")
+        } catch (throwable: IllegalStateException) {
+            assertSame(failure, throwable)
+        }
+
+        val nextRunStarted = gate.runBootstrapIfIdle {
+            bootstrapCalls++
+        }
+
+        assertTrue(nextRunStarted)
+        assertEquals(2, bootstrapCalls)
+    }
+
+    @Test
+    fun `bootstrap gate releases when block is cancelled`() = runTest {
+        val gate = SplashBootstrapGate(SessionManager())
+        val cancellation = CancellationException("cancelled")
+        var bootstrapCalls = 0
+
+        try {
+            gate.runBootstrapIfIdle {
+                bootstrapCalls++
+                throw cancellation
+            }
+            fail("Expected bootstrap cancellation to be rethrown")
+        } catch (throwable: CancellationException) {
+            assertSame(cancellation, throwable)
+        }
+
+        val nextRunStarted = gate.runBootstrapIfIdle {
+            bootstrapCalls++
+        }
+
+        assertTrue(nextRunStarted)
+        assertEquals(2, bootstrapCalls)
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGateTest.kt
@@ -1,0 +1,47 @@
+package com.example.infinite_track.presentation.screen.splash
+
+import com.example.infinite_track.domain.manager.SessionManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SplashBootstrapGateTest {
+
+    @Test
+    fun `second bootstrap start is ignored until current cycle finishes`() {
+        val gate = SplashBootstrapGate(SessionManager())
+
+        assertTrue(gate.beginBootstrap())
+        assertFalse(gate.beginBootstrap())
+
+        gate.finishBootstrap()
+
+        assertTrue(gate.beginBootstrap())
+    }
+
+    @Test
+    fun `terminal logout runs only once when gate owns session expiry handling`() = runTest {
+        val gate = SplashBootstrapGate(SessionManager())
+        var logoutCalls = 0
+
+        gate.runTerminalLogoutIfOwner { logoutCalls++ }
+        gate.runTerminalLogoutIfOwner { logoutCalls++ }
+
+        assertEquals(1, logoutCalls)
+    }
+
+    @Test
+    fun `terminal logout is skipped when another path already owns session expiry handling`() = runTest {
+        val sessionManager = SessionManager()
+        val gate = SplashBootstrapGate(sessionManager)
+        var logoutCalls = 0
+
+        assertTrue(sessionManager.beginSessionExpiryHandling())
+
+        gate.runTerminalLogoutIfOwner { logoutCalls++ }
+
+        assertEquals(0, logoutCalls)
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelOwnerWiringTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelOwnerWiringTest.kt
@@ -1,0 +1,50 @@
+package com.example.infinite_track.presentation.screen.splash
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SplashViewModelOwnerWiringTest {
+    private val projectRoot = File(requireNotNull(System.getProperty("user.dir")))
+
+    @Test
+    fun `startup splash route uses activity scoped splash view model owner`() {
+        val mainActivity = source("main", "MainActivity.kt")
+        val infiniteTrackApp = source("main", "InfiniteTrackApp.kt")
+        val appNavGraph = source("navigation", "AppNavGraph.kt")
+        val splashScreen = source("screen/splash", "SplashScreen.kt")
+
+        assertTrue(
+            "MainActivity must pass its activity-scoped SplashViewModel into InfiniteTrackApp",
+            mainActivity.contains("splashViewModel = viewModel")
+        )
+        assertTrue(
+            "InfiniteTrackApp must require and thread the shared SplashViewModel into the nav graph",
+            infiniteTrackApp.contains("splashViewModel: SplashViewModel") &&
+                infiniteTrackApp.contains("appNavGraph(") &&
+                infiniteTrackApp.contains("splashViewModel = splashViewModel")
+        )
+        assertTrue(
+            "AppNavGraph must require the shared SplashViewModel and pass it to SplashScreen",
+            appNavGraph.contains("splashViewModel: SplashViewModel") &&
+                appNavGraph.contains("SplashScreen(") &&
+                appNavGraph.contains("splashViewModel = splashViewModel")
+        )
+        assertTrue(
+            "SplashScreen must require its caller-provided SplashViewModel",
+            splashScreen.contains("splashViewModel: SplashViewModel")
+        )
+        assertFalse(
+            "SplashScreen must not create a second nav-entry-scoped SplashViewModel via hiltViewModel()",
+            splashScreen.contains("splashViewModel: SplashViewModel = hiltViewModel()")
+        )
+    }
+
+    private fun source(packagePath: String, fileName: String): String {
+        return File(
+            projectRoot,
+            "src/main/java/com/example/infinite_track/presentation/$packagePath/$fileName"
+        ).readText()
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
@@ -14,6 +14,7 @@ import com.example.infinite_track.domain.use_case.auth.CheckSessionUseCase
 import com.example.infinite_track.domain.use_case.auth.GenerateAndSaveEmbeddingUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,7 +27,8 @@ import org.junit.Ignore
 import org.junit.Test
 import java.io.File
 
-@Ignore("Requires Android Main looper in JVM; bootstrap behavior is covered by CheckSessionUseCaseTest.")
+@OptIn(ExperimentalCoroutinesApi::class)
+@Ignore("Requires Android Main looper in JVM; bootstrap behavior is covered by CheckSessionUseCaseTest and SplashBootstrapGateTest.")
 class SplashViewModelTest {
     @Test
     fun `navigates to home when bootstrap succeeds`() = runTest {
@@ -63,9 +65,11 @@ class SplashViewModelTest {
         }
     }
 
-    private fun createViewModel(repository: FakeAuthRepository): SplashViewModel {
-        val userPreference = createUserPreference()
-        val sessionManager = SessionManager()
+    private fun createViewModel(
+        repository: FakeAuthRepository,
+        userPreference: UserPreference = createUserPreference(),
+        sessionManager: SessionManager = SessionManager()
+    ): SplashViewModel {
         return SplashViewModel(
             checkSessionUseCase = CheckSessionUseCase(
                 authRepository = repository,
@@ -77,7 +81,7 @@ class SplashViewModelTest {
                 sessionManager = sessionManager
             ),
             logoutUseCase = LogoutUseCase(repository),
-            context = ContextWrapper(null)
+            sessionManager = sessionManager
         )
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/splash/SplashViewModelTest.kt
@@ -80,8 +80,7 @@ class SplashViewModelTest {
                 userPreference = userPreference,
                 sessionManager = sessionManager
             ),
-            logoutUseCase = LogoutUseCase(repository),
-            sessionManager = sessionManager
+            logoutUseCase = LogoutUseCase(repository)
         )
     }
 

--- a/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
+++ b/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
@@ -1,0 +1,22 @@
+# INF-147 Follow-up — Android bootstrap/logout/permission-session contract
+
+## Scope
+
+This follow-up stays strictly inside Android startup auth continuity:
+- one bootstrap cycle per launch
+- one terminal logout side effect per failure cycle
+- notification permission prompt delayed until session truth is known
+
+## Explicit non-scope
+
+This follow-up does not absorb:
+- INF-97 face bootstrap semantics
+- INF-96 location/background permission decoupling
+- INF-66 attendance orchestration hardening
+
+## Runtime expectation after implementation
+
+- clean launch with invalid session shows one terminal path to login
+- `/api/auth/logout` occurs at most once during startup failure
+- POST_NOTIFICATIONS prompt does not overlap the invalid-session flow
+- offline startup still falls back to one local logout path without crash

--- a/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
+++ b/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
@@ -16,7 +16,7 @@ This follow-up does not absorb:
 
 ## Runtime expectation after implementation
 
-- clean launch with invalid session shows one terminal path to login
+- clean launch with invalid session shows one splash-owned terminal path to login without the global session-expired dialog
 - `/api/auth/logout` occurs at most once during startup failure
 - POST_NOTIFICATIONS prompt does not overlap the invalid-session flow
 - offline startup follows the temporary/bootstrap-unavailable path without crash while preserving local auth state

--- a/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
+++ b/docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md
@@ -19,4 +19,4 @@ This follow-up does not absorb:
 - clean launch with invalid session shows one terminal path to login
 - `/api/auth/logout` occurs at most once during startup failure
 - POST_NOTIFICATIONS prompt does not overlap the invalid-session flow
-- offline startup still falls back to one local logout path without crash
+- offline startup follows the temporary/bootstrap-unavailable path without crash while preserving local auth state


### PR DESCRIPTION
## Summary
- make Android startup auth/bootstrap own a single terminal path to login without duplicate logout or global session-expired dialog collisions
- delay POST_NOTIFICATIONS prompting until authenticated startup wins and keep the once-per-launch prompt guard stable across Activity recreation
- preserve truthful bootstrap reauth reasons across profile sync, refresh failure, and retry paths, while keeping runtime interceptor reauth behavior intact

## Test Plan
- [x] ./gradlew.bat testDebugUnitTest
- [x] ./gradlew.bat compileDebugAndroidTestKotlin
- [x] runtime verification in emulator for online invalid-session path
- [x] runtime verification in emulator for offline bootstrap-unavailable / fallback path

## Notes
- work performed in isolated worktree branch `fix/auth-bootstrap-session-contract`
- INF-147 follow-up sync note added under `docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)