### PR TITLE
docs: add tracked superpowers plans and specs

### DIFF
--- a/docs/superpowers/plans/2026-05-10-inf-163-shell-navigation-contract.md
+++ b/docs/superpowers/plans/2026-05-10-inf-163-shell-navigation-contract.md
@@ -1,0 +1,249 @@
+# INF-163 Shell Navigation Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring Android main shell navigation into explicit INF-163 compliance on top of `fix/inf-163-bottom-bar-role-navigation-develop` after syncing that branch with `develop`.
+
+**Architecture:** Keep main shell behavior centralized in `MainShellNavigationPolicy` and continue driving UI through the existing `MainBottomBar` and `MainScreen` integration points. Close the remaining contract gaps with tests first: Management must have no FAB, profile child routes that keep the bottom bar visible must keep the Profile tab selected, and English menu labels must be corrected at the string-resource source instead of being reformatted in UI code.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Jetpack Navigation, Hilt, JUnit4, Gradle
+
+---
+
+## File map
+
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicy.kt` — single source of truth for bottom-bar routes, selected-state behavior, and role-to-FAB mapping.
+- Modify: `app/src/test/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicyTest.kt` — contract tests for bottom-bar order, nested selected-state behavior, and explicit FAB policy.
+- Modify: `app/src/main/res/values/strings.xml` — English bottom-bar labels; fix capitalization at the resource source.
+- Verify only: `app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt` — should keep consuming `fabConfigForRole()` and `shouldShowBottomBar()` with no new role branching.
+- Verify only: `app/src/main/java/com/example/infinite_track/presentation/components/navigation/MainBottomBar.kt` — should keep using `stringResource(id = item.labelRes)` directly with no runtime label formatter.
+- Verify only: `app/src/main/java/com/example/infinite_track/presentation/navigation/model/Screen.kt` and `app/src/main/java/com/example/infinite_track/presentation/navigation/model/NavigationItem.kt` — these should remain the only navigation model definitions after the branch is synced with `develop`.
+- Do not modify unless merge conflicts force it: `app/src/main/java/com/example/infinite_track/presentation/components/navigation/BottomBarStaff.kt`, `app/src/main/java/com/example/infinite_track/presentation/components/navigation/BottomBarInternship.kt`.
+
+### Task 1: Sync the INF-163 branch with `develop` and verify the shell source of truth
+
+**Files:**
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/navigation/model/Screen.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/navigation/model/NavigationItem.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/components/navigation/MainBottomBar.kt`
+
+- [ ] **Step 1: Create an isolated workspace from the target branch**
+
+```bash
+git fetch origin
+git worktree add ".worktrees/inf-163-shell" "fix/inf-163-bottom-bar-role-navigation-develop"
+```
+
+Expected: a new worktree exists at `.worktrees/inf-163-shell` and is checked out on `fix/inf-163-bottom-bar-role-navigation-develop`.
+
+- [ ] **Step 2: Merge the latest `develop` into the target branch inside the worktree**
+
+```bash
+git -C ".worktrees/inf-163-shell" merge develop
+```
+
+Expected: merge completes cleanly or stops with explicit conflicts. If imports conflict, resolve them in favor of the model-package layout shown below:
+
+```kotlin
+import com.example.infinite_track.presentation.navigation.model.NavigationItem
+import com.example.infinite_track.presentation.navigation.model.Screen
+```
+
+- [ ] **Step 3: Verify that only one `Screen` and one `NavigationItem` definition remain**
+
+```bash
+git -C ".worktrees/inf-163-shell" grep -n "sealed class Screen" -- "app/src/main/java/com/example/infinite_track/presentation/navigation"
+git -C ".worktrees/inf-163-shell" grep -n "class NavigationItem" -- "app/src/main/java/com/example/infinite_track/presentation/navigation"
+```
+
+Expected: exactly one `Screen` definition and one `NavigationItem` definition, both under `presentation/navigation/model/`.
+
+- [ ] **Step 4: Run the existing shell policy test as the post-merge baseline**
+
+```bash
+cd ".worktrees/inf-163-shell" && ./gradlew.bat testDebugUnitTest --tests "com.example.infinite_track.presentation.navigation.main.MainShellNavigationPolicyTest"
+```
+
+Expected: `BUILD SUCCESSFUL`. If this fails before any new edits, stop and fix the merge damage before changing the contract.
+
+### Task 2: Lock the remaining INF-163 contract gaps with failing tests
+
+**Files:**
+- Modify: `app/src/test/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicyTest.kt`
+- Test: `app/src/test/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicyTest.kt`
+
+- [ ] **Step 1: Replace the old Management FAB expectation and expand the Profile selected-state test**
+
+Update `MainShellNavigationPolicyTest.kt` so the Profile test covers all Profile child destinations that currently keep the bottom bar visible, and replace the old “preserve current repo behavior” FAB test with the explicit INF-163 rule.
+
+```kotlin
+@Test
+fun `profile tab stays selected for profile child routes that keep the bottom bar visible`() {
+    val profileItem = MainShellNavigationPolicy.bottomBarItemsForRole("Employee")[3]
+
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.Profile.route))
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.ProfileFlow.route))
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.EditProfile.route))
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.ContactUs.route))
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.PaySlip.route))
+    assertTrue(MainShellNavigationPolicy.isSelected(profileItem, Screen.MyDocument.route))
+    assertFalse(MainShellNavigationPolicy.isSelected(profileItem, Screen.Home.route))
+}
+
+@Test
+fun `fab mapping keeps only internship attendance action under INF-163`() {
+    assertEquals(
+        Screen.Attendance.route,
+        MainShellNavigationPolicy.fabConfigForRole("Internship")?.destination?.route
+    )
+    assertNull(MainShellNavigationPolicy.fabConfigForRole("Management"))
+    assertNull(MainShellNavigationPolicy.fabConfigForRole("Employee"))
+    assertNull(MainShellNavigationPolicy.fabConfigForRole("Admin"))
+}
+```
+
+- [ ] **Step 2: Run the shell policy test to prove the new contract fails on the old implementation**
+
+```bash
+cd ".worktrees/inf-163-shell" && ./gradlew.bat testDebugUnitTest --tests "com.example.infinite_track.presentation.navigation.main.MainShellNavigationPolicyTest"
+```
+
+Expected: `FAIL` because `fabConfigForRole("Management")` still returns `Screen.TimeOffReq`, and `isSelected()` still returns `false` for at least one of `Screen.ContactUs`, `Screen.PaySlip`, or `Screen.MyDocument`.
+
+- [ ] **Step 3: Implement the minimal policy change to satisfy the new contract**
+
+Update `MainShellNavigationPolicy.kt` so the Profile selected-state set includes the visible Profile child routes and only Internship receives a FAB.
+
+```kotlin
+private val profileSelectedRoutes = setOf(
+    Screen.Profile.route,
+    Screen.ProfileFlow.route,
+    Screen.EditProfile.route,
+    Screen.ContactUs.route,
+    Screen.PaySlip.route,
+    Screen.MyDocument.route
+)
+
+fun fabConfigForRole(userRole: String): FabConfig? {
+    return when (userRole) {
+        "Internship" -> FabConfig(
+            iconRes = R.drawable.ic_intern_fab,
+            destination = Screen.Attendance
+        )
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Re-run the shell policy test to verify the contract now passes**
+
+```bash
+cd ".worktrees/inf-163-shell" && ./gradlew.bat testDebugUnitTest --tests "com.example.infinite_track.presentation.navigation.main.MainShellNavigationPolicyTest"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit the contract fix**
+
+```bash
+cd ".worktrees/inf-163-shell" && git add \
+  app/src/main/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicy.kt \
+  app/src/test/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicyTest.kt && \
+  git commit -m "fix: finalize INF-163 shell navigation contract"
+```
+
+### Task 3: Correct the English shell labels at the resource source
+
+**Files:**
+- Modify: `app/src/main/res/values/strings.xml`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/components/navigation/MainBottomBar.kt`
+
+- [ ] **Step 1: Confirm the UI is not formatting bottom-bar labels at runtime**
+
+```bash
+cd ".worktrees/inf-163-shell" && grep -n "formatBottomBarLabel" app/src/main/java/com/example/infinite_track/presentation/components/navigation/MainBottomBar.kt
+```
+
+Expected: no output. The bottom bar should rely on string resources directly.
+
+- [ ] **Step 2: Fix the English bottom-bar strings in `values/strings.xml`**
+
+Replace the existing lowercase English values with the contract labels.
+
+```xml
+<string name="bottom_menu_home">Home</string>
+<string name="bottom_menu_history">History</string>
+<string name="bottom_menu_contact">Contact</string>
+<string name="bottom_menu_profile">Profile</string>
+```
+
+- [ ] **Step 3: Run resource processing to verify the resource edit compiles cleanly**
+
+```bash
+cd ".worktrees/inf-163-shell" && ./gradlew.bat :app:processDebugResources
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit the resource cleanup**
+
+```bash
+cd ".worktrees/inf-163-shell" && git add app/src/main/res/values/strings.xml && git commit -m "fix: normalize INF-163 bottom bar labels"
+```
+
+### Task 4: Run final verification and prepare the closure evidence note
+
+**Files:**
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/components/navigation/MainBottomBar.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicy.kt`
+- Verify: `app/src/test/java/com/example/infinite_track/presentation/navigation/main/MainShellNavigationPolicyTest.kt`
+
+- [ ] **Step 1: Run the focused regression suite for the shell contract**
+
+```bash
+cd ".worktrees/inf-163-shell" && ./gradlew.bat testDebugUnitTest --tests "com.example.infinite_track.presentation.navigation.main.MainShellNavigationPolicyTest"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 2: Capture the implementation diff against `develop` for the closure note**
+
+```bash
+cd ".worktrees/inf-163-shell" && git diff --stat develop...HEAD
+```
+
+Expected: the diff is limited to INF-163 shell-navigation files plus the merge commit from syncing with `develop`.
+
+- [ ] **Step 3: Prepare the final Linear evidence note using the exact template below**
+
+```markdown
+## INF-163 closure
+
+### Fact
+- Main shell bottom bar is driven from `MainShellNavigationPolicy`.
+- All supported main-shell roles use `Home | History | Contact | Profile`.
+- `MyLeave` is no longer a primary bottom-bar tab.
+- `Internship` keeps the Attendance FAB.
+- `Employee`, `Admin`, and `Management` now have no shell FAB.
+- Profile child routes that keep the bottom bar visible keep the Profile tab selected.
+
+### Verification
+- `./gradlew.bat testDebugUnitTest --tests "com.example.infinite_track.presentation.navigation.main.MainShellNavigationPolicyTest"`
+- `./gradlew.bat :app:processDebugResources`
+
+### Risk
+- Manual emulator verification is still needed if product wants visual proof of the FAB disappearing for Management.
+
+### Needs Verification
+- If the branch merge from `develop` pulled in unrelated shell-adjacent edits, inspect the final diff before opening the PR.
+```
+
+- [ ] **Step 4: Report completion only after the verification commands have succeeded**
+
+```bash
+cd ".worktrees/inf-163-shell" && git status --short
+```
+
+Expected: no unexpected modified files beyond the intended INF-163 work.

--- a/docs/superpowers/plans/2026-06-04-inf-147-closure-audit.md
+++ b/docs/superpowers/plans/2026-06-04-inf-147-closure-audit.md
@@ -1,0 +1,358 @@
+# INF-147 Closure Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decide truthfully whether Linear issue `INF-147` can be closed on current `develop`, using an explicit acceptance matrix, current evidence, targeted gap verification, and a Linear-ready closure draft.
+
+**Architecture:** Treat this as an audit artifact workflow, not a feature build. Keep one canonical audit note under `docs/linear-sync/` for the acceptance matrix and closure recommendation, keep one current runtime evidence file under `docs/auth-runtime-evidence/`, and produce one Linear-ready comment draft under `docs/linear-sync/` so the close/no-close decision can be reviewed independently of chat history.
+
+**Tech Stack:** Markdown docs, git history, Android emulator + adb runtime capture, existing Android app/runtime evidence, Linear issue data
+
+---
+
+## File map
+
+- Create: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md` — canonical acceptance matrix, evidence mapping, status per criterion, and final closure recommendation.
+- Create: `docs/linear-sync/INF-147-closure-comment-2026-06-04.md` — final Linear-ready comment, either close-ready or not-close-ready.
+- Create: `docs/auth-runtime-evidence/RUN_2026-06-04-INF-147-gap-checks.md` — current targeted runtime evidence for any criteria re-checked during the audit.
+- Verify: `docs/superpowers/specs/2026-06-04-inf-147-closure-audit-design.md` — approved closure-audit design; do not drift from it.
+- Verify: `docs/linear-sync/INF-147-followup-2026-05-30.md` — prior Android contract alignment note from PR #21.
+- Verify: `docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md` — prior Android bootstrap/logout/permission follow-up note from PR #22.
+- Verify: `docs/auth-runtime-evidence/RUN_2026-05-30.md` — prior runtime evidence note.
+- Verify: `docs/runtime-startup.png`, `docs/runtime-after-dismiss.png`, `docs/runtime-relaunch-now.png`, `docs/runtime-logcat.txt` — current runtime artifacts already captured on `develop`.
+- Verify: `app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt` — bootstrap/session truth behavior under current implementation.
+- Verify: `app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt` — protected API refresh behavior and logout side-effect rules.
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt` — notification prompt timing during startup.
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt` — bootstrap-cycle ownership at launch.
+
+### Task 1: Scaffold the canonical INF-147 acceptance matrix
+
+**Files:**
+- Create: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+- Verify: `docs/superpowers/specs/2026-06-04-inf-147-closure-audit-design.md`
+
+- [ ] **Step 1: Confirm the approved design file is present before drafting the audit note**
+
+```bash
+test -f docs/superpowers/specs/2026-06-04-inf-147-closure-audit-design.md && echo DESIGN_READY
+```
+
+Expected: `DESIGN_READY`
+
+- [ ] **Step 2: Create the audit note with the exact matrix skeleton below**
+
+```markdown
+# INF-147 Closure Audit — 2026-06-04
+
+## Scope
+
+Evaluate whether `INF-147` is close-ready on current `develop` using only current code, current docs, current runtime artifacts, and explicit remaining blockers.
+
+## Acceptance Matrix
+
+| Criterion | Expected behavior | Current evidence | Evidence source | Status | Next action |
+| --- | --- | --- | --- | --- | --- |
+| Login → expired access token → refresh succeeds | Android silently refreshes and continues session truthfully when refresh is still valid. | No current direct runtime proof recorded in this audit note yet. | Pending reconciliation. | Not Proven | Reconcile prior evidence; if still missing, keep open or verify if feasible. |
+| App resume / foreground with expired access token | Resume path refreshes truthfully instead of pretending local session is still valid. | No current direct runtime proof recorded in this audit note yet. | Pending reconciliation. | Not Proven | Reconcile current code/docs and decide whether targeted runtime proof is feasible. |
+| Refresh fails because token is invalid or revoked | Android forces full re-auth and does not preserve a fake valid session. | No current direct runtime proof recorded in this audit note yet. | Pending reconciliation. | Not Proven | Reconcile startup/runtime invalid-session evidence and current implementation. |
+| Refresh fails because inactivity > 48 hours | Android requires full login again under the backend inactivity contract. | No current direct runtime proof recorded in this audit note yet. | Pending reconciliation. | Not Proven | Check whether any current evidence proves this; if not, leave as blocker. |
+| Offline/server-down during refresh does not trigger misleading auth cleanup | Temporary refresh failures preserve local auth state and do not pretend the session is invalid. | No current direct runtime proof recorded in this audit note yet. | Pending reconciliation. | Not Proven | Reconcile docs + implementation + any current runtime capture. |
+
+## Decision Rule
+
+- `Close-ready` only if every issue-critical criterion is `Proven`.
+- `Not close-ready` if any issue-critical criterion remains `Not Proven`.
+- `Needs split follow-up` only if the remaining gap is outside the intended scope of `INF-147`.
+```
+
+- [ ] **Step 3: Verify the file contains all five Linear verification criteria exactly once**
+
+```bash
+for phrase in \
+  "Login → expired access token → refresh succeeds" \
+  "App resume / foreground with expired access token" \
+  "Refresh fails because token is invalid or revoked" \
+  "Refresh fails because inactivity > 48 hours" \
+  "Offline/server-down during refresh does not trigger misleading auth cleanup"; do
+  grep -n "$phrase" docs/linear-sync/INF-147-closure-audit-2026-06-04.md || exit 1
+done
+```
+
+Expected: one matching line number for each phrase and exit code `0`.
+
+- [ ] **Step 4: Commit the scaffold before adding evidence**
+
+```bash
+git add docs/linear-sync/INF-147-closure-audit-2026-06-04.md
+git commit -m "docs: scaffold INF-147 closure audit matrix"
+```
+
+Expected: one commit containing only the new audit note scaffold.
+
+### Task 2: Reconcile historical evidence against current `develop`
+
+**Files:**
+- Modify: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+- Verify: `docs/linear-sync/INF-147-followup-2026-05-30.md`
+- Verify: `docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md`
+- Verify: `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+- Verify: `docs/runtime-startup.png`
+- Verify: `docs/runtime-after-dismiss.png`
+- Verify: `docs/runtime-relaunch-now.png`
+- Verify: `docs/runtime-logcat.txt`
+- Verify: `app/src/main/java/com/example/infinite_track/domain/use_case/auth/CheckSessionUseCase.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/di/auth/AuthRefreshInterceptor.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt`
+- Verify: `app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashBootstrapGate.kt`
+
+- [ ] **Step 1: Capture the exact current implementation range that landed INF-147 work on `develop`**
+
+```bash
+git log --oneline 59d8cbe..HEAD
+```
+
+Expected: the output includes the PR #22 merge commit `5f2a9a9` and the auth-bootstrap/session-contract commits that followed PR #21.
+
+- [ ] **Step 2: Append an evidence inventory section to the audit note using the exact headings below**
+
+```markdown
+## Reconciled Evidence Inventory
+
+### Repo history
+- `59d8cbe..HEAD` contains PR #22 bootstrap/session-contract follow-up work on top of the earlier INF-147 alignment.
+
+### Prior Android notes
+- `docs/linear-sync/INF-147-followup-2026-05-30.md`
+- `docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md`
+
+### Runtime artifacts already captured on current develop
+- `docs/runtime-startup.png`
+- `docs/runtime-after-dismiss.png`
+- `docs/runtime-relaunch-now.png`
+- `docs/runtime-logcat.txt`
+
+### Current code anchors
+- `CheckSessionUseCase.kt`
+- `AuthRefreshInterceptor.kt`
+- `StartupNotificationPermissionPolicy.kt`
+- `SplashBootstrapGate.kt`
+```
+
+- [ ] **Step 3: Upgrade matrix rows only where the current evidence actually supports it**
+
+Use the exact wording below for the rows that already have strong current evidence:
+
+```markdown
+| Refresh fails because token is invalid or revoked | Android forces full re-auth and does not preserve a fake valid session. | Current startup runtime shows invalid-session UI leading back to login, with one visible terminal invalid-session message and no authenticated landing state. | `docs/runtime-startup.png`, `docs/runtime-after-dismiss.png`, `docs/runtime-relaunch-now.png`, `docs/runtime-logcat.txt`, `CheckSessionUseCase.kt`, `SplashBootstrapGate.kt` | Partially Proven | Keep partial unless a truly revoked refresh-token scenario is demonstrated beyond startup invalid-session behavior. |
+| Offline/server-down during refresh does not trigger misleading auth cleanup | Temporary refresh failures preserve local auth state and do not pretend the session is invalid. | Prior docs and current implementation strongly encode temporary/bootstrap-unavailable behavior, but this audit has not yet produced a fresh current-develop runtime proof for an authenticated refresh failure. | `docs/auth-runtime-evidence/RUN_2026-05-30.md`, `docs/linear-sync/INF-147-followup-2026-05-30.md`, `CheckSessionUseCase.kt`, `AuthRefreshInterceptor.kt` | Partially Proven | Attempt targeted gap verification only if a controlled authenticated session is available; otherwise keep partial. |
+```
+
+Do **not** mark the `48 hours` row as proven unless there is explicit current evidence.
+
+- [ ] **Step 4: Verify that every matrix row now cites at least one concrete source**
+
+```bash
+grep -n "| .* | .* | .* | .* | .* | .* |" docs/linear-sync/INF-147-closure-audit-2026-06-04.md
+```
+
+Expected: five populated matrix rows remain in the file, each with a non-empty `Evidence source` column.
+
+- [ ] **Step 5: Commit the reconciled evidence mapping**
+
+```bash
+git add docs/linear-sync/INF-147-closure-audit-2026-06-04.md
+git commit -m "docs: reconcile INF-147 closure evidence"
+```
+
+Expected: one commit updating only the audit note.
+
+### Task 3: Record current targeted gap verification and blockers
+
+**Files:**
+- Create: `docs/auth-runtime-evidence/RUN_2026-06-04-INF-147-gap-checks.md`
+- Modify: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+- Verify: `docs/runtime-startup.png`
+- Verify: `docs/runtime-after-dismiss.png`
+- Verify: `docs/runtime-relaunch-now.png`
+- Verify: `docs/runtime-logcat.txt`
+
+- [ ] **Step 1: Create the current gap-check note with the exact template below**
+
+```markdown
+# INF-147 Gap Checks — 2026-06-04
+
+## Scope
+- Reuse only current `develop` runtime artifacts already captured during manual Android startup verification.
+- Do not fabricate backend-stateful proofs that the local environment cannot truthfully provide.
+
+## Observed current-develop artifacts
+- `docs/runtime-startup.png` shows invalid-session startup landing on login.
+- `docs/runtime-after-dismiss.png` shows the overlay can be dismissed without a second conflicting prompt.
+- `docs/runtime-relaunch-now.png` shows relaunch returns to the same invalid-session/login state.
+- `docs/runtime-logcat.txt` contains one observed `/api/auth/logout` occurrence during the captured startup-failure flow.
+
+## Explicit blockers
+- No current runtime proof of `refresh succeeds after expired access token` from an authenticated expired-session scenario.
+- No current runtime proof of `foreground/resume with expired access token` from an authenticated resumed session.
+- No controlled current runtime proof of `48-hour inactivity` denial.
+- No controlled current runtime proof of a truly revoked refresh token distinct from the general invalid-session startup path.
+
+## Audit consequence
+- Any criterion still depending on the blocked scenarios must remain `Not Proven`.
+```
+
+- [ ] **Step 2: Verify the captured logout count directly from the current log artifact**
+
+```bash
+grep -i -n "api/auth/logout" docs/runtime-logcat.txt
+```
+
+Expected: one matching line showing the captured logout request in the startup-failure flow.
+
+- [ ] **Step 3: Append a remaining-gaps section to the audit note using the exact wording below**
+
+```markdown
+## Remaining Gaps After Current-Develop Reconciliation
+
+- `Login -> expired access token -> refresh succeeds` remains `Not Proven` because no current authenticated expired-session runtime proof exists in this audit.
+- `App resume / foreground with expired access token` remains `Not Proven` unless a controlled authenticated resume scenario is captured.
+- `Refresh fails because token is invalid or revoked` remains `Partially Proven`; startup invalid-session behavior is current, but a specifically revoked refresh-token scenario is not.
+- `Refresh fails because inactivity > 48 hours` remains `Not Proven`; no current runtime proof demonstrates the backend inactivity path.
+- `Offline/server-down during refresh does not trigger misleading auth cleanup` remains `Partially Proven` unless a current authenticated temporary-failure runtime scenario is captured.
+```
+
+- [ ] **Step 4: Update the matrix statuses so they match the blocker note exactly**
+
+Use these final pre-decision statuses unless new runtime evidence has been captured during the same audit session:
+
+```markdown
+- `Login -> expired access token -> refresh succeeds` = `Not Proven`
+- `App resume / foreground with expired access token` = `Not Proven`
+- `Refresh fails because token is invalid or revoked` = `Partially Proven`
+- `Refresh fails because inactivity > 48 hours` = `Not Proven`
+- `Offline/server-down during refresh does not trigger misleading auth cleanup` = `Partially Proven`
+```
+
+- [ ] **Step 5: Commit the gap note and matrix status update**
+
+```bash
+git add \
+  docs/auth-runtime-evidence/RUN_2026-06-04-INF-147-gap-checks.md \
+  docs/linear-sync/INF-147-closure-audit-2026-06-04.md
+git commit -m "docs: record INF-147 closure gaps"
+```
+
+Expected: one commit containing only the new gap-check note and the updated audit note.
+
+### Task 4: Draft the Linear closure comment and final recommendation
+
+**Files:**
+- Create: `docs/linear-sync/INF-147-closure-comment-2026-06-04.md`
+- Modify: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+- Verify: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+
+- [ ] **Step 1: Add the final recommendation section to the audit note using the exact text below**
+
+```markdown
+## Final Recommendation
+
+Recommendation: `Do not close INF-147 yet`.
+
+Reason:
+- The Android repository and current runtime evidence strongly support that the core implementation is in place.
+- However, the issue's own verification bullets still include multiple runtime-semantic scenarios that remain unproven in the current audit.
+- Closing the issue today would overstate the evidence, especially for the `expired access token refresh succeeds`, `foreground/resume`, and `48-hour inactivity` criteria.
+```
+
+- [ ] **Step 2: Create the Linear-ready comment draft with the exact content below**
+
+```markdown
+## INF-147 closure audit update
+
+### What is already in place
+- Android has already absorbed the backend refresh-session contract from `INF-145`.
+- PR #21 aligned Android refresh/session compatibility.
+- PR #22 tightened bootstrap/logout/notification-session behavior on top of that contract.
+- Current `develop` runtime evidence confirms truthful startup invalid-session handling back to login and a stable dismissible invalid-session overlay.
+
+### What is currently proven or partially proven
+- Startup invalid-session behavior is current and visible on `develop`.
+- Startup failure produces one observed logout side effect in the captured runtime log.
+- Notification prompt does not overlap the captured invalid-session startup path.
+- Temporary-failure semantics and bootstrap truthfulness are strongly supported by code and prior docs, but not all issue verification bullets have fresh direct runtime proof.
+
+### Why this issue should stay open for now
+The issue's own verification section still asks us to prove these runtime-semantic scenarios explicitly:
+- login -> access token expired -> refresh succeeds
+- app resume / foreground with expired access token
+- refresh fail because inactivity > 48 hours -> full login required
+
+Those criteria are not yet proven by the current audit artifacts on `develop`, so closing the issue now would overstate the evidence.
+
+### Recommended next step
+Keep `INF-147` open until one of these happens:
+1. the remaining runtime-semantic scenarios are demonstrated and added to the audit, or
+2. the issue scope is narrowed and the still-unproven scenarios are split into a follow-up verification issue.
+```
+
+- [ ] **Step 3: Verify the recommendation and the comment draft agree with each other**
+
+```bash
+grep -n "Do not close INF-147 yet" docs/linear-sync/INF-147-closure-audit-2026-06-04.md
+grep -n "Why this issue should stay open for now" docs/linear-sync/INF-147-closure-comment-2026-06-04.md
+```
+
+Expected: both files contain the no-close recommendation language with no contradictory `close-ready` wording.
+
+- [ ] **Step 4: Commit the final closure artifacts**
+
+```bash
+git add \
+  docs/linear-sync/INF-147-closure-audit-2026-06-04.md \
+  docs/linear-sync/INF-147-closure-comment-2026-06-04.md
+git commit -m "docs: draft INF-147 closure recommendation"
+```
+
+### Task 5: Final consistency pass before execution handoff
+
+**Files:**
+- Verify: `docs/linear-sync/INF-147-closure-audit-2026-06-04.md`
+- Verify: `docs/linear-sync/INF-147-closure-comment-2026-06-04.md`
+- Verify: `docs/auth-runtime-evidence/RUN_2026-06-04-INF-147-gap-checks.md`
+
+- [ ] **Step 1: Confirm there are no placeholders or unresolved markers in the new artifacts**
+
+```bash
+pattern=$(python - <<'PY'
+print("|".join([
+    "TB" + "D",
+    "TO" + "DO",
+    "FIX" + "ME",
+    "fill " + "in",
+    "similar " + "to " + "Task",
+]))
+PY
+)
+! grep -R -nE "$pattern" \
+  docs/linear-sync/INF-147-closure-audit-2026-06-04.md \
+  docs/linear-sync/INF-147-closure-comment-2026-06-04.md \
+  docs/auth-runtime-evidence/RUN_2026-06-04-INF-147-gap-checks.md
+```
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 2: Confirm the working tree only contains the intended closure-audit artifacts**
+
+```bash
+git status --short
+```
+
+Expected: only the three intended docs are modified or newly created.
+
+- [ ] **Step 3: Capture the final diffstat for review handoff**
+
+```bash
+git diff --stat HEAD~4..HEAD
+```
+
+Expected: only the INF-147 closure-audit documents appear in the diffstat.

--- a/docs/superpowers/plans/2026-06-14-gradle-cache-relocation.md
+++ b/docs/superpowers/plans/2026-06-14-gradle-cache-relocation.md
@@ -1,0 +1,265 @@
+# Gradle Cache Relocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist Gradle user home to `D:\Java_Home`, remove the legacy Gradle cache folders from `C:\Users\Febriyadi\.gradle`, and rebuild the Android project so Gradle runs from the new location.
+
+**Architecture:** Treat this as a machine-level environment migration, not an Android application code change. Persist `GRADLE_USER_HOME` at the Windows user-environment level, mirror it into the current shell so verification can run immediately, stop old Gradle daemons, clean only the old cache folders that are safe to remove, then rebuild the repo and confirm new Gradle activity appears under `D:\Java_Home`.
+
+**Tech Stack:** Windows user environment variables, PowerShell, Gradle Wrapper (`gradlew.bat`), Android Gradle Plugin, existing Android repo at `E:\skrisi\android`
+
+---
+
+## File map
+
+- Verify: `docs/superpowers/specs/2026-06-14-gradle-cache-relocation-design.md` — approved design for this environment migration.
+- Verify: `gradle/wrapper/gradle-wrapper.properties` — confirms wrapper distributions resolve from `GRADLE_USER_HOME`.
+- Verify: `gradle.properties` — confirms the repo does not already override Gradle user home.
+- No application source files should be modified during execution.
+- No Android runtime code, DI modules, or build scripts should be edited unless the plan fails and a new design is approved.
+
+### Task 1: Persist `GRADLE_USER_HOME` to `D:\Java_Home`
+
+**Files:**
+- Verify: `docs/superpowers/specs/2026-06-14-gradle-cache-relocation-design.md`
+- Verify: `gradle/wrapper/gradle-wrapper.properties`
+
+- [ ] **Step 1: Confirm the approved design file exists before changing machine environment**
+
+Run:
+
+```powershell
+if (Test-Path "E:\skrisi\android\docs\superpowers\specs\2026-06-14-gradle-cache-relocation-design.md") { 'DESIGN_READY' } else { throw 'Design spec missing' }
+```
+
+Expected: `DESIGN_READY`
+
+- [ ] **Step 2: Confirm the wrapper is configured to use `GRADLE_USER_HOME`**
+
+Run:
+
+```powershell
+Select-String -Path "E:\skrisi\android\gradle\wrapper\gradle-wrapper.properties" -Pattern "distributionBase=GRADLE_USER_HOME","zipStoreBase=GRADLE_USER_HOME"
+```
+
+Expected: two matches, one for `distributionBase=GRADLE_USER_HOME` and one for `zipStoreBase=GRADLE_USER_HOME`
+
+- [ ] **Step 3: Ensure the target Gradle home directory exists**
+
+Run:
+
+```powershell
+if (-not (Test-Path "D:\Java_Home")) { New-Item -ItemType Directory -Path "D:\Java_Home" | Out-Null }
+Get-ChildItem "D:\Java_Home"
+```
+
+Expected: command succeeds without error; the directory exists even if it is empty
+
+- [ ] **Step 4: Persist the user-level environment variable**
+
+Run:
+
+```powershell
+[Environment]::SetEnvironmentVariable('GRADLE_USER_HOME', 'D:\Java_Home', 'User')
+[Environment]::GetEnvironmentVariable('GRADLE_USER_HOME', 'User')
+```
+
+Expected: the second line prints exactly `D:\Java_Home`
+
+- [ ] **Step 5: Mirror the same value into the current shell so verification can run immediately**
+
+Run:
+
+```powershell
+$env:GRADLE_USER_HOME = 'D:\Java_Home'
+$env:GRADLE_USER_HOME
+```
+
+Expected: prints exactly `D:\Java_Home`
+
+### Task 2: Stop old Gradle daemons and verify the new home is active for this shell
+
+**Files:**
+- Verify: `gradle.properties`
+
+- [ ] **Step 1: Confirm the repo does not already force another Gradle home**
+
+Run:
+
+```powershell
+Select-String -Path "E:\skrisi\android\gradle.properties" -Pattern "org.gradle.caching","gradle.user.home","GRADLE_USER_HOME"
+```
+
+Expected: no match for a repo-level Gradle user home override; empty output is acceptable
+
+- [ ] **Step 2: Stop any running Gradle daemons before cleanup**
+
+Run:
+
+```powershell
+& "E:\skrisi\android\gradlew.bat" --stop
+```
+
+Expected: output such as `Stopping Daemon(s)` or `No Gradle daemons are running`
+
+- [ ] **Step 3: Run a lightweight Gradle command that should initialize the new home if needed**
+
+Run:
+
+```powershell
+& "E:\skrisi\android\gradlew.bat" -version
+```
+
+Expected: Gradle version output appears successfully and does not fail on wrapper initialization
+
+- [ ] **Step 4: Verify wrapper artifacts now exist under the new Gradle home**
+
+Run:
+
+```powershell
+Get-ChildItem "D:\Java_Home\wrapper\dists" -Recurse -ErrorAction Stop | Select-Object -First 20 FullName
+```
+
+Expected: output contains at least one Gradle wrapper distribution path, typically including `gradle-8.7-bin`
+
+### Task 3: Remove the recommended legacy cache folders from `C:`
+
+**Files:**
+- No repo files changed
+
+- [ ] **Step 1: Verify the old cache folders exist before deleting them**
+
+Run:
+
+```powershell
+foreach ($path in @('C:\Users\Febriyadi\.gradle\caches', 'C:\Users\Febriyadi\.gradle\wrapper\dists')) {
+  if (Test-Path $path) { "FOUND: $path" } else { "MISSING: $path" }
+}
+```
+
+Expected: ideally both paths print as `FOUND`; if one is already missing, note it and continue without treating that as a failure
+
+- [ ] **Step 2: Delete the old `caches` folder only**
+
+Run:
+
+```powershell
+if (Test-Path "C:\Users\Febriyadi\.gradle\caches") {
+  Remove-Item "C:\Users\Febriyadi\.gradle\caches" -Recurse -Force -Confirm:$false
+}
+Test-Path "C:\Users\Febriyadi\.gradle\caches"
+```
+
+Expected: final line prints `False`
+
+- [ ] **Step 3: Delete the old wrapper distributions folder only**
+
+Run:
+
+```powershell
+if (Test-Path "C:\Users\Febriyadi\.gradle\wrapper\dists") {
+  Remove-Item "C:\Users\Febriyadi\.gradle\wrapper\dists" -Recurse -Force -Confirm:$false
+}
+Test-Path "C:\Users\Febriyadi\.gradle\wrapper\dists"
+```
+
+Expected: final line prints `False`
+
+- [ ] **Step 4: Confirm the broader old Gradle home directory was not deleted wholesale**
+
+Run:
+
+```powershell
+Test-Path "C:\Users\Febriyadi\.gradle"
+```
+
+Expected: usually `True`; if `False`, stop and record that cleanup went wider than planned
+
+### Task 4: Rebuild the Android project from the new Gradle home
+
+**Files:**
+- No application files changed
+- Verify: `app/build.gradle.kts`
+
+- [ ] **Step 1: Run a clean build using the new `GRADLE_USER_HOME`**
+
+Run:
+
+```powershell
+& "E:\skrisi\android\gradlew.bat" clean
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 2: Assemble the debug app from the repository root**
+
+Run:
+
+```powershell
+& "E:\skrisi\android\gradlew.bat" app:assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL` and an APK output under `E:\skrisi\android\app\build\outputs\apk\debug\`
+
+- [ ] **Step 3: Verify dependency/cache activity exists under the new Gradle home after the rebuild**
+
+Run:
+
+```powershell
+Get-ChildItem "D:\Java_Home\caches" -ErrorAction Stop | Select-Object -First 20 FullName
+```
+
+Expected: non-empty output showing Gradle cache directories under `D:\Java_Home\caches`
+
+- [ ] **Step 4: Verify the debug APK exists after the rebuild**
+
+Run:
+
+```powershell
+Test-Path "E:\skrisi\android\app\build\outputs\apk\debug\app-debug.apk"
+```
+
+Expected: `True`
+
+### Task 5: Record handoff status and IDE follow-up
+
+**Files:**
+- No repo files changed unless the execution workflow explicitly records a follow-up note elsewhere
+
+- [ ] **Step 1: Re-read the user-level environment variable from Windows to confirm persistence survived the build**
+
+Run:
+
+```powershell
+[Environment]::GetEnvironmentVariable('GRADLE_USER_HOME', 'User')
+```
+
+Expected: exactly `D:\Java_Home`
+
+- [ ] **Step 2: State the Android Studio follow-up explicitly**
+
+Use this exact handoff text in the execution summary:
+
+```text
+Android Studio should be restarted once so the IDE picks up the updated GRADLE_USER_HOME consistently. Until that restart is confirmed, IDE-side inheritance remains Needs Verification even if terminal builds are already successful.
+```
+
+Expected: the final summary includes this exact note
+
+- [ ] **Step 3: Do not create a code commit unless repository files were intentionally changed during execution**
+
+Use this exact handoff text in the execution summary:
+
+```text
+No application source or build-script changes were planned for this migration. If execution stays machine-level only, no git commit is required.
+```
+
+Expected: the final summary explicitly states whether no commit was needed
+
+---
+
+## Self-review checklist
+
+- Spec coverage: the plan covers persistent `GRADLE_USER_HOME`, immediate-shell activation, daemon shutdown, limited cleanup of `caches` and `wrapper/dists`, rebuild verification, and Android Studio restart follow-up.
+- Placeholder scan: no `TODO`, `TBD`, or vague “handle later” wording remains.
+- Type consistency: every path, command, and expected output uses the same target `D:\Java_Home` and the same old cache paths under `C:\Users\Febriyadi\.gradle`.

--- a/docs/superpowers/specs/2026-06-04-inf-147-closure-audit-design.md
+++ b/docs/superpowers/specs/2026-06-04-inf-147-closure-audit-design.md
@@ -1,0 +1,281 @@
+# INF-147 Closure Audit Design
+
+## Context
+
+Linear `INF-147` asks Android to consume the backend refresh-token contract defined by `INF-145` so mobile session continuity stays truthful to backend session state. The Android repository has already absorbed two major waves of work:
+
+- PR #21 (`fix/inf-147-login-refresh-token-compat`) aligned Android with the backend refresh-session contract.
+- PR #22 (`fix/auth-bootstrap-session-contract`) tightened startup/bootstrap behavior, logout side effects, and notification-permission timing during invalid-session flows.
+
+The remaining problem is no longer “implement silent refresh from scratch.” The remaining problem is deciding whether `INF-147` is actually ready to close. The current Linear issue still sits in `Backlog`, while the repo and runtime evidence show substantial implementation progress. That creates a governance gap:
+
+- code reality may already satisfy most of the issue,
+- but the issue cannot be closed honestly unless each verification claim is mapped to current evidence.
+
+This design therefore treats the next work as a focused closure audit, not as a feature implementation task.
+
+## Goals
+
+- Build an explicit acceptance matrix for `INF-147` using the issue’s own verification bullets.
+- Define which evidence sources are strong enough to mark a criterion as proven.
+- Reconcile repo state, merged PRs, docs, and runtime observations into one current closure view.
+- Run only the minimum additional verification needed to decide whether `INF-147` is close-ready.
+- Produce a closure outcome that is honest, auditable, and easy to paste back into Linear.
+
+## Non-Goals
+
+- Re-implement Android auth continuity from scratch.
+- Audit unrelated auth-adjacent issues outside the scope of `INF-147`.
+- Re-run the entire Android test suite as a substitute for runtime evidence.
+- Close backend issue `INF-145` again or redefine its contract.
+- Expand into unrelated Android concerns such as face bootstrap semantics, maps, or attendance flow unless they block interpreting a specific `INF-147` criterion.
+
+## Recommended Approach
+
+Treat `INF-147` closure as a four-step audit:
+
+1. Build an acceptance matrix from the issue’s verification section.
+2. Reconcile all existing evidence against the current `develop` branch.
+3. Verify only the remaining gaps that affect the close/no-close decision.
+4. Produce a closure draft for Linear with one of three outcomes:
+   - `close-ready`
+   - `not-close-ready`
+   - `needs-split-follow-up`
+
+This keeps the work focused on the real question: whether the issue can be closed truthfully today.
+
+## Work Structure
+
+### Step 1 — Build the Acceptance Matrix
+
+Use the `INF-147` verification bullets as the source of truth. Each criterion should be represented in a matrix with these fields:
+
+- `Acceptance criterion`
+- `Expected behavior`
+- `Current evidence`
+- `Evidence source`
+- `Status`
+- `Next action`
+
+The matrix is the central artifact. All later decisions must point back to it rather than to conversational memory.
+
+### Step 2 — Reconcile Existing Evidence
+
+Evidence should be collected from these sources:
+
+1. Linear issue `INF-147`
+2. Backend contract issue `INF-145`
+3. Merged PR/commit history (`PR #21`, `PR #22`)
+4. Repo docs and ADR notes
+5. Current runtime observations captured from the app
+
+This step exists to answer two questions:
+
+- What was claimed historically?
+- What is still true on current `develop`?
+
+Evidence that was valid on an old branch but not yet checked against current `develop` should not be treated as automatically current.
+
+### Step 3 — Verify the Remaining Gaps
+
+Do not re-test everything. Only verify criteria that remain `Partially Proven` or `Not Proven` after reconciliation.
+
+Gap verification should be constrained to the closure decision. If a scenario is outside the issue’s core contract, note it as context but do not let it expand the audit into a new engineering project.
+
+### Step 4 — Produce the Closure Outcome
+
+The audit should end with a Linear-ready summary that says one of:
+
+- `close-ready` — all issue-critical criteria are proven.
+- `not-close-ready` — one or more issue-critical criteria remain unproven.
+- `needs-split-follow-up` — the issue’s core goal is proven, but the remaining concern belongs in a separate follow-up issue.
+
+## Acceptance Matrix Model
+
+Each verification point from `INF-147` should be evaluated with one of three statuses.
+
+### Proven
+
+Use `Proven` when:
+
+- the expected behavior has been observed directly in runtime, or
+- an existing evidence artifact is specific, current, and still aligned with the current `develop` implementation.
+
+Examples of candidate `Proven` items in the current state may include:
+
+- startup invalid-session flow landing on login,
+- single terminal logout side effect during startup failure,
+- notification prompt not overlapping the invalid-session bootstrap path.
+
+### Partially Proven
+
+Use `Partially Proven` when:
+
+- code, tests, and prior docs strongly support the expected behavior,
+- but the issue’s stated verification expects a more direct or current runtime proof than is presently available.
+
+This status is important because it prevents over-claiming while still recognizing strong implementation evidence.
+
+### Not Proven
+
+Use `Not Proven` when:
+
+- no sufficiently specific evidence exists,
+- the scenario has not been reproduced directly enough,
+- or the current environment cannot truthfully demonstrate the behavior.
+
+This is likely to apply to backend-stateful scenarios such as a true `48-hour inactivity` outcome unless a controlled environment can reproduce it.
+
+## Evidence Rules
+
+Not all evidence sources have equal weight.
+
+### Strongest evidence
+
+1. Current runtime observation on the app
+2. Current repo artifacts that explicitly capture runtime behavior
+
+These are the preferred basis for marking a criterion `Proven`.
+
+### Supporting but insufficient alone
+
+1. Linear comments
+2. Code structure
+3. Merged commit history
+4. Unit/integration tests described in docs
+
+These can justify `Partially Proven`, but they should not by themselves close a runtime-focused verification bullet.
+
+### Evidence principles
+
+- A historical comment is not enough if it has not been reconciled with current `develop`.
+- Code presence is not proof of runtime behavior.
+- Runtime observations should be preferred over inferred correctness.
+- If a criterion cannot be demonstrated truthfully in the current environment, keep it unproven and explain why.
+
+## Target Verification Scope
+
+The audit should focus on the exact verification bullets in `INF-147`:
+
+1. `login -> access token expired -> refresh succeeds`
+2. `app resume / foreground transition with expired access token`
+3. `refresh fails because token is invalid or revoked`
+4. `refresh fails because inactivity > 48 hours -> full login required`
+5. `offline/server-down during refresh does not trigger misleading auth cleanup`
+
+The expected initial classification before fresh auditing is:
+
+### Likely Proven or near-Proven
+
+- terminal invalid-session startup behavior leading back to login
+- startup logout side-effect control
+- notification-permission timing during invalid-session startup
+
+These do not map one-to-one to every original `INF-147` bullet, but they matter because PR #22 tightened Android startup auth continuity in ways directly related to truthful session handling.
+
+### Likely Partially Proven
+
+- app resume / foreground continuity with expired access token
+- offline/server-down semantics during refresh
+
+These appear strongly supported by the code and docs, but may still need current runtime-specific evidence for closure confidence.
+
+### Likely Not Proven
+
+- refresh success after an actually expired access token in a controlled runtime scenario
+- true `48-hour inactivity` denial path
+- explicit revoked-refresh-token path under the current backend environment
+
+These should not be assumed complete without more direct proof.
+
+## Gap Verification Rules
+
+Gap verification should stay tightly bounded.
+
+Allowed work:
+
+- reconcile stale evidence against current `develop`
+- run targeted runtime checks for specific unproven criteria
+- inspect current docs and merged commits to support status decisions
+
+Disallowed work unless a criterion clearly requires it:
+
+- broad new refactors
+- unrelated UX polish
+- unrelated auth cleanup not needed for the close/no-close decision
+- turning the closure audit into a general Android auth review
+
+If a new implementation defect is discovered that directly invalidates a criterion, record it explicitly and treat the issue as `not-close-ready`.
+
+## Final Output Design
+
+The closure audit should always produce three deliverables.
+
+### 1. Repo-side working note
+
+A written spec/note in the repository that records:
+
+- the acceptance matrix,
+- evidence mapping,
+- remaining gaps,
+- and the final closure recommendation.
+
+This ensures the decision is durable and reviewable outside chat history.
+
+### 2. Linear-ready draft comment
+
+Prepare one of two comment shapes:
+
+#### If close-ready
+
+- summarize what Android now implements,
+- cite the evidence for each criterion,
+- state that `INF-147` acceptance criteria are satisfied,
+- recommend moving the issue to done.
+
+#### If not close-ready
+
+- summarize what is already complete,
+- list what is proven,
+- list what remains unproven,
+- explain exactly why the issue should remain open,
+- suggest the next verification step or follow-up split.
+
+### 3. Explicit closure recommendation
+
+The audit must end with one of:
+
+- `Close INF-147`
+- `Do not close INF-147 yet`
+- `Close core scope but split follow-up issue`
+
+## Decision Rules
+
+### Close-ready
+
+Only if every issue-critical verification criterion is `Proven`, or if any remaining concern is clearly outside the intended scope of `INF-147` and does not weaken the issue’s core claim.
+
+### Not close-ready
+
+If any issue-critical verification bullet remains `Not Proven`, especially where the issue explicitly calls for runtime-semantic confidence rather than code-only confidence.
+
+### Needs split follow-up
+
+If the issue’s core silent-refresh contract is proven, but a remaining concern is better represented as a separate follow-up issue instead of holding the main issue open indefinitely.
+
+## Expected Likely Outcome
+
+Based on current evidence, the most likely final outcomes are:
+
+- `close-ready with minor caveats`, or
+- `not-close-ready because one or more backend-stateful verification scenarios remain unproven`, most likely the `48-hour inactivity` path.
+
+The audit should not prejudge this result. The acceptance matrix determines the answer.
+
+## Acceptance Criteria for This Closure Audit Design
+
+- The next work starts from a written acceptance matrix, not an informal checklist.
+- Evidence strength is defined explicitly before new verification starts.
+- Gap verification is limited to issue-critical closure questions.
+- The audit can end truthfully with either close or no-close.
+- The final output can be pasted into Linear with minimal rewriting.

--- a/docs/superpowers/specs/2026-06-14-gradle-cache-relocation-design.md
+++ b/docs/superpowers/specs/2026-06-14-gradle-cache-relocation-design.md
@@ -1,0 +1,145 @@
+# Gradle Cache Relocation Design
+
+## Context
+
+The Android repository currently relies on the default Windows Gradle user home because `GRADLE_USER_HOME` is not set in the active environment. As a result, Gradle wrapper distributions and dependency caches resolve under the default user-home path on `C:`.
+
+The user wants Gradle cache storage to move persistently to:
+
+```text
+D:\Java_Home
+```
+
+The goal is not just a one-time terminal override. The target behavior is persistent usage for both terminal-driven Gradle commands and Android Studio usage going forward. The user also wants the old cache location cleaned up, but only with the recommended, lower-risk scope rather than deleting the entire old Gradle home.
+
+## Goals
+
+- Persist Gradle user home at `D:\Java_Home` for future terminal and Android Studio usage.
+- Make Gradle wrapper distributions and dependency caches resolve from the new location.
+- Clean up the relevant legacy cache folders from the old default Gradle home.
+- Rebuild the Android project after relocation to verify the new cache location is active.
+- Keep cleanup scoped tightly enough to avoid unnecessary deletion of unrelated Gradle state.
+
+## Non-Goals
+
+- Reconfigure project-level Gradle build cache semantics.
+- Rewrite `settings.gradle.kts` or module build scripts just to force a new cache location.
+- Delete the entire old Gradle home directory.
+- Optimize or migrate unrelated Android Studio settings outside what is required for consistent Gradle home usage.
+
+## Recommended Approach
+
+Use a persistent Windows environment configuration for `GRADLE_USER_HOME` rather than a repo-local Gradle script change.
+
+This is the recommended path because the requirement is cross-entrypoint consistency:
+
+- terminal commands should use `D:\Java_Home`
+- Gradle wrapper should use `D:\Java_Home`
+- Android Studio should converge on the same Gradle home after environment refresh / IDE restart
+
+A repo-local Gradle script approach would not reliably guarantee the same behavior across terminal and IDE, and it would also couple a machine-specific path into repository configuration.
+
+## Design
+
+### 1. Persistent Gradle Home Configuration
+
+Set the Windows user environment variable:
+
+```text
+GRADLE_USER_HOME=D:\Java_Home
+```
+
+This makes the relocation machine-persistent without baking a developer-specific absolute path into the repository.
+
+The repository itself should remain unchanged unless later verification proves a repo-level override is still required.
+
+### 2. Legacy Cache Cleanup Scope
+
+After the new Gradle home is active, delete only the recommended legacy cache folders from the old location:
+
+```text
+C:\Users\Febriyadi\.gradle\caches
+C:\Users\Febriyadi\.gradle\wrapper\dists
+```
+
+Do not delete the entire old directory:
+
+```text
+C:\Users\Febriyadi\.gradle
+```
+
+This narrower cleanup reduces the chance of removing unrelated historical state that is not relevant to the current relocation objective.
+
+### 3. Rebuild Verification
+
+After configuration and cleanup, rebuild the Android project from the repository root.
+
+Primary verification should confirm:
+
+1. `GRADLE_USER_HOME` resolves to `D:\Java_Home` in the active shell.
+2. Gradle commands for this repository complete successfully.
+3. Gradle repopulates or reuses data under `D:\Java_Home` rather than the old cache folders.
+
+Recommended verification commands:
+
+```bash
+./gradlew clean
+./gradlew app:assembleDebug
+```
+
+If the first rebuild indicates additional confidence is needed, a broader project verification can also include:
+
+```bash
+./gradlew app:testDebugUnitTest
+```
+
+## Operational Notes
+
+- Existing terminals may need to be reopened before they inherit the new persistent environment variable.
+- Android Studio may need a restart before it consistently reads the updated environment.
+- If Android Studio still points to old Gradle state after restart, the issue should be treated as `Needs Verification` rather than silently assumed fixed.
+
+## Risk Assessment
+
+### Risk: wider machine impact
+
+Changing `GRADLE_USER_HOME` at the user-environment level can affect other Gradle projects run by the same Windows user.
+
+### Risk: premature cleanup
+
+If old cache folders are deleted before verifying the new path is active, fallback artifacts are lost and the next build may need to fully re-download dependencies.
+
+### Risk: IDE/environment drift
+
+Terminal and Android Studio may temporarily disagree until sessions are restarted.
+
+## Verification Outcome Rules
+
+### Done
+
+The task can be treated as done only when:
+
+- the persistent environment variable is set,
+- the old recommended cache folders are removed,
+- the Android project rebuild succeeds,
+- and the active build behavior points at `D:\Java_Home`.
+
+### Needs Verification
+
+Use `Needs Verification` when:
+
+- Android Studio has not yet been restarted,
+- the shell has not been refreshed,
+- or the build succeeds but IDE-side inheritance of the new Gradle home is not yet confirmed.
+
+## Docs / ADR Note
+
+This change affects local developer environment behavior, not application runtime architecture, auth/session behavior, attendance semantics, navigation shell, or release policy. A focused spec is sufficient; no ADR is required.
+
+## PR / Release Notes
+
+If implementation proceeds, the change should be described as local build-environment maintenance:
+
+- persist Gradle cache home to `D:\Java_Home`
+- remove legacy Gradle cache folders from the default `C:` path
+- rebuild project to verify the new cache location is in effect


### PR DESCRIPTION
## Summary
- add the approved `docs/superpowers/plans/*` implementation plans as tracked repo artifacts
- add the approved `docs/superpowers/specs/*` design specs as tracked repo artifacts
- keep runtime evidence, local tooling config, archive PDF, and delete-later files out of this PR

## Scope guard
This PR intentionally excludes:
- `docs/runtime-*`
- `docs/runtime-logcat.txt`
- `.mcp.json`
- `app/src/test/java/com/example/infinite_track/di/NetworkModuleTest.kt`
- `docs/tmp-arrow_down-copy.xml`
- `infinite-track-android-review-recap.pdf`

## Verification
- docs-only scope review via isolated worktree
- `git ls-files --others --exclude-standard` in the worktree showed only the five approved docs before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation plans and design specifications for Android shell navigation contract, closure audit process, and Gradle build cache relocation.
  * New planning documents establish step-by-step workflows, verification procedures, and acceptance criteria for upcoming infrastructure and platform improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->