### PR TITLE
fix: wire approved WFA booking id into attendance check-in

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
@@ -13,7 +13,10 @@ fun BookingItem.toDomain(): BookingHistoryItem {
 		scheduleDate = formatScheduleDateId(this.scheduleDate),
 		status = formatStatusTitle(this.status),
 		notes = this.notes ?: "",
-		suitabilityLabel = this.suitabilityLabel ?: mapSuitabilityLabelId(this.suitabilityScore)
+		suitabilityLabel = this.suitabilityLabel ?: mapSuitabilityLabelId(this.suitabilityScore),
+		bookingId = this.bookingId,
+		scheduleDateRaw = this.scheduleDate,
+		statusRaw = this.status
 	)
 }
 

--- a/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
@@ -24,6 +24,7 @@ import com.example.infinite_track.domain.use_case.auth.LoginUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.VerifyFaceUseCase
 import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.contact.GetContactsUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
@@ -180,6 +181,13 @@ object UseCaseModule {
         bookingRepository: BookingRepository
     ): SubmitWfaBookingUseCase {
         return SubmitWfaBookingUseCase(bookingRepository)
+    }
+
+    @Provides
+    fun provideResolveTodayApprovedWfaBookingIdUseCase(
+        bookingRepository: BookingRepository
+    ): ResolveTodayApprovedWfaBookingIdUseCase {
+        return ResolveTodayApprovedWfaBookingIdUseCase(bookingRepository)
     }
 
     // Provide the Check In Use Case

--- a/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
@@ -6,5 +6,8 @@ data class BookingHistoryItem(
     val scheduleDate: String,
     val status: String,
     val notes: String,
-    val suitabilityLabel: String
+    val suitabilityLabel: String,
+    val bookingId: Int = 0,
+    val scheduleDateRaw: String = "",
+    val statusRaw: String = ""
 )

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingIdUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingIdUseCase.kt
@@ -1,0 +1,43 @@
+package com.example.infinite_track.domain.use_case.booking
+
+import com.example.infinite_track.domain.repository.BookingRepository
+import javax.inject.Inject
+
+class ResolveTodayApprovedWfaBookingIdUseCase @Inject constructor(
+    private val bookingRepository: BookingRepository
+) {
+    suspend operator fun invoke(scheduleDateIso: String): Result<Int> {
+        var page = 1
+
+        while (true) {
+            val bookingPageResult = bookingRepository.getBookingHistory(
+                status = "approved",
+                page = page,
+                limit = 50
+            )
+
+            val bookingPage = bookingPageResult.getOrElse { error ->
+                return Result.failure(error)
+            }
+
+            val approvedBooking = bookingPage.bookings.firstOrNull { booking ->
+                booking.statusRaw.equals("approved", ignoreCase = true) &&
+                    booking.scheduleDateRaw == scheduleDateIso
+            }
+
+            if (approvedBooking != null) {
+                return Result.success(approvedBooking.bookingId)
+            }
+
+            if (!bookingPage.hasNextPage) {
+                break
+            }
+
+            page += 1
+        }
+
+        return Result.failure(
+            IllegalStateException("Approved WFA booking for $scheduleDateIso was not found.")
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactory.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactory.kt
@@ -1,0 +1,30 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+import com.example.infinite_track.domain.model.attendance.AttendanceRequestModel
+
+object AttendanceCheckInRequestFactory {
+    fun create(
+        selectedWorkMode: String,
+        bookingId: Int?
+    ): AttendanceRequestModel {
+        val categoryId = when (selectedWorkMode) {
+            "Work From Office", "WFO" -> 1
+            "Work From Home", "WFH" -> 2
+            "WFA", "Work From Anywhere" -> 3
+            else -> 1
+        }
+
+        if (categoryId == 3 && bookingId == null) {
+            throw IllegalArgumentException("WFA check-in requires bookingId.")
+        }
+
+        return AttendanceRequestModel(
+            categoryId = categoryId,
+            latitude = 0.0,
+            longitude = 0.0,
+            notes = "Check-in via mobile app",
+            bookingId = bookingId,
+            type = "checkin"
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -13,6 +13,7 @@ import com.example.infinite_track.domain.use_case.attendance.CheckInUseCase
 import com.example.infinite_track.domain.use_case.attendance.CheckOutUseCase
 import com.example.infinite_track.domain.use_case.attendance.GetTodayStatusUseCase
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentAddressUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentCoordinatesUseCase
 import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
@@ -74,6 +75,7 @@ class AttendanceViewModel @Inject constructor(
     private val attendancePreference: AttendancePreference,
     private val geofenceManager: GeofenceManager,
     private val getLoggedInUserUseCase: GetLoggedInUserUseCase,
+    private val resolveTodayApprovedWfaBookingIdUseCase: ResolveTodayApprovedWfaBookingIdUseCase,
     // Add UseCase dependencies for attendance operations
     private val checkInUseCase: CheckInUseCase,
     private val checkOutUseCase: CheckOutUseCase
@@ -762,15 +764,44 @@ class AttendanceViewModel @Inject constructor(
                         else -> 1 // Default to WFO
                     }
 
-                    // Create attendance request model with proper parameters
-                    val attendanceRequest = AttendanceRequestModel(
-                        categoryId = categoryId, // Use correct category ID based on work mode
-                        latitude = 0.0, // Will be updated by UseCase with real-time GPS
-                        longitude = 0.0, // Will be updated by UseCase with real-time GPS
-                        notes = "Check-in via mobile app",
-                        bookingId = null, // No booking for regular check-in
-                        type = "checkin"
-                    )
+                    val bookingId = if (categoryId == 3) {
+                        val scheduleDateIso = _uiState.value.todayStatus?.todayDate
+                        if (scheduleDateIso.isNullOrBlank()) {
+                            _uiState.value = _uiState.value.copy(
+                                activeDialog = DialogState.Error(
+                                    "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
+                                )
+                            )
+                            return@collect
+                        }
+
+                        resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
+                            .getOrElse { exception ->
+                                _uiState.value = _uiState.value.copy(
+                                    activeDialog = DialogState.Error(
+                                        exception.message
+                                            ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
+                                    )
+                                )
+                                return@collect
+                            }
+                    } else {
+                        null
+                    }
+
+                    val attendanceRequest = try {
+                        AttendanceCheckInRequestFactory.create(
+                            selectedWorkMode = _uiState.value.selectedWorkMode,
+                            bookingId = bookingId
+                        )
+                    } catch (exception: IllegalArgumentException) {
+                        _uiState.value = _uiState.value.copy(
+                            activeDialog = DialogState.Error(
+                                exception.message ?: "Payload check-in WFA tidak valid."
+                            )
+                        )
+                        return@collect
+                    }
 
                     // Call CheckInUseCase with both request and target location
                     checkInUseCase(attendanceRequest, targetLocation).onSuccess { activeSession ->

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingIdUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingIdUseCaseTest.kt
@@ -1,0 +1,132 @@
+package com.example.infinite_track.domain.use_case.booking
+
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.model.booking.BookingHistoryPage
+import com.example.infinite_track.domain.repository.BookingRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResolveTodayApprovedWfaBookingIdUseCaseTest {
+
+    @Test
+    fun invoke_returnsApprovedBookingIdForRequestedDateEvenWhenItAppearsOnLaterPage() {
+        runBlocking {
+            val repository = FakeBookingRepository(
+                pages = mapOf(
+                    1 to BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(
+                                bookingId = 100,
+                                scheduleDateRaw = "2026-06-20",
+                                statusRaw = "approved"
+                            )
+                        ),
+                        hasNextPage = true
+                    ),
+                    2 to BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(
+                                bookingId = 321,
+                                scheduleDateRaw = "2026-06-22",
+                                statusRaw = "approved"
+                            )
+                        ),
+                        hasNextPage = false
+                    )
+                )
+            )
+
+            val useCase = ResolveTodayApprovedWfaBookingIdUseCase(repository)
+
+            val result = useCase("2026-06-22")
+
+            assertEquals(321, result.getOrThrow())
+            assertEquals(listOf(1, 2), repository.requestedPages)
+        }
+    }
+
+    @Test
+    fun invoke_failsWhenApprovedBookingForDateDoesNotExist() {
+        runBlocking {
+            val repository = FakeBookingRepository(
+                pages = mapOf(
+                    1 to BookingHistoryPage(
+                        bookings = listOf(
+                            bookingItem(
+                                bookingId = 200,
+                                scheduleDateRaw = "2026-06-21",
+                                statusRaw = "approved"
+                            ),
+                            bookingItem(
+                                bookingId = 201,
+                                scheduleDateRaw = "2026-06-22",
+                                statusRaw = "pending"
+                            )
+                        ),
+                        hasNextPage = false
+                    )
+                )
+            )
+
+            val useCase = ResolveTodayApprovedWfaBookingIdUseCase(repository)
+
+            val result = useCase("2026-06-22")
+
+            kotlin.runCatching { result.getOrThrow() }
+                .onSuccess { throw AssertionError("Expected missing approved booking to fail") }
+                .onFailure { error: Throwable ->
+                    assertEquals(
+                        "Approved WFA booking for 2026-06-22 was not found.",
+                        error.message
+                    )
+                }
+        }
+    }
+
+    private fun bookingItem(
+        bookingId: Int,
+        scheduleDateRaw: String,
+        statusRaw: String
+    ) = BookingHistoryItem(
+        id = bookingId.toString(),
+        bookingId = bookingId,
+        locationDescription = "Test location",
+        scheduleDate = scheduleDateRaw,
+        scheduleDateRaw = scheduleDateRaw,
+        status = statusRaw.replaceFirstChar { it.uppercase() },
+        statusRaw = statusRaw,
+        notes = "",
+        suitabilityLabel = ""
+    )
+
+    private class FakeBookingRepository(
+        private val pages: Map<Int, BookingHistoryPage>
+    ) : BookingRepository {
+        val requestedPages = mutableListOf<Int>()
+
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): Result<BookingHistoryPage> {
+            requestedPages += page
+            return Result.success(
+                pages[page] ?: BookingHistoryPage(emptyList(), hasNextPage = false)
+            )
+        }
+
+        override suspend fun submitBooking(
+            scheduleDate: String,
+            latitude: Double,
+            longitude: Double,
+            radius: Int,
+            description: String,
+            notes: String
+        ): Result<Unit> {
+            throw UnsupportedOperationException("Not needed in this test")
+        }
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactoryTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactoryTest.kt
@@ -1,0 +1,28 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AttendanceCheckInRequestFactoryTest {
+
+    @Test
+    fun create_preservesBookingIdForWfaRequests() {
+        val request = AttendanceCheckInRequestFactory.create(
+            selectedWorkMode = "WFA",
+            bookingId = 456
+        )
+
+        assertEquals(3, request.categoryId)
+        assertEquals(456, request.bookingId)
+        assertEquals("checkin", request.type)
+        assertEquals("Check-in via mobile app", request.notes)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun create_rejectsWfaRequestWithoutBookingId() {
+        AttendanceCheckInRequestFactory.create(
+            selectedWorkMode = "Work From Anywhere",
+            bookingId = null
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- resolve an approved WFA `booking_id` at check-in time instead of sending an ambiguous `null`
- preserve booking metadata needed to locate the correct approved booking for today's attendance
- guard WFA request construction so Android cannot build a WFA check-in payload without `booking_id`

## Why
Backend contract for `POST /api/attendance/check-in` requires `booking_id` when `category_id === 3` (WFA) and uses it for ownership, approval, same-day, and location validation. Android previously declared that contract in the DTO but still built WFA check-in with `bookingId = null`.

## Verification
Using JDK 17 (`C:\Users\Febriyadi\.jdks\jbr-17.0.14`) in this worktree:
- `./gradlew app:compileDebugKotlin -Dkotlin.compiler.execution.strategy=in-process`
- `./gradlew app:testDebugUnitTest -Dkotlin.compiler.execution.strategy=in-process`
- `./gradlew app:lint -Dkotlin.compiler.execution.strategy=in-process`

All passed.

## Needs Verification
- Please review runtime behavior on `develop` after merge/pull, especially the real WFA flow:
  - approved WFA booking exists for today
  - Android resolves the booking and sends `booking_id` during check-in
  - backend accepts the request and records attendance successfully

## Scope Guard
- Android-only change
- no Web FE work
- no backend truth changes
- no redesign of the full WFA booking flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced attendance check-in to automatically resolve and validate approved Work From Anywhere bookings for the current date during check-in submission.

* **Tests**
  * Added comprehensive test coverage for WFA booking resolution logic and check-in request factory validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->