### PR TITLE
docs(context): normalize android agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS — Android (skrisi/android)
+
+> Draft Fase 1. Tujuan placement: root repo Android sebagai `AGENTS.md`.
+> Merujuk ke NORTH_STAR_ROADMAP.md. CLAUDE.md repo tetap berlaku untuk governance + runtime gate.
+> Human-curated. Agent mengisi detail, tidak mengubah arah.
+
+## Role repo
+Android = trusted data-capture client (Kotlin/Jetpack Compose). Login/session, attendance check-in/out, work mode, geofence, face verification, WFA booking, persistence lokal, Firebase distribution. BUKAN sumber kebenaran akhir; backend yang memutuskan.
+
+## STYLE
+- Clean Architecture: presentation -> domain -> data, DI via Hilt.
+- Stack: Compose + Material 3, Retrofit/OkHttp, Room/DataStore, WorkManager, Mapbox, CameraX + ML Kit + TFLite, FCM.
+- Jangan ekspos/print secret (local.properties, google-services.json, keystore, Mapbox token).
+
+## GOTCHAS
+- Base URL backend dipilih hardcoded di NetworkModule.kt: emulator 10.0.2.2:3005, device fisik LAN IP hardcoded (mis. 192.168.1.64:3005). Rawan gagal jika environment network berubah.
+- Auth refresh memakai single-flight + interceptor; session expiry global di SessionManager (trigger 401). Ini consumer dari kontrak backend INF-145.
+- Runtime-sensitive (auth/attendance/geofence/face/navigation): compile saja TIDAK cukup; perlu emulator/device + Maestro bila flow butuh konfirmasi runtime.
+- memory-bank/ lama = stale, bukan status progress otoritatif.
+
+## ARCH_DECISIONS
+- Backend final truth; Android capture intent + sinyal device.
+- Release/distribution: Firebase App Distribution HANYA dari master. develop = integrasi + verifikasi manusia.
+- Promotion: feature/* atau worktree → review/PR → develop → master → Firebase.
+
+## TEST_STRATEGY
+- Compile: `./gradlew app:compileDebugKotlin`. Build: `app:assembleDebug` / `app:assembleRelease`.
+- Test/lint: `./gradlew app:test`, `app:testDebugUnitTest`, `app:lint`.
+- Device: `adb devices -l`, `app:connectedDebugAndroidTest`, Maestro flow saat alur user butuh konfirmasi.
+- Jika runtime tak bisa dijalankan → tandai Needs Verification, bukan Done.
+
+## SENSITIVE (gate sebelum edit)
+presentation/screen/auth + splash, domain/manager/SessionManager.kt, data/repository/auth + attendance, presentation/geofencing, data/worker/LocationEventWorker.kt, data/face, presentation/navigation + main, di/NetworkModule.kt, app/build.gradle.kts + gradle/libs.versions.toml + local.properties + google-services.json, .github/workflows/.
+
+## DEPENDENCY RULE
+Android adalah konsumen, dan untuk auth/session masih Backlog (INF-147). Jangan buka task Android yang bergantung kontrak backend sebelum kontrak itu terkunci. Android default STANDBY kecuali demo path bergeser ke mobile-first.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,23 @@
+# PROJECT_STATUS — Android (skrisi/android)
+
+> File DINAMIS. Baca di awal task, update di akhir. Bukan tempat aturan permanen (CLAUDE.md).
+
+## Snapshot
+- Branch aktif: develop
+- Baseline: UNBLOCK IN PROGRESS (2026-06-15). .gitignore fixed (untracked 23.129 -> ~17). 2 commit aman: abd2483 (gitignore di develop), 8b2de7d (rescue snapshot di wip/android-baseline-2026-06-15).
+- BELUM selesai (host): develop working tree masih kotor (churn 401/424); finish via host: del lock -> git checkout -f develop -> git reset --hard abd2483 -> del "tash apply stash@{2}".
+- google-services.json: TRACKED (keputusan sadar user; jangan untrack).
+- .mcp.json: Maestro (runtime UI test) sudah ada.
+
+## Sedang berjalan
+- INF-147 silent refresh: SUDAH merged (PR #10) — ini VERIFICATION/closure card (runtime evidence), bukan implement ulang.
+
+## Risiko / blocker aktif
+- Develop belum bersih sampai reset di host selesai.
+- Runtime gate wajib (emulator/Maestro) untuk auth/attendance — compile-only tidak cukup.
+
+## Next safe action
+- Selesaikan reset develop di host -> verifikasi bersih -> turun ke siap-worktree.
+
+## Catatan
+- Konsumen kontrak backend. Base URL hardcoded di NetworkModule = titik verifikasi awal.


### PR DESCRIPTION
## Summary
- add Android AGENTS.md and PROJECT_STATUS.md
- preserve existing CLAUDE.md because shared-context and isolated-worktree execution guidance already existed in substance
- leave Android .mcp.json untouched

## Test Plan
- [x] Verified diff is context-only
- [x] Verified no feature/source-code files changed
- [ ] Repo test suite not rerun (docs/context-only normalization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural governance and engineering standards documentation for the Android project
  * Added project status tracking documentation with current snapshot and verification details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->