### PR TITLE
fix(android): bridge approved WFA booking into attendance check-in

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
@@ -13,7 +13,10 @@ fun BookingItem.toDomain(): BookingHistoryItem {
 		scheduleDate = formatScheduleDateId(this.scheduleDate),
 		status = formatStatusTitle(this.status),
 		notes = this.notes ?: "",
-		suitabilityLabel = this.suitabilityLabel ?: mapSuitabilityLabelId(this.suitabilityScore)
+		suitabilityLabel = this.suitabilityLabel ?: mapSuitabilityLabelId(this.suitabilityScore),
+		bookingId = this.bookingId,
+		scheduleDateRaw = this.scheduleDate,
+		statusRaw = this.status
 	)
 }
 

--- a/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
@@ -24,6 +24,7 @@ import com.example.infinite_track.domain.use_case.auth.LoginUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.VerifyFaceUseCase
 import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.contact.GetContactsUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
@@ -180,6 +181,14 @@ object UseCaseModule {
         bookingRepository: BookingRepository
     ): SubmitWfaBookingUseCase {
         return SubmitWfaBookingUseCase(bookingRepository)
+    }
+
+    // Provide the approved WFA booking resolver use case
+    @Provides
+    fun provideResolveTodayApprovedWfaBookingUseCase(
+        bookingRepository: BookingRepository
+    ): ResolveTodayApprovedWfaBookingUseCase {
+        return ResolveTodayApprovedWfaBookingUseCase(bookingRepository)
     }
 
     // Provide the Check In Use Case

--- a/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
@@ -6,5 +6,8 @@ data class BookingHistoryItem(
     val scheduleDate: String,
     val status: String,
     val notes: String,
-    val suitabilityLabel: String
+    val suitabilityLabel: String,
+    val bookingId: Int? = null,
+    val scheduleDateRaw: String? = null,
+    val statusRaw: String? = null
 )

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCase.kt
@@ -1,0 +1,44 @@
+package com.example.infinite_track.domain.use_case.booking
+
+import com.example.infinite_track.domain.repository.BookingRepository
+import javax.inject.Inject
+
+class ResolveTodayApprovedWfaBookingUseCase @Inject constructor(
+    private val bookingRepository: BookingRepository
+) {
+    suspend operator fun invoke(scheduleDate: String): Result<Int?> {
+        var page = 1
+
+        while (true) {
+            val bookingPageResult = bookingRepository.getBookingHistory(
+                status = "approved",
+                page = page,
+                limit = 20,
+                sortBy = "schedule_date",
+                sortOrder = "DESC"
+            )
+
+            if (bookingPageResult.isFailure) {
+                return Result.failure(
+                    bookingPageResult.exceptionOrNull()
+                        ?: Exception("Gagal memuat booking WFA yang telah di-approve.")
+                )
+            }
+
+            val bookingPage = bookingPageResult.getOrThrow()
+            val matchedBookingId = bookingPage.bookings.firstOrNull { booking ->
+                booking.scheduleDateRaw == scheduleDate && booking.statusRaw.equals("approved", ignoreCase = true)
+            }?.bookingId
+
+            if (matchedBookingId != null) {
+                return Result.success(matchedBookingId)
+            }
+
+            if (!bookingPage.hasNextPage) {
+                return Result.success(null)
+            }
+
+            page++
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -13,6 +13,7 @@ import com.example.infinite_track.domain.use_case.attendance.CheckInUseCase
 import com.example.infinite_track.domain.use_case.attendance.CheckOutUseCase
 import com.example.infinite_track.domain.use_case.attendance.GetTodayStatusUseCase
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentAddressUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentCoordinatesUseCase
 import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
@@ -74,6 +75,7 @@ class AttendanceViewModel @Inject constructor(
     private val attendancePreference: AttendancePreference,
     private val geofenceManager: GeofenceManager,
     private val getLoggedInUserUseCase: GetLoggedInUserUseCase,
+    private val resolveTodayApprovedWfaBookingUseCase: ResolveTodayApprovedWfaBookingUseCase,
     // Add UseCase dependencies for attendance operations
     private val checkInUseCase: CheckInUseCase,
     private val checkOutUseCase: CheckOutUseCase
@@ -762,13 +764,46 @@ class AttendanceViewModel @Inject constructor(
                         else -> 1 // Default to WFO
                     }
 
+                    val bookingId = if (categoryId == 3) {
+                        val scheduleDate = _uiState.value.todayStatus?.todayDate
+                        if (scheduleDate.isNullOrBlank()) {
+                            _uiState.value = _uiState.value.copy(
+                                activeDialog = DialogState.Error("Tanggal aktif attendance belum tersedia untuk WFA check-in.")
+                            )
+                            return@collect
+                        }
+
+                        val resolvedBookingId = resolveTodayApprovedWfaBookingUseCase(scheduleDate)
+                            .getOrElse { exception ->
+                                _uiState.value = _uiState.value.copy(
+                                    activeDialog = DialogState.Error(
+                                        exception.message ?: "Gagal memuat booking WFA yang telah di-approve."
+                                    )
+                                )
+                                return@collect
+                            }
+
+                        if (resolvedBookingId == null) {
+                            _uiState.value = _uiState.value.copy(
+                                activeDialog = DialogState.Error(
+                                    "Booking WFA yang di-approve untuk hari ini tidak ditemukan. Silakan pastikan booking Anda sudah di-approve sebelum check-in."
+                                )
+                            )
+                            return@collect
+                        }
+
+                        resolvedBookingId
+                    } else {
+                        null
+                    }
+
                     // Create attendance request model with proper parameters
                     val attendanceRequest = AttendanceRequestModel(
                         categoryId = categoryId, // Use correct category ID based on work mode
                         latitude = 0.0, // Will be updated by UseCase with real-time GPS
                         longitude = 0.0, // Will be updated by UseCase with real-time GPS
                         notes = "Check-in via mobile app",
-                        bookingId = null, // No booking for regular check-in
+                        bookingId = bookingId,
                         type = "checkin"
                     )
 

--- a/app/src/test/java/com/example/infinite_track/data/mapper/booking/BookingMapperContractBridgeTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/mapper/booking/BookingMapperContractBridgeTest.kt
@@ -1,0 +1,67 @@
+package com.example.infinite_track.data.mapper.booking
+
+import com.example.infinite_track.data.soucre.network.response.booking.BookingItem
+import com.example.infinite_track.data.soucre.network.response.booking.BookingLocation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.fail
+import org.junit.Test
+
+class BookingMapperContractBridgeTest {
+
+    @Test
+    fun `toDomain preserves raw booking identity fields for downstream attendance bridge`() {
+        val dto = BookingItem(
+            bookingId = 321,
+            userId = 10,
+            userFullName = "Test User",
+            userEmail = null,
+            userNipNim = null,
+            userPositionName = null,
+            userRoleName = null,
+            scheduleDate = "2026-06-21",
+            status = "approved",
+            location = BookingLocation(
+                locationId = 99,
+                latitude = -0.9,
+                longitude = 119.9,
+                radius = 100f,
+                description = "Cafe Palu"
+            ),
+            notes = "Focus work",
+            suitabilityScore = 90f,
+            suitabilityLabel = "Sangat Sesuai",
+            createdAt = "2026-06-20T10:00:00Z",
+            processedAt = "2026-06-20T11:00:00Z",
+            approvedBy = 5
+        )
+
+        val domain = dto.toDomain()
+        val domainClass = domain::class.java
+
+        val bookingIdField: java.lang.reflect.Field = runCatching { domainClass.getDeclaredField("bookingId") }
+            .getOrElse {
+                fail("BookingHistoryItem must preserve raw bookingId for WFA attendance bridge")
+                throw AssertionError("unreachable")
+            }
+        val scheduleDateRawField: java.lang.reflect.Field = runCatching { domainClass.getDeclaredField("scheduleDateRaw") }
+            .getOrElse {
+                fail("BookingHistoryItem must preserve raw scheduleDateRaw for WFA attendance bridge")
+                throw AssertionError("unreachable")
+            }
+        val statusRawField: java.lang.reflect.Field = runCatching { domainClass.getDeclaredField("statusRaw") }
+            .getOrElse {
+                fail("BookingHistoryItem must preserve raw statusRaw for WFA attendance bridge")
+                throw AssertionError("unreachable")
+            }
+
+        bookingIdField.setAccessible(true)
+        scheduleDateRawField.setAccessible(true)
+        statusRawField.setAccessible(true)
+
+        assertNotNull(bookingIdField.get(domain))
+        assertEquals(321, bookingIdField.get(domain))
+        assertEquals("2026-06-21", scheduleDateRawField.get(domain))
+        assertEquals("approved", statusRawField.get(domain))
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCaseTest.kt
@@ -1,0 +1,139 @@
+package com.example.infinite_track.domain.use_case.booking
+
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.model.booking.BookingHistoryPage
+import com.example.infinite_track.domain.repository.BookingRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResolveTodayApprovedWfaBookingUseCaseTest {
+
+    @Test
+    fun `returns approved booking id for the requested schedule date`() = runTest {
+        val repository = FakeBookingRepository(
+            listOf(
+                Result.success(
+                    BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(88, "2026-06-20", "approved"),
+                            bookingItem(99, "2026-06-21", "approved"),
+                            bookingItem(101, "2026-06-21", "pending")
+                        ),
+                        hasNextPage = false
+                    )
+                )
+            )
+        )
+
+        val useCase = ResolveTodayApprovedWfaBookingUseCase(repository)
+
+        val result = useCase("2026-06-21")
+
+        assertEquals(99, result.getOrNull())
+        assertEquals("approved", repository.lastRequestedStatus)
+    }
+
+    @Test
+    fun `returns approved booking id from a later page when the first page does not contain today's booking`() = runTest {
+        val repository = FakeBookingRepository(
+            listOf(
+                Result.success(
+                    BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(88, "2026-06-23", "approved")
+                        ),
+                        hasNextPage = true
+                    )
+                ),
+                Result.success(
+                    BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(144, "2026-06-21", "approved")
+                        ),
+                        hasNextPage = false
+                    )
+                )
+            )
+        )
+
+        val useCase = ResolveTodayApprovedWfaBookingUseCase(repository)
+
+        val result = useCase("2026-06-21")
+
+        assertEquals(144, result.getOrNull())
+        assertEquals(listOf(1, 2), repository.requestedPages)
+        assertEquals("approved", repository.lastRequestedStatus)
+    }
+
+    @Test
+    fun `returns null when no approved booking matches the requested schedule date`() = runTest {
+        val repository = FakeBookingRepository(
+            listOf(
+                Result.success(
+                    BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(88, "2026-06-20", "approved")
+                        ),
+                        hasNextPage = false
+                    )
+                )
+            )
+        )
+
+        val useCase = ResolveTodayApprovedWfaBookingUseCase(repository)
+
+        val result = useCase("2026-06-21")
+
+        assertNull(result.getOrNull())
+        assertEquals("approved", repository.lastRequestedStatus)
+    }
+
+    private fun bookingItem(bookingId: Int, scheduleDateRaw: String, statusRaw: String): BookingHistoryItem {
+        return BookingHistoryItem(
+            id = bookingId.toString(),
+            locationDescription = "Cafe Palu",
+            scheduleDate = "21 Jun 2026",
+            status = statusRaw.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+            notes = "Focus work",
+            suitabilityLabel = "Sangat Sesuai",
+            bookingId = bookingId,
+            scheduleDateRaw = scheduleDateRaw,
+            statusRaw = statusRaw
+        )
+    }
+
+    private class FakeBookingRepository(
+        private val results: List<Result<BookingHistoryPage>>
+    ) : BookingRepository {
+        var lastRequestedStatus: String? = null
+        val requestedPages = mutableListOf<Int>()
+        private var callCount = 0
+
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): Result<BookingHistoryPage> {
+            lastRequestedStatus = status
+            requestedPages += page
+            val index = callCount.coerceAtMost(results.lastIndex)
+            callCount++
+            return results[index]
+        }
+
+        override suspend fun submitBooking(
+            scheduleDate: String,
+            latitude: Double,
+            longitude: Double,
+            radius: Int,
+            description: String,
+            notes: String
+        ): Result<Unit> = Result.success(Unit)
+    }
+}


### PR DESCRIPTION
## Summary
- align Android WFA check-in payload with backend contract that requires `booking_id` for `category_id = 3`
- preserve raw approved booking identity from booking history mapping
- add a narrow resolver to find today's approved WFA booking across paginated booking history
- inject resolved `booking_id` into WFA attendance check-in before sending request
- add unit coverage for raw identity preservation and paginated approved-booking resolution

## Why
Backend remains the source of truth for WFA booking + attendance semantics.
Before this change, Android could enter WFA check-in flow while still building the attendance payload with `bookingId = null`, which is incompatible with backend validation.

## Scope
Android only.
No backend contract changes.
No full WFA booking flow redesign.

## Verification
### Verified in worktree
- `app:testDebugUnitTest` ✅
- `app:compileDebugKotlin` ✅

> Note: local verification in this environment used `JAVA_HOME=D:\Java_Home\java 1.8.2` because default Android Studio JBR 21 triggered a local KAPT toolchain issue in this repo.

### Needs Verification
- runtime/manual WFA check-in verification with an approved booking is still pending
- per plan, this runtime verification will be performed after merge/pull to `develop`

## Risk / Notes
- resolver now scans approved booking history across pages instead of assuming page 1 is sufficient
- if no approved booking exists for today, Android fails closed and shows a user-facing error instead of sending an ambiguous WFA check-in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced WFA check-in with validation against approved bookings for the selected date
  * System now resolves and applies the correct booking ID for WFA work mode check-ins
  * Check-in is blocked if no approved booking is found for the selected date

* **Tests**
  * Added comprehensive tests for WFA booking resolution and booking history data mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->