### PR TITLE
fix: align Android foreground session validation with backend contract

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,6 +157,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
     
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt
+++ b/app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt
@@ -1,11 +1,13 @@
 package com.example.infinite_track
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.Configuration
+import com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserver
 import com.example.infinite_track.utils.NotificationHelper
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
-import androidx.hilt.work.HiltWorkerFactory
-import androidx.work.Configuration
 
 @HiltAndroidApp
 class InfiniteTrackApplication : Application(), Configuration.Provider {
@@ -13,11 +15,15 @@ class InfiniteTrackApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject
+    lateinit var foregroundSessionLifecycleObserver: ForegroundSessionLifecycleObserver
+
     override fun onCreate() {
         super.onCreate()
 
         // Initialize notification channel for Geofencing
         NotificationHelper.createNotificationChannel(this)
+        ProcessLifecycleOwner.get().lifecycle.addObserver(foregroundSessionLifecycleObserver)
     }
 
     override val workManagerConfiguration: Configuration

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -59,7 +59,8 @@ class AuthRepositoryImpl @Inject constructor(
                 RefreshRequest(refreshToken = existingRefreshToken)
             ).data
 
-            if (refreshData.token.isBlank() || refreshData.id <= 0) {
+            val accessToken = refreshData.resolvedAccessToken().takeIf { it.isNotBlank() }
+            if (accessToken == null || refreshData.id <= 0) {
                 val error = IllegalStateException("Invalid refresh session payload")
                 safeLogError("Refresh session returned invalid payload", error)
                 return Result.failure(
@@ -73,17 +74,17 @@ class AuthRepositoryImpl @Inject constructor(
             }
 
             val refreshedUserId = refreshData.id.toString()
-            val refreshTokenToStore = refreshData.refreshToken?.takeIf { it.isNotBlank() } ?: existingRefreshToken
+            val refreshTokenToStore = refreshData.resolvedRefreshToken() ?: existingRefreshToken
 
             userPreference.saveSession(
-                token = refreshData.token,
+                token = accessToken,
                 userId = refreshedUserId,
                 refreshToken = refreshTokenToStore,
                 lastRefreshAt = System.currentTimeMillis()
             )
             Result.success(
                 AuthRefreshResult(
-                    token = refreshData.token,
+                    token = accessToken,
                     refreshToken = refreshTokenToStore,
                     userId = refreshedUserId
                 )
@@ -115,9 +116,9 @@ class AuthRepositoryImpl @Inject constructor(
         return try {
             val loginResponse = apiService.login(loginRequest)
             val loginData = loginResponse.data
-            val accessToken = loginData.token.takeIf { it.isNotBlank() }
+            val accessToken = loginData.resolvedAccessToken().takeIf { it.isNotBlank() }
                 ?: return Result.failure(IllegalStateException("Login response missing usable access token"))
-            val refreshToken = loginData.refreshToken?.takeIf { it.isNotBlank() }
+            val refreshToken = loginData.resolvedRefreshToken()
 
             userPreference.saveSession(
                 token = accessToken,

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.local.room.UserDao
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
 import com.example.infinite_track.data.soucre.network.request.LogoutRequest
-import com.example.infinite_track.data.soucre.network.request.RefreshRequest
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
 import com.example.infinite_track.data.soucre.network.response.ErrorResponse
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
@@ -55,12 +55,12 @@ class AuthRepositoryImpl @Inject constructor(
                 )
             }
 
-            val refreshData = apiService.refresh(
-                RefreshRequest(refreshToken = existingRefreshToken)
+            val refreshData = authSessionApiService.refreshSession(
+                RefreshSessionRequest(refreshToken = existingRefreshToken)
             ).data
+            val accessToken = refreshData.resolvedAccessToken()
 
-            val accessToken = refreshData.resolvedAccessToken().takeIf { it.isNotBlank() }
-            if (accessToken == null || refreshData.id <= 0) {
+            if (accessToken.isBlank() || refreshData.id <= 0) {
                 val error = IllegalStateException("Invalid refresh session payload")
                 safeLogError("Refresh session returned invalid payload", error)
                 return Result.failure(

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt
@@ -1,0 +1,8 @@
+package com.example.infinite_track.data.soucre.network.response
+
+import com.google.gson.annotations.SerializedName
+
+data class AuthPayload(
+    @SerializedName("access_token") val accessToken: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null
+)

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt
@@ -21,9 +21,20 @@ data class UserData(
     @SerializedName("photo") val photo: String,
     @SerializedName("photo_updated_at") val photoUpdatedAt: String,
     @SerializedName("location") val location: LocationData,
-    @SerializedName("token") val token: String,
-    @SerializedName("refresh_token") val refreshToken: String? = null
-)
+    @SerializedName("token") val token: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null,
+    @SerializedName("auth") val auth: AuthPayload? = null
+) {
+    fun resolvedAccessToken(): String {
+        return auth?.accessToken?.takeIf { it.isNotBlank() }
+            ?: token.orEmpty()
+    }
+
+    fun resolvedRefreshToken(): String? {
+        return auth?.refreshToken?.takeIf { it.isNotBlank() }
+            ?: refreshToken?.takeIf { it.isNotBlank() }
+    }
+}
 
 data class LocationData(
     @SerializedName("latitude") val latitude: Double,

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt
@@ -11,9 +11,20 @@ data class RefreshResponse(
 
 data class AuthData(
     @SerializedName("id") val id: Int,
-    @SerializedName("token") val token: String,
-    @SerializedName("refresh_token") val refreshToken: String? = null
-)
+    @SerializedName("token") val token: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null,
+    @SerializedName("auth") val auth: AuthPayload? = null
+) {
+    fun resolvedAccessToken(): String {
+        return auth?.accessToken?.takeIf { it.isNotBlank() }
+            ?: token.orEmpty()
+    }
+
+    fun resolvedRefreshToken(): String? {
+        return auth?.refreshToken?.takeIf { it.isNotBlank() }
+            ?: refreshToken?.takeIf { it.isNotBlank() }
+    }
+}
 
 data class RefreshErrorResponse(
     @SerializedName("success") val success: Boolean,

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
 
 @Singleton
 interface AuthSessionApiService {
-    @Headers("X-Client-Type: android")
+    @Headers("X-Client-Type: mobile")
     @POST("api/auth/refresh")
     suspend fun refreshSession(@Body request: RefreshSessionRequest): RefreshSessionResponse
 

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt
@@ -14,6 +14,7 @@ interface AuthSessionApiService {
     @POST("api/auth/refresh")
     suspend fun refreshSession(@Body request: RefreshSessionRequest): RefreshSessionResponse
 
+    @Headers("X-Client-Type: mobile")
     @POST("api/auth/logout")
     suspend fun logout(): LogoutResponse
 }

--- a/app/src/main/java/com/example/infinite_track/di/AppModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/AppModule.kt
@@ -13,6 +13,9 @@ import com.example.infinite_track.data.soucre.local.room.UserDao
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import dagger.Module
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,6 +25,13 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
+
+    @Singleton
+    @Provides
+    @ApplicationCoroutineScope
+    fun provideApplicationCoroutineScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    }
 
     // Core database providers
     @Singleton

--- a/app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt
+++ b/app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt
@@ -1,0 +1,7 @@
+package com.example.infinite_track.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationCoroutineScope

--- a/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
@@ -22,6 +22,7 @@ import com.example.infinite_track.domain.use_case.auth.GenerateAndSaveEmbeddingU
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
 import com.example.infinite_track.domain.use_case.auth.LoginUseCase
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
 import com.example.infinite_track.domain.use_case.auth.VerifyFaceUseCase
 import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
@@ -92,6 +93,15 @@ object UseCaseModule {
     @Provides
     fun provideLogoutUseCase(authRepository: AuthRepository): LogoutUseCase {
         return LogoutUseCase(authRepository)
+    }
+
+    @Provides
+    fun provideValidateForegroundSessionUseCase(
+        authRepository: AuthRepository,
+        userPreference: UserPreference,
+        sessionManager: SessionManager
+    ): ValidateForegroundSessionUseCase {
+        return ValidateForegroundSessionUseCase(authRepository, userPreference, sessionManager)
     }
 
     // Provide the Contacts Use Case

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
@@ -64,7 +64,6 @@ class ValidateForegroundSessionUseCase(
     ): ForegroundSessionValidationResult.ReauthRequired {
         existingForcedReauthResult()?.let { return it }
 
-        sessionManager.triggerForcedReauth(reason)
         return ForegroundSessionValidationResult.ReauthRequired(reason)
     }
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
@@ -20,6 +20,8 @@ class ValidateForegroundSessionUseCase(
     private val sessionManager: SessionManager
 ) {
     suspend operator fun invoke(): ForegroundSessionValidationResult {
+        existingForcedReauthResult()?.let { return it }
+
         val accessToken = userPreference.getAuthToken().first()
         val refreshToken = userPreference.getRefreshToken().first()
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
@@ -2,8 +2,6 @@ package com.example.infinite_track.domain.use_case.auth
 
 import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.domain.manager.SessionManager
-import com.example.infinite_track.domain.repository.AuthRefreshException
-import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
 import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.ProfileSyncResult
@@ -12,7 +10,6 @@ import kotlinx.coroutines.flow.first
 sealed class ForegroundSessionValidationResult {
     data object Skipped : ForegroundSessionValidationResult()
     data object Valid : ForegroundSessionValidationResult()
-    data object Refreshed : ForegroundSessionValidationResult()
     data class ReauthRequired(val reason: SessionManager.ReauthReason) : ForegroundSessionValidationResult()
     data class TemporaryFailure(val message: String?, val cause: Throwable?) : ForegroundSessionValidationResult()
 }
@@ -44,78 +41,50 @@ class ValidateForegroundSessionUseCase(
         }
     }
 
-    private suspend fun handleUnauthorized(
-        initialReason: AuthRefreshFailureReason?
+    private fun handleUnauthorized(
+        reason: AuthRefreshFailureReason?
     ): ForegroundSessionValidationResult {
-        if (initialReason?.isTerminalReason() == true) {
-            return reauthRequired(reauthReasonFor(initialReason))
+        existingForcedReauthResult()?.let { return it }
+
+        val reauthReason = reason?.toTerminalReauthReason()
+        if (reauthReason != null) {
+            return reauthRequired(reauthReason)
         }
 
-        val refreshResult = authRepository.refreshSession()
-        if (refreshResult.isSuccess) {
-            return when (val retrySync = authRepository.syncUserProfile()) {
-                is ProfileSyncResult.Success -> ForegroundSessionValidationResult.Refreshed
-                is ProfileSyncResult.TemporaryFailure -> ForegroundSessionValidationResult.TemporaryFailure(
-                    message = retrySync.message,
-                    cause = retrySync.cause
-                )
-                is ProfileSyncResult.Unauthorized -> reauthRequired(
-                    reason = reauthReasonFor(preferredUnauthorizedReason(retrySync.reason, initialReason))
-                )
-            }
-        }
-
-        val refreshException = refreshResult.exceptionOrNull() as? AuthRefreshException
-        return when (refreshException?.kind) {
-            AuthRefreshFailureKind.NON_REFRESHABLE -> reauthRequired(
-                reason = reauthReasonFor(preferredUnauthorizedReason(refreshException.reason, initialReason))
-            )
-            AuthRefreshFailureKind.TRANSPORT,
-            AuthRefreshFailureKind.TRANSIENT,
-            null -> ForegroundSessionValidationResult.TemporaryFailure(
-                message = refreshException?.message,
-                cause = refreshException
-            )
-        }
+        return ForegroundSessionValidationResult.TemporaryFailure(
+            message = "Foreground profile sync remained unauthorized after interceptor handling",
+            cause = null
+        )
     }
 
     private fun reauthRequired(
         reason: SessionManager.ReauthReason
     ): ForegroundSessionValidationResult.ReauthRequired {
+        existingForcedReauthResult()?.let { return it }
+
         sessionManager.triggerForcedReauth(reason)
         return ForegroundSessionValidationResult.ReauthRequired(reason)
     }
 
-    private fun preferredUnauthorizedReason(
-        laterReason: AuthRefreshFailureReason?,
-        initialReason: AuthRefreshFailureReason?
-    ): AuthRefreshFailureReason {
-        val fallbackReason = laterReason ?: AuthRefreshFailureReason.REFRESH_INVALID
-        return when {
-            initialReason == null -> fallbackReason
-            initialReason.isTerminalReason() && fallbackReason.isGenericReason() -> initialReason
-            else -> fallbackReason
+    private fun existingForcedReauthResult(): ForegroundSessionValidationResult.ReauthRequired? {
+        val existingReason = sessionManager.reauthReason.value
+        return if (sessionManager.sessionExpired.value && existingReason != null) {
+            ForegroundSessionValidationResult.ReauthRequired(existingReason)
+        } else {
+            null
         }
     }
 
-    private fun AuthRefreshFailureReason.isTerminalReason(): Boolean {
-        return this == AuthRefreshFailureReason.INACTIVITY_EXPIRED ||
-            this == AuthRefreshFailureReason.REFRESH_INVALID ||
-            this == AuthRefreshFailureReason.REFRESH_REVOKED
-    }
-
-    private fun AuthRefreshFailureReason.isGenericReason(): Boolean {
-        return this == AuthRefreshFailureReason.REFRESH_INVALID ||
-            this == AuthRefreshFailureReason.UNKNOWN
-    }
-
-    private fun reauthReasonFor(reason: AuthRefreshFailureReason): SessionManager.ReauthReason {
-        return when (reason) {
+    private fun AuthRefreshFailureReason.toTerminalReauthReason(): SessionManager.ReauthReason? {
+        return when (this) {
             AuthRefreshFailureReason.INACTIVITY_EXPIRED -> SessionManager.ReauthReason.INACTIVITY_EXPIRED
             AuthRefreshFailureReason.REFRESH_INVALID,
             AuthRefreshFailureReason.MISSING_REFRESH_TOKEN -> SessionManager.ReauthReason.REFRESH_INVALID
             AuthRefreshFailureReason.REFRESH_REVOKED -> SessionManager.ReauthReason.REFRESH_REVOKED
-            else -> SessionManager.ReauthReason.UNKNOWN
+            AuthRefreshFailureReason.ACCESS_EXPIRED,
+            AuthRefreshFailureReason.TRANSPORT_ERROR,
+            AuthRefreshFailureReason.INVALID_PAYLOAD,
+            AuthRefreshFailureReason.UNKNOWN -> null
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
@@ -1,0 +1,121 @@
+package com.example.infinite_track.domain.use_case.auth
+
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import kotlinx.coroutines.flow.first
+
+sealed class ForegroundSessionValidationResult {
+    data object Skipped : ForegroundSessionValidationResult()
+    data object Valid : ForegroundSessionValidationResult()
+    data object Refreshed : ForegroundSessionValidationResult()
+    data class ReauthRequired(val reason: SessionManager.ReauthReason) : ForegroundSessionValidationResult()
+    data class TemporaryFailure(val message: String?, val cause: Throwable?) : ForegroundSessionValidationResult()
+}
+
+class ValidateForegroundSessionUseCase(
+    private val authRepository: AuthRepository,
+    private val userPreference: UserPreference,
+    private val sessionManager: SessionManager
+) {
+    suspend operator fun invoke(): ForegroundSessionValidationResult {
+        val accessToken = userPreference.getAuthToken().first()
+        val refreshToken = userPreference.getRefreshToken().first()
+
+        if (accessToken.isBlank() || refreshToken.isBlank()) {
+            return ForegroundSessionValidationResult.Skipped
+        }
+
+        if (sessionManager.isBootstrapSessionInProgress) {
+            return ForegroundSessionValidationResult.Skipped
+        }
+
+        return when (val syncResult = authRepository.syncUserProfile()) {
+            is ProfileSyncResult.Success -> ForegroundSessionValidationResult.Valid
+            is ProfileSyncResult.TemporaryFailure -> ForegroundSessionValidationResult.TemporaryFailure(
+                message = syncResult.message,
+                cause = syncResult.cause
+            )
+            is ProfileSyncResult.Unauthorized -> handleUnauthorized(syncResult.reason)
+        }
+    }
+
+    private suspend fun handleUnauthorized(
+        initialReason: AuthRefreshFailureReason?
+    ): ForegroundSessionValidationResult {
+        if (initialReason?.isTerminalReason() == true) {
+            return reauthRequired(reauthReasonFor(initialReason))
+        }
+
+        val refreshResult = authRepository.refreshSession()
+        if (refreshResult.isSuccess) {
+            return when (val retrySync = authRepository.syncUserProfile()) {
+                is ProfileSyncResult.Success -> ForegroundSessionValidationResult.Refreshed
+                is ProfileSyncResult.TemporaryFailure -> ForegroundSessionValidationResult.TemporaryFailure(
+                    message = retrySync.message,
+                    cause = retrySync.cause
+                )
+                is ProfileSyncResult.Unauthorized -> reauthRequired(
+                    reason = reauthReasonFor(preferredUnauthorizedReason(retrySync.reason, initialReason))
+                )
+            }
+        }
+
+        val refreshException = refreshResult.exceptionOrNull() as? AuthRefreshException
+        return when (refreshException?.kind) {
+            AuthRefreshFailureKind.NON_REFRESHABLE -> reauthRequired(
+                reason = reauthReasonFor(preferredUnauthorizedReason(refreshException.reason, initialReason))
+            )
+            AuthRefreshFailureKind.TRANSPORT,
+            AuthRefreshFailureKind.TRANSIENT,
+            null -> ForegroundSessionValidationResult.TemporaryFailure(
+                message = refreshException?.message,
+                cause = refreshException
+            )
+        }
+    }
+
+    private fun reauthRequired(
+        reason: SessionManager.ReauthReason
+    ): ForegroundSessionValidationResult.ReauthRequired {
+        sessionManager.triggerForcedReauth(reason)
+        return ForegroundSessionValidationResult.ReauthRequired(reason)
+    }
+
+    private fun preferredUnauthorizedReason(
+        laterReason: AuthRefreshFailureReason?,
+        initialReason: AuthRefreshFailureReason?
+    ): AuthRefreshFailureReason {
+        val fallbackReason = laterReason ?: AuthRefreshFailureReason.REFRESH_INVALID
+        return when {
+            initialReason == null -> fallbackReason
+            initialReason.isTerminalReason() && fallbackReason.isGenericReason() -> initialReason
+            else -> fallbackReason
+        }
+    }
+
+    private fun AuthRefreshFailureReason.isTerminalReason(): Boolean {
+        return this == AuthRefreshFailureReason.INACTIVITY_EXPIRED ||
+            this == AuthRefreshFailureReason.REFRESH_INVALID ||
+            this == AuthRefreshFailureReason.REFRESH_REVOKED
+    }
+
+    private fun AuthRefreshFailureReason.isGenericReason(): Boolean {
+        return this == AuthRefreshFailureReason.REFRESH_INVALID ||
+            this == AuthRefreshFailureReason.UNKNOWN
+    }
+
+    private fun reauthReasonFor(reason: AuthRefreshFailureReason): SessionManager.ReauthReason {
+        return when (reason) {
+            AuthRefreshFailureReason.INACTIVITY_EXPIRED -> SessionManager.ReauthReason.INACTIVITY_EXPIRED
+            AuthRefreshFailureReason.REFRESH_INVALID,
+            AuthRefreshFailureReason.MISSING_REFRESH_TOKEN -> SessionManager.ReauthReason.REFRESH_INVALID
+            AuthRefreshFailureReason.REFRESH_REVOKED -> SessionManager.ReauthReason.REFRESH_REVOKED
+            else -> SessionManager.ReauthReason.UNKNOWN
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt
@@ -14,12 +14,12 @@ sealed class ForegroundSessionValidationResult {
     data class TemporaryFailure(val message: String?, val cause: Throwable?) : ForegroundSessionValidationResult()
 }
 
-class ValidateForegroundSessionUseCase(
+open class ValidateForegroundSessionUseCase(
     private val authRepository: AuthRepository,
     private val userPreference: UserPreference,
     private val sessionManager: SessionManager
 ) {
-    suspend operator fun invoke(): ForegroundSessionValidationResult {
+    open suspend operator fun invoke(): ForegroundSessionValidationResult {
         existingForcedReauthResult()?.let { return it }
 
         val accessToken = userPreference.getAuthToken().first()

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -76,32 +76,26 @@ class ForegroundSessionLifecycleObserver private constructor(
 
         applicationScope.launch {
             try {
-                try {
-                    validationCount += 1
-                    when (val result = validateForegroundSessionUseCase()) {
-                        ForegroundSessionValidationResult.Skipped -> Unit
-                        ForegroundSessionValidationResult.Valid -> Unit
-                        is ForegroundSessionValidationResult.TemporaryFailure -> Unit
-                        is ForegroundSessionValidationResult.ReauthRequired -> {
-                            if (sessionManager.beginSessionExpiryHandling()) {
-                                try {
-                                    logoutUseCaseProvider.get().invoke()
-                                } finally {
-                                    sessionManager.triggerForcedReauth(result.reason)
-                                }
-                            }
+                validationCount += 1
+                when (val result = validateForegroundSessionUseCase()) {
+                    ForegroundSessionValidationResult.Skipped -> Unit
+                    ForegroundSessionValidationResult.Valid -> Unit
+                    is ForegroundSessionValidationResult.TemporaryFailure -> Unit
+                    is ForegroundSessionValidationResult.ReauthRequired -> {
+                        if (sessionManager.beginSessionExpiryHandling()) {
+                            sessionManager.triggerForcedReauth(result.reason)
+                            logoutUseCaseProvider.get().invoke()
                         }
                     }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    unexpectedFailureLogger(e)
-                    // Treat unexpected validator failures like temporary foreground transport failures.
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                unexpectedFailureLogger(e)
+                throw e
             } finally {
                 gate.release()
             }
         }
     }
-
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -16,15 +16,13 @@ import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
-class ForegroundSessionLifecycleObserver internal constructor(
+class ForegroundSessionLifecycleObserver private constructor(
     private val validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
     private val sessionManager: SessionManager,
     private val logoutUseCaseProvider: Provider<LogoutUseCase>,
     private val applicationScope: CoroutineScope,
-    private val gate: ForegroundSessionResumeGate = ForegroundSessionResumeGate(),
-    private val unexpectedFailureLogger: (Throwable) -> Unit = { throwable ->
-        Log.w(TAG, "Foreground session validation failed unexpectedly; preserving local session state", throwable)
-    }
+    private val gate: ForegroundSessionResumeGate,
+    private val unexpectedFailureLogger: (Throwable) -> Unit
 ) : DefaultLifecycleObserver {
 
     @Inject
@@ -37,8 +35,36 @@ class ForegroundSessionLifecycleObserver internal constructor(
         validateForegroundSessionUseCase = validateForegroundSessionUseCase,
         sessionManager = sessionManager,
         logoutUseCaseProvider = logoutUseCaseProvider,
-        applicationScope = applicationScope
+        applicationScope = applicationScope,
+        gate = ForegroundSessionResumeGate(),
+        unexpectedFailureLogger = { throwable ->
+            Log.w(TAG, "Foreground session validation failed unexpectedly; preserving local session state", throwable)
+        }
     )
+
+    companion object {
+        private const val TAG = "ForegroundSession"
+
+        internal fun createForTest(
+            validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
+            sessionManager: SessionManager,
+            logoutUseCaseProvider: Provider<LogoutUseCase>,
+            applicationScope: CoroutineScope,
+            gate: ForegroundSessionResumeGate,
+            unexpectedFailureLogger: (Throwable) -> Unit = { throwable ->
+                Log.w(TAG, "Foreground session validation failed unexpectedly; preserving local session state", throwable)
+            }
+        ): ForegroundSessionLifecycleObserver {
+            return ForegroundSessionLifecycleObserver(
+                validateForegroundSessionUseCase = validateForegroundSessionUseCase,
+                sessionManager = sessionManager,
+                logoutUseCaseProvider = logoutUseCaseProvider,
+                applicationScope = applicationScope,
+                gate = gate,
+                unexpectedFailureLogger = unexpectedFailureLogger
+            )
+        }
+    }
 
     internal var validationCount: Int = 0
         private set
@@ -78,7 +104,4 @@ class ForegroundSessionLifecycleObserver internal constructor(
         }
     }
 
-    private companion object {
-        const val TAG = "ForegroundSession"
-    }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -1,5 +1,6 @@
 package com.example.infinite_track.presentation.main
 
+import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.example.infinite_track.di.ApplicationCoroutineScope
@@ -20,7 +21,10 @@ class ForegroundSessionLifecycleObserver internal constructor(
     private val sessionManager: SessionManager,
     private val logoutUseCaseProvider: Provider<LogoutUseCase>,
     private val applicationScope: CoroutineScope,
-    private val gate: ForegroundSessionResumeGate = ForegroundSessionResumeGate()
+    private val gate: ForegroundSessionResumeGate = ForegroundSessionResumeGate(),
+    private val unexpectedFailureLogger: (Throwable) -> Unit = { throwable ->
+        Log.w(TAG, "Foreground session validation failed unexpectedly; preserving local session state", throwable)
+    }
 ) : DefaultLifecycleObserver {
 
     @Inject
@@ -65,11 +69,16 @@ class ForegroundSessionLifecycleObserver internal constructor(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
+                    unexpectedFailureLogger(e)
                     // Treat unexpected validator failures like temporary foreground transport failures.
                 }
             } finally {
                 gate.release()
             }
         }
+    }
+
+    private companion object {
+        const val TAG = "ForegroundSession"
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -7,6 +7,7 @@ import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.use_case.auth.ForegroundSessionValidationResult
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -45,20 +46,26 @@ class ForegroundSessionLifecycleObserver internal constructor(
 
         applicationScope.launch {
             try {
-                validationCount += 1
-                when (val result = validateForegroundSessionUseCase()) {
-                    ForegroundSessionValidationResult.Skipped -> Unit
-                    ForegroundSessionValidationResult.Valid -> Unit
-                    is ForegroundSessionValidationResult.TemporaryFailure -> Unit
-                    is ForegroundSessionValidationResult.ReauthRequired -> {
-                        if (sessionManager.beginSessionExpiryHandling()) {
-                            try {
-                                logoutUseCaseProvider.get().invoke()
-                            } finally {
-                                sessionManager.triggerForcedReauth(result.reason)
+                try {
+                    validationCount += 1
+                    when (val result = validateForegroundSessionUseCase()) {
+                        ForegroundSessionValidationResult.Skipped -> Unit
+                        ForegroundSessionValidationResult.Valid -> Unit
+                        is ForegroundSessionValidationResult.TemporaryFailure -> Unit
+                        is ForegroundSessionValidationResult.ReauthRequired -> {
+                            if (sessionManager.beginSessionExpiryHandling()) {
+                                try {
+                                    logoutUseCaseProvider.get().invoke()
+                                } finally {
+                                    sessionManager.triggerForcedReauth(result.reason)
+                                }
                             }
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Treat unexpected validator failures like temporary foreground transport failures.
                 }
             } finally {
                 gate.release()

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -1,0 +1,83 @@
+package com.example.infinite_track.presentation.main
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.example.infinite_track.di.ApplicationCoroutineScope
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.use_case.auth.ForegroundSessionValidationResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+@Singleton
+class ForegroundSessionLifecycleObserver private constructor(
+    private val validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
+    private val sessionManager: SessionManager,
+    private val logoutUseCaseProvider: Provider<LogoutUseCase>,
+    private val applicationScope: CoroutineScope,
+    private val gate: ForegroundSessionResumeGate
+) : DefaultLifecycleObserver {
+
+    @Inject
+    constructor(
+        validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
+        sessionManager: SessionManager,
+        logoutUseCaseProvider: Provider<LogoutUseCase>,
+        @ApplicationCoroutineScope applicationScope: CoroutineScope
+    ) : this(
+        validateForegroundSessionUseCase = validateForegroundSessionUseCase,
+        sessionManager = sessionManager,
+        logoutUseCaseProvider = logoutUseCaseProvider,
+        applicationScope = applicationScope,
+        gate = ForegroundSessionResumeGate()
+    )
+
+    internal constructor(
+        validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
+        sessionManager: SessionManager,
+        logoutUseCaseProvider: Provider<LogoutUseCase>,
+        applicationScope: CoroutineScope,
+        gate: ForegroundSessionResumeGate
+    ) : this(
+        validateForegroundSessionUseCase = validateForegroundSessionUseCase,
+        sessionManager = sessionManager,
+        logoutUseCaseProvider = logoutUseCaseProvider,
+        applicationScope = applicationScope,
+        gate = gate
+    )
+
+    internal var validationCount: Int = 0
+        private set
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (!gate.tryAcquire(sessionManager.isBootstrapSessionInProgress)) {
+            return
+        }
+
+        applicationScope.launch {
+            try {
+                validationCount += 1
+                when (val result = validateForegroundSessionUseCase()) {
+                    ForegroundSessionValidationResult.Skipped -> Unit
+                    ForegroundSessionValidationResult.Valid -> Unit
+                    is ForegroundSessionValidationResult.TemporaryFailure -> Unit
+                    is ForegroundSessionValidationResult.ReauthRequired -> {
+                        if (sessionManager.beginSessionExpiryHandling()) {
+                            try {
+                                logoutUseCaseProvider.get().invoke()
+                            } finally {
+                                sessionManager.triggerForcedReauth(result.reason)
+                            }
+                        }
+                    }
+                }
+            } finally {
+                gate.release()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt
@@ -14,12 +14,12 @@ import javax.inject.Provider
 import javax.inject.Singleton
 
 @Singleton
-class ForegroundSessionLifecycleObserver private constructor(
+class ForegroundSessionLifecycleObserver internal constructor(
     private val validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
     private val sessionManager: SessionManager,
     private val logoutUseCaseProvider: Provider<LogoutUseCase>,
     private val applicationScope: CoroutineScope,
-    private val gate: ForegroundSessionResumeGate
+    private val gate: ForegroundSessionResumeGate = ForegroundSessionResumeGate()
 ) : DefaultLifecycleObserver {
 
     @Inject
@@ -32,22 +32,7 @@ class ForegroundSessionLifecycleObserver private constructor(
         validateForegroundSessionUseCase = validateForegroundSessionUseCase,
         sessionManager = sessionManager,
         logoutUseCaseProvider = logoutUseCaseProvider,
-        applicationScope = applicationScope,
-        gate = ForegroundSessionResumeGate()
-    )
-
-    internal constructor(
-        validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
-        sessionManager: SessionManager,
-        logoutUseCaseProvider: Provider<LogoutUseCase>,
-        applicationScope: CoroutineScope,
-        gate: ForegroundSessionResumeGate
-    ) : this(
-        validateForegroundSessionUseCase = validateForegroundSessionUseCase,
-        sessionManager = sessionManager,
-        logoutUseCaseProvider = logoutUseCaseProvider,
-        applicationScope = applicationScope,
-        gate = gate
+        applicationScope = applicationScope
     )
 
     internal var validationCount: Int = 0

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt
@@ -4,11 +4,16 @@ internal class ForegroundSessionResumeGate(
     private val nowMillis: () -> Long = { System.currentTimeMillis() },
     private val debounceWindowMs: Long = 2_000L
 ) {
+    private var initialStartObserved: Boolean = false
     private var validationRunning: Boolean = false
     private var lastStartedAtMillis: Long = Long.MIN_VALUE
 
     @Synchronized
     fun tryAcquire(bootstrapInProgress: Boolean): Boolean {
+        if (!initialStartObserved) {
+            initialStartObserved = true
+            return false
+        }
         if (bootstrapInProgress) {
             return false
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt
@@ -1,0 +1,31 @@
+package com.example.infinite_track.presentation.main
+
+internal class ForegroundSessionResumeGate(
+    private val nowMillis: () -> Long = { System.currentTimeMillis() },
+    private val debounceWindowMs: Long = 2_000L
+) {
+    private var validationRunning: Boolean = false
+    private var lastStartedAtMillis: Long = Long.MIN_VALUE
+
+    @Synchronized
+    fun tryAcquire(bootstrapInProgress: Boolean): Boolean {
+        if (bootstrapInProgress) {
+            return false
+        }
+        if (validationRunning) {
+            return false
+        }
+        val now = nowMillis()
+        if (lastStartedAtMillis != Long.MIN_VALUE && now - lastStartedAtMillis < debounceWindowMs) {
+            return false
+        }
+        validationRunning = true
+        lastStartedAtMillis = now
+        return true
+    }
+
+    @Synchronized
+    fun release() {
+        validationRunning = false
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -15,6 +15,7 @@ import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequ
 import com.example.infinite_track.data.soucre.network.response.AttendanceHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.AttendanceResponse
 import com.example.infinite_track.data.soucre.network.response.ErrorResponse
+import com.example.infinite_track.data.soucre.network.response.AuthPayload
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.LogoutResponse
 import com.example.infinite_track.data.soucre.network.response.LocationData
@@ -92,6 +93,30 @@ class AuthRepositoryImplRefreshSessionTest {
         assertTrue(userPreference.getRefreshToken().first().isBlank())
         assertEquals("10", userPreference.getUserId().first())
         assertEquals(1, userDao.insertedUsers.size)
+    }
+
+    @Test
+    fun `login persists primary auth token payload before legacy direct fields`() = runBlocking {
+        val userPreference = createUserPreference()
+        val userDao = CapturingUserDao()
+        val repository = createLoginRepository(
+            userPreference = userPreference,
+            userDao = userDao,
+            userData = createUserData(refreshToken = "legacy-refresh").copy(
+                token = "legacy-access",
+                auth = AuthPayload(
+                    accessToken = "primary-access",
+                    refreshToken = "primary-refresh"
+                )
+            )
+        )
+
+        val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
+
+        assertTrue(result.isSuccess)
+        assertEquals("primary-access", userPreference.getAuthToken().first())
+        assertEquals("primary-refresh", userPreference.getRefreshToken().first())
+        assertEquals("10", userPreference.getUserId().first())
     }
 
     @Test
@@ -680,6 +705,47 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
+    fun `refresh session uses auth session api and stores primary auth token payload`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+        val fakeAuthSessionApi = FakeAuthSessionApiService(
+            refreshSessionBlock = {
+                RefreshSessionResponse(
+                    success = true,
+                    message = "ok",
+                    data = RefreshSessionData(
+                        id = 10,
+                        token = "legacy-new-access",
+                        refreshToken = "legacy-new-refresh",
+                        auth = AuthPayload(
+                            accessToken = "primary-new-access",
+                            refreshToken = "primary-new-refresh"
+                        )
+                    )
+                )
+            }
+        )
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshBlock = { _ ->
+                    throw AssertionError("refresh must use AuthSessionApiService, not protected ApiService")
+                }
+            ),
+            authSessionApiService = fakeAuthSessionApi,
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result.isSuccess)
+        assertEquals("primary-new-access", userPreference.getAuthToken().first())
+        assertEquals("primary-new-refresh", userPreference.getRefreshToken().first())
+        assertEquals("old-refresh", fakeAuthSessionApi.lastRefreshRequest?.refreshToken)
+    }
+
+    @Test
     fun `refresh session success stores latest tokens`() = runBlocking {
         val userPreference = createUserPreference()
         userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
@@ -991,7 +1057,8 @@ class AuthRepositoryImplRefreshSessionTest {
                 categoryName = "WFO"
             ),
             token = "access-token",
-            refreshToken = refreshToken
+            refreshToken = refreshToken,
+            auth = null
         )
     }
 

--- a/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
@@ -4,13 +4,11 @@ import com.example.infinite_track.data.soucre.network.request.RefreshRequest
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshResponse
-import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.google.gson.Gson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import retrofit2.http.Headers
 
 class AuthApiContractTest {
     private val gson = Gson()
@@ -147,18 +145,6 @@ class AuthApiContractTest {
         assertEquals(147, response.data.id)
         assertEquals("legacy-new-access-token-redacted", response.data.resolvedAccessToken())
         assertEquals("legacy-new-refresh-token-redacted", response.data.resolvedRefreshToken())
-    }
-
-    @Test
-    fun `auth session refresh endpoint uses canonical mobile client type header`() {
-        val method = AuthSessionApiService::class.java.getMethod(
-            "refreshSession",
-            com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest::class.java
-        )
-        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
-
-        assertTrue(headers.contains("X-Client-Type: mobile"))
-        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
@@ -4,17 +4,19 @@ import com.example.infinite_track.data.soucre.network.request.RefreshRequest
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshResponse
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.google.gson.Gson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import retrofit2.http.Headers
 
 class AuthApiContractTest {
     private val gson = Gson()
 
     @Test
-    fun `mobile login response parses required refresh token from json data`() {
+    fun `mobile login response parses primary auth token payload`() {
         val json = """
             {
               "success": true,
@@ -38,8 +40,10 @@ class AuthApiContractTest {
                   "description": "Redacted office",
                   "category_name": "Office"
                 },
-                "token": "access-token-redacted",
-                "refresh_token": "refresh-token-redacted"
+                "auth": {
+                  "access_token": "primary-access-token-redacted",
+                  "refresh_token": "primary-refresh-token-redacted"
+                }
               }
             }
         """.trimIndent()
@@ -47,8 +51,46 @@ class AuthApiContractTest {
         val response = gson.fromJson(json, LoginResponse::class.java)
 
         assertTrue(response.success)
-        assertEquals("access-token-redacted", response.data.token)
-        assertEquals("refresh-token-redacted", response.data.refreshToken)
+        assertEquals("primary-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("primary-refresh-token-redacted", response.data.resolvedRefreshToken())
+    }
+
+    @Test
+    fun `mobile login response falls back to legacy direct token fields`() {
+        val json = """
+            {
+              "success": true,
+              "message": "Login success",
+              "data": {
+                "id": 147,
+                "full_name": "Redacted User",
+                "email": "redacted@example.test",
+                "role_name": "Student",
+                "position_name": "Learner",
+                "program_name": "Infinite Learning",
+                "division_name": "Mobile",
+                "nip_nim": "NIM-REDACTED",
+                "phone": "0000000000",
+                "photo": "https://example.test/avatar.png",
+                "photo_updated_at": "2026-05-30T00:00:00Z",
+                "location": {
+                  "latitude": -6.2,
+                  "longitude": 106.8,
+                  "radius": 100,
+                  "description": "Redacted office",
+                  "category_name": "Office"
+                },
+                "token": "legacy-access-token-redacted",
+                "refresh_token": "legacy-refresh-token-redacted"
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, LoginResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals("legacy-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("legacy-refresh-token-redacted", response.data.resolvedRefreshToken())
     }
 
     @Test
@@ -59,7 +101,7 @@ class AuthApiContractTest {
     }
 
     @Test
-    fun `refresh success response parses access and rotated refresh token`() {
+    fun `refresh success response parses primary auth token payload`() {
         val json = """
             {
               "success": true,
@@ -67,8 +109,10 @@ class AuthApiContractTest {
               "message": "Refresh success",
               "data": {
                 "id": 147,
-                "token": "new-access-token-redacted",
-                "refresh_token": "new-refresh-token-redacted"
+                "auth": {
+                  "access_token": "primary-new-access-token-redacted",
+                  "refresh_token": "primary-new-refresh-token-redacted"
+                }
               }
             }
         """.trimIndent()
@@ -77,9 +121,44 @@ class AuthApiContractTest {
 
         assertTrue(response.success)
         assertEquals(147, response.data.id)
-        assertEquals("new-access-token-redacted", response.data.token)
-        assertEquals("new-refresh-token-redacted", response.data.refreshToken)
+        assertEquals("primary-new-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("primary-new-refresh-token-redacted", response.data.resolvedRefreshToken())
         assertEquals("Refresh success", response.message)
+    }
+
+    @Test
+    fun `refresh success response falls back to legacy direct token fields`() {
+        val json = """
+            {
+              "success": true,
+              "code": null,
+              "message": "Refresh success",
+              "data": {
+                "id": 147,
+                "token": "legacy-new-access-token-redacted",
+                "refresh_token": "legacy-new-refresh-token-redacted"
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, RefreshResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals(147, response.data.id)
+        assertEquals("legacy-new-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("legacy-new-refresh-token-redacted", response.data.resolvedRefreshToken())
+    }
+
+    @Test
+    fun `auth session refresh endpoint uses canonical mobile client type header`() {
+        val method = AuthSessionApiService::class.java.getMethod(
+            "refreshSession",
+            com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest::class.java
+        )
+        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+
+        assertTrue(headers.contains("X-Client-Type: mobile"))
+        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
@@ -4,11 +4,13 @@ import com.example.infinite_track.data.soucre.network.request.RefreshRequest
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshResponse
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.google.gson.Gson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import retrofit2.http.Headers
 
 class AuthApiContractTest {
     private val gson = Gson()
@@ -162,5 +164,14 @@ class AuthApiContractTest {
         assertFalse(response.success)
         assertEquals("AUTH_SESSION_INACTIVE", response.code)
         assertEquals("Session inactive for more than 48 hours", response.message)
+    }
+
+    @Test
+    fun `auth session refresh endpoint uses canonical mobile client type header`() {
+        val method = AuthSessionApiService::class.java.declaredMethods.first { it.name == "refreshSession" }
+        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+
+        assertTrue(headers.contains("X-Client-Type: mobile"))
+        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
     }
 }

--- a/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
@@ -11,9 +11,13 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.http.Headers
+import java.lang.reflect.Method
 
 class AuthApiContractTest {
     private val gson = Gson()
+
+    private fun authSessionMethod(name: String): Method =
+        AuthSessionApiService::class.java.declaredMethods.first { method -> method.name == name }
 
     @Test
     fun `mobile login response parses primary auth token payload`() {
@@ -168,8 +172,15 @@ class AuthApiContractTest {
 
     @Test
     fun `auth session refresh endpoint uses canonical mobile client type header`() {
-        val method = AuthSessionApiService::class.java.declaredMethods.first { it.name == "refreshSession" }
-        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+        val headers = authSessionMethod("refreshSession").getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+
+        assertTrue(headers.contains("X-Client-Type: mobile"))
+        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
+    }
+
+    @Test
+    fun `auth session logout endpoint uses canonical mobile client type header`() {
+        val headers = authSessionMethod("logout").getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
 
         assertTrue(headers.contains("X-Client-Type: mobile"))
         assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
@@ -7,8 +7,6 @@ import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.data.soucre.network.request.LoginRequest
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.domain.repository.AuthRefreshException
-import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
 import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
 import com.example.infinite_track.domain.repository.AuthRefreshResult
 import com.example.infinite_track.domain.repository.AuthRepository
@@ -74,7 +72,7 @@ class ValidateForegroundSessionUseCaseTest {
     }
 
     @Test
-    fun `returns valid when profile sync succeeds without refresh`() = runBlocking {
+    fun `returns valid when profile sync succeeds through interceptor path`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -89,40 +87,98 @@ class ValidateForegroundSessionUseCaseTest {
     }
 
     @Test
-    fun `returns refreshed when sync is unauthorized but refresh and retry succeed`() = runBlocking {
+    fun `returns temporary failure when interceptor-backed profile sync remains access-expired unauthorized`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
         }
         val repository = FakeAuthRepository(
             syncResults = mutableListOf(
-                ProfileSyncResult.Unauthorized(),
-                ProfileSyncResult.Success(sampleUser())
-            ),
-            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1"))
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.ACCESS_EXPIRED)
+            )
         )
 
         val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
 
-        assertEquals(ForegroundSessionValidationResult.Refreshed, result)
-        assertEquals(2, repository.syncCallCount)
-        assertEquals(1, repository.refreshCallCount)
+        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+        assertEquals(false, sessionManager.sessionExpired.value)
     }
 
     @Test
-    fun `returns reauth required when refresh fails with non refreshable reason`() = runBlocking {
+    fun `returns temporary failure when interceptor-backed profile sync remains generic unauthorized`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Unauthorized()))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+        assertEquals(false, sessionManager.sessionExpired.value)
+    }
+
+    @Test
+    fun `returns existing reauth when interceptor already handled access-expired unauthorized terminal refresh failure`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_INVALID)
+        }
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.ACCESS_EXPIRED)
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns existing reauth when interceptor already handled generic unauthorized terminal refresh failure`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_REVOKED)
+        }
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Unauthorized()))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when profile sync reports refresh revoked`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
         }
         val repository = FakeAuthRepository(
-            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
-            refreshSessionResult = Result.failure(
-                AuthRefreshException(
-                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
-                    reason = AuthRefreshFailureReason.REFRESH_REVOKED,
-                    message = "revoked"
-                )
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_REVOKED)
             )
         )
 
@@ -135,11 +191,35 @@ class ValidateForegroundSessionUseCaseTest {
         assertEquals(true, sessionManager.sessionExpired.value)
         assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
         assertEquals(1, repository.syncCallCount)
-        assertEquals(1, repository.refreshCallCount)
+        assertEquals(0, repository.refreshCallCount)
     }
 
     @Test
-    fun `returns reauth required when profile sync reports terminal auth reason`() = runBlocking {
+    fun `returns reauth required when profile sync reports refresh invalid`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when profile sync reports inactive session`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -147,13 +227,6 @@ class ValidateForegroundSessionUseCaseTest {
         val repository = FakeAuthRepository(
             syncResults = mutableListOf(
                 ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED)
-            ),
-            refreshSessionResult = Result.failure(
-                AuthRefreshException(
-                    kind = AuthRefreshFailureKind.TRANSPORT,
-                    reason = AuthRefreshFailureReason.TRANSPORT_ERROR,
-                    message = "offline"
-                )
             )
         )
 
@@ -170,44 +243,40 @@ class ValidateForegroundSessionUseCaseTest {
     }
 
     @Test
-    fun `returns temporary failure when refresh transport error occurs`() = runBlocking {
-        val sessionManager = SessionManager()
+    fun `preserves existing forced reauth reason when interceptor already handled terminal auth`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_REVOKED)
+        }
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
         }
         val repository = FakeAuthRepository(
-            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
-            refreshSessionResult = Result.failure(
-                AuthRefreshException(
-                    kind = AuthRefreshFailureKind.TRANSPORT,
-                    reason = AuthRefreshFailureReason.TRANSPORT_ERROR,
-                    message = "offline"
-                )
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
             )
         )
 
         val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
 
-        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
         assertEquals(1, repository.syncCallCount)
-        assertEquals(1, repository.refreshCallCount)
-        assertEquals(false, sessionManager.sessionExpired.value)
+        assertEquals(0, repository.refreshCallCount)
     }
 
     @Test
-    fun `returns temporary failure when refresh transient error occurs`() = runBlocking {
+    fun `returns temporary failure when profile sync reports transport failure`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
-            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
         }
         val repository = FakeAuthRepository(
-            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
-            refreshSessionResult = Result.failure(
-                AuthRefreshException(
-                    kind = AuthRefreshFailureKind.TRANSIENT,
-                    reason = AuthRefreshFailureReason.INVALID_PAYLOAD,
-                    message = "invalid payload"
-                )
+            syncResults = mutableListOf(
+                ProfileSyncResult.TemporaryFailure(message = "offline", cause = null)
             )
         )
 
@@ -215,7 +284,7 @@ class ValidateForegroundSessionUseCaseTest {
 
         assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
         assertEquals(1, repository.syncCallCount)
-        assertEquals(1, repository.refreshCallCount)
+        assertEquals(0, repository.refreshCallCount)
         assertEquals(false, sessionManager.sessionExpired.value)
     }
 
@@ -242,10 +311,7 @@ class ValidateForegroundSessionUseCaseTest {
     )
 
     private class FakeAuthRepository(
-        private val syncResults: MutableList<ProfileSyncResult> = mutableListOf(),
-        private val refreshSessionResult: Result<AuthRefreshResult> = Result.success(
-            AuthRefreshResult("token", "refresh", "1")
-        )
+        private val syncResults: MutableList<ProfileSyncResult> = mutableListOf()
     ) : AuthRepository {
         var syncCallCount: Int = 0
         var refreshCallCount: Int = 0
@@ -260,7 +326,7 @@ class ValidateForegroundSessionUseCaseTest {
 
         override suspend fun refreshSession(): Result<AuthRefreshResult> {
             refreshCallCount += 1
-            return refreshSessionResult
+            error("Foreground validation must rely on syncUserProfile interceptor handling")
         }
 
         override suspend fun syncUserProfile(): ProfileSyncResult {

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
@@ -231,7 +231,7 @@ class ValidateForegroundSessionUseCaseTest {
     }
 
     @Test
-    fun `returns reauth required when profile sync reports refresh revoked`() = runBlocking {
+    fun `returns reauth required without publishing forced state when profile sync reports refresh revoked`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -248,14 +248,14 @@ class ValidateForegroundSessionUseCaseTest {
             ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
             result
         )
-        assertEquals(true, sessionManager.sessionExpired.value)
-        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertEquals(false, sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
         assertEquals(1, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
 
     @Test
-    fun `returns reauth required when profile sync reports refresh invalid`() = runBlocking {
+    fun `returns reauth required without publishing forced state when profile sync reports refresh invalid`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -272,14 +272,14 @@ class ValidateForegroundSessionUseCaseTest {
             ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID),
             result
         )
-        assertEquals(true, sessionManager.sessionExpired.value)
-        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+        assertEquals(false, sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
         assertEquals(1, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
 
     @Test
-    fun `returns reauth required when profile sync reports inactive session`() = runBlocking {
+    fun `returns reauth required without publishing forced state when profile sync reports inactive session`() = runBlocking {
         val sessionManager = SessionManager()
         val userPreference = createUserPreference().also {
             it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
@@ -296,8 +296,8 @@ class ValidateForegroundSessionUseCaseTest {
             ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.INACTIVITY_EXPIRED),
             result
         )
-        assertEquals(true, sessionManager.sessionExpired.value)
-        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertEquals(false, sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
         assertEquals(1, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
@@ -1,0 +1,281 @@
+package com.example.infinite_track.domain.use_case.auth
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRefreshResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class ValidateForegroundSessionUseCaseTest {
+    private lateinit var tempFile: File
+    private lateinit var scope: CoroutineScope
+    private lateinit var dataStore: DataStore<Preferences>
+
+    @Before
+    fun setUp() {
+        tempFile = File.createTempFile("foreground-session-", ".preferences_pb").also { it.delete() }
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        dataStore = PreferenceDataStoreFactory.create(scope = scope) { tempFile }
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        tempFile.delete()
+    }
+
+    @Test
+    fun `skips when auth token or refresh token is missing`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference()
+        val repository = FakeAuthRepository()
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Skipped, result)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `skips while bootstrap session is already in progress`() = runBlocking {
+        val sessionManager = SessionManager().also { it.beginBootstrapSession() }
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser())))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Skipped, result)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns valid when profile sync succeeds without refresh`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser())))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Valid, result)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns refreshed when sync is unauthorized but refresh and retry succeed`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(),
+                ProfileSyncResult.Success(sampleUser())
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1"))
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Refreshed, result)
+        assertEquals(2, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when refresh fails with non refreshable reason`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = AuthRefreshFailureReason.REFRESH_REVOKED,
+                    message = "revoked"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when profile sync reports terminal auth reason`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.INACTIVITY_EXPIRED)
+            ),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.TRANSPORT,
+                    reason = AuthRefreshFailureReason.TRANSPORT_ERROR,
+                    message = "offline"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.INACTIVITY_EXPIRED),
+            result
+        )
+        assertEquals(true, sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.INACTIVITY_EXPIRED, sessionManager.reauthReason.value)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns temporary failure when refresh transport error occurs`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.TRANSPORT,
+                    reason = AuthRefreshFailureReason.TRANSPORT_ERROR,
+                    message = "offline"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+        assertEquals(false, sessionManager.sessionExpired.value)
+    }
+
+    @Test
+    fun `returns temporary failure when refresh transient error occurs`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.TRANSIENT,
+                    reason = AuthRefreshFailureReason.INVALID_PAYLOAD,
+                    message = "invalid payload"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+        assertEquals(false, sessionManager.sessionExpired.value)
+    }
+
+    private fun createUserPreference(): UserPreference = UserPreference(dataStore)
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "Redacted User",
+        email = "redacted@example.test",
+        roleName = "Employee",
+        positionName = "Engineer",
+        programName = null,
+        divisionName = "Mobile",
+        nipNim = "EMP-001",
+        phone = "08123456789",
+        photoUrl = "https://example.test/photo.png",
+        photoUpdatedAt = "2026-06-21T00:00:00Z",
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
+        faceEmbedding = null
+    )
+
+    private class FakeAuthRepository(
+        private val syncResults: MutableList<ProfileSyncResult> = mutableListOf(),
+        private val refreshSessionResult: Result<AuthRefreshResult> = Result.success(
+            AuthRefreshResult("token", "refresh", "1")
+        )
+    ) : AuthRepository {
+        var syncCallCount: Int = 0
+        var refreshCallCount: Int = 0
+
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+            error("Not used in this test")
+        }
+
+        override suspend fun logout(): Result<Unit> {
+            return Result.success(Unit)
+        }
+
+        override suspend fun refreshSession(): Result<AuthRefreshResult> {
+            refreshCallCount += 1
+            return refreshSessionResult
+        }
+
+        override suspend fun syncUserProfile(): ProfileSyncResult {
+            syncCallCount += 1
+            return syncResults.removeAt(0)
+        }
+
+        override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+            error("Bootstrap sync is not used by foreground validation")
+        }
+
+        override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+
+        override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+            error("Not used in this test")
+        }
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
@@ -57,6 +57,24 @@ class ValidateForegroundSessionUseCaseTest {
     }
 
     @Test
+    fun `returns existing reauth before skipped when tokens are blank`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_INVALID)
+        }
+        val userPreference = createUserPreference()
+        val repository = FakeAuthRepository()
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID),
+            result
+        )
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
     fun `skips while bootstrap session is already in progress`() = runBlocking {
         val sessionManager = SessionManager().also { it.beginBootstrapSession() }
         val userPreference = createUserPreference().also {
@@ -67,6 +85,48 @@ class ValidateForegroundSessionUseCaseTest {
         val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
 
         assertEquals(ForegroundSessionValidationResult.Skipped, result)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns existing reauth before valid when profile sync would succeed`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.REFRESH_REVOKED)
+        }
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser())))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
+            result
+        )
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns existing reauth before temporary failure when profile sync would fail temporarily`() = runBlocking {
+        val sessionManager = SessionManager().also {
+            it.triggerForcedReauth(SessionManager.ReauthReason.INACTIVITY_EXPIRED)
+        }
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.TemporaryFailure(message = "offline", cause = null))
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.INACTIVITY_EXPIRED),
+            result
+        )
         assertEquals(0, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
@@ -144,7 +204,7 @@ class ValidateForegroundSessionUseCaseTest {
         )
         assertEquals(true, sessionManager.sessionExpired.value)
         assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
-        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
 
@@ -166,7 +226,7 @@ class ValidateForegroundSessionUseCaseTest {
         )
         assertEquals(true, sessionManager.sessionExpired.value)
         assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
-        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
 
@@ -264,7 +324,7 @@ class ValidateForegroundSessionUseCaseTest {
         )
         assertEquals(true, sessionManager.sessionExpired.value)
         assertEquals(SessionManager.ReauthReason.REFRESH_REVOKED, sessionManager.reauthReason.value)
-        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.syncCallCount)
         assertEquals(0, repository.refreshCallCount)
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -133,6 +133,41 @@ class ForegroundSessionLifecycleObserverTest {
         assertEquals(null, sessionManager.reauthReason.value)
     }
 
+    @Test
+    fun `unexpected validation exception is bounded as temporary no-op`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(),
+            syncException = IllegalStateException("unexpected validator failure")
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(1, observer.validationCount)
+        assertEquals(1, validationRepository.syncCallCount)
+        assertEquals(0, logoutRepository.logoutCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
+    }
+
     private fun createUserPreference(): UserPreference {
         val tempDir = createTempDir(prefix = "foreground-observer-")
         val appContext = object : ContextWrapper(null) {
@@ -168,7 +203,8 @@ private class TestLifecycleOwner : LifecycleOwner {
 
 private class FakeValidationRepository(
     private val syncResults: MutableList<ProfileSyncResult>,
-    private val refreshFailureReason: AuthRefreshFailureReason? = null
+    private val refreshFailureReason: AuthRefreshFailureReason? = null,
+    private val syncException: Throwable? = null
 ) : AuthRepository {
     var syncCallCount: Int = 0
         private set
@@ -197,6 +233,7 @@ private class FakeValidationRepository(
 
     override suspend fun syncUserProfile(): ProfileSyncResult {
         syncCallCount += 1
+        syncException?.let { throw it }
         return syncResults.removeAt(0)
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -18,7 +18,10 @@ import com.example.infinite_track.domain.repository.ProfileSyncResult
 import com.example.infinite_track.domain.use_case.auth.ForegroundSessionValidationResult
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -27,7 +30,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -93,10 +95,11 @@ class ForegroundSessionLifecycleObserverTest {
     }
 
     @Test
-    fun `reauth required triggers logout and forced reauth state`() = runTest {
+    fun `reauth required publishes forced reauth before logout completes`() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
         val sessionManager = SessionManager()
-        val logoutRepository = FakeLogoutRepository()
+        val logoutCompletion = CompletableDeferred<Unit>()
+        val logoutRepository = FakeLogoutRepository(logoutCompletion)
         val observer = ForegroundSessionLifecycleObserver.createForTest(
             validateForegroundSessionUseCase = FixedForegroundValidationUseCase(
                 ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID)
@@ -115,6 +118,9 @@ class ForegroundSessionLifecycleObserverTest {
         assertEquals(1, logoutRepository.logoutCallCount)
         assertTrue(sessionManager.sessionExpired.value)
         assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+
+        logoutCompletion.complete(Unit)
+        scope.advanceUntilIdle()
     }
 
     @Test
@@ -143,29 +149,32 @@ class ForegroundSessionLifecycleObserverTest {
     }
 
     @Test
-    fun `unexpected validation exception is bounded as temporary no-op`() = runTest {
-        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+    fun `unexpected validation exception is not swallowed as temporary failure`() = runTest {
+        val capturedFailures = mutableListOf<Throwable>()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = kotlinx.coroutines.CoroutineScope(
+            dispatcher + SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
+                capturedFailures += throwable
+            }
+        )
         val sessionManager = SessionManager()
         val logoutRepository = FakeLogoutRepository()
-        val loggedFailures = mutableListOf<Throwable>()
         val expectedFailure = IllegalStateException("unexpected validator failure")
         val observer = ForegroundSessionLifecycleObserver.createForTest(
             validateForegroundSessionUseCase = ThrowingForegroundValidationUseCase(expectedFailure),
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
             applicationScope = scope,
-            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L),
-            unexpectedFailureLogger = { loggedFailures += it }
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
         )
         val owner = TestLifecycleOwner()
 
         observer.onStart(owner)
         observer.onStart(owner)
-        scope.advanceUntilIdle()
+        advanceUntilIdle()
 
         assertEquals(1, observer.validationCount)
-        assertEquals(1, loggedFailures.size)
-        assertSame(expectedFailure, loggedFailures.single())
+        assertEquals(listOf(expectedFailure), capturedFailures)
         assertEquals(0, logoutRepository.logoutCallCount)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(null, sessionManager.reauthReason.value)
@@ -294,7 +303,9 @@ private class FakeValidationRepository(
     }
 }
 
-private class FakeLogoutRepository : AuthRepository {
+private class FakeLogoutRepository(
+    private val logoutCompletion: CompletableDeferred<Unit>? = null
+) : AuthRepository {
     var logoutCallCount: Int = 0
         private set
 
@@ -304,6 +315,7 @@ private class FakeLogoutRepository : AuthRepository {
 
     override suspend fun logout(): Result<Unit> {
         logoutCallCount += 1
+        logoutCompletion?.await()
         return Result.success(Unit)
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -1,0 +1,244 @@
+package com.example.infinite_track.presentation.main
+
+import android.content.ContextWrapper
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRefreshResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import javax.inject.Provider
+
+class ForegroundSessionLifecycleObserverTest {
+
+    @Test
+    fun `onStart validates once and ignores re-entry while running`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser()))
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(1, observer.validationCount)
+        assertEquals(1, validationRepository.syncCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+    }
+
+    @Test
+    fun `reauth required triggers logout and forced reauth state`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
+            ),
+            refreshFailureReason = AuthRefreshFailureReason.REFRESH_INVALID
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(1, logoutRepository.logoutCallCount)
+        assertTrue(sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+    }
+
+    @Test
+    fun `temporary failure does not trigger logout or forced reauth`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(ProfileSyncResult.TemporaryFailure(message = "offline"))
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(0, logoutRepository.logoutCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
+    }
+
+    private fun createUserPreference(): UserPreference {
+        val tempDir = createTempDir(prefix = "foreground-observer-")
+        val appContext = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = tempDir
+        }
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(appContext.filesDir, "user.preferences_pb") }
+        )
+        return UserPreference(dataStore)
+    }
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "Redacted User",
+        email = "redacted@example.test",
+        roleName = "Employee",
+        positionName = "Engineer",
+        divisionName = "Mobile",
+        nipNim = "EMP-001",
+        phone = "08123456789",
+        photoUrl = "https://example.test/photo.png",
+        workLocation = null,
+        programName = null,
+        employeeType = null,
+        photoUpdatedAt = "2026-06-21T00:00:00Z",
+        faceEmbedding = null
+    )
+}
+
+private class TestLifecycleOwner : LifecycleOwner {
+    override val lifecycle: Lifecycle = LifecycleRegistry(this)
+}
+
+private class FakeValidationRepository(
+    private val syncResults: MutableList<ProfileSyncResult>,
+    private val refreshFailureReason: AuthRefreshFailureReason? = null
+) : AuthRepository {
+    var syncCallCount: Int = 0
+        private set
+
+    override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+        error("Not used")
+    }
+
+    override suspend fun logout(): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun refreshSession(): Result<AuthRefreshResult> {
+        return if (refreshFailureReason == null) {
+            Result.success(AuthRefreshResult("new-access", "new-refresh", "1"))
+        } else {
+            Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = refreshFailureReason,
+                    message = "reauth"
+                )
+            )
+        }
+    }
+
+    override suspend fun syncUserProfile(): ProfileSyncResult {
+        syncCallCount += 1
+        return syncResults.removeAt(0)
+    }
+
+    override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+
+    override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+        error("Not used")
+    }
+}
+
+private class FakeLogoutRepository : AuthRepository {
+    var logoutCallCount: Int = 0
+        private set
+
+    override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+        error("Not used")
+    }
+
+    override suspend fun logout(): Result<Unit> {
+        logoutCallCount += 1
+        return Result.success(Unit)
+    }
+
+    override suspend fun refreshSession(): Result<AuthRefreshResult> {
+        error("Not used")
+    }
+
+    override suspend fun syncUserProfile(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+
+    override suspend fun saveFaceEmbedding(userId: Int, embedding: ByteArray): Result<Unit> {
+        error("Not used")
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -15,6 +15,7 @@ import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
 import com.example.infinite_track.domain.repository.AuthRefreshResult
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.ProfileSyncResult
+import com.example.infinite_track.domain.use_case.auth.ForegroundSessionValidationResult
 import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
 import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
 import kotlinx.coroutines.Job
@@ -45,7 +46,7 @@ class ForegroundSessionLifecycleObserverTest {
             syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser()))
         )
         val logoutRepository = FakeLogoutRepository()
-        val observer = ForegroundSessionLifecycleObserver(
+        val observer = ForegroundSessionLifecycleObserver.createForTest(
             validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
                 authRepository = validationRepository,
                 userPreference = userPreference,
@@ -71,19 +72,9 @@ class ForegroundSessionLifecycleObserverTest {
     fun `onStart validates once and ignores re-entry while running`() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
         val sessionManager = SessionManager()
-        val userPreference = createUserPreference().also {
-            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
-        }
-        val validationRepository = FakeValidationRepository(
-            syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser()))
-        )
         val logoutRepository = FakeLogoutRepository()
-        val observer = ForegroundSessionLifecycleObserver(
-            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
-                authRepository = validationRepository,
-                userPreference = userPreference,
-                sessionManager = sessionManager
-            ),
+        val observer = ForegroundSessionLifecycleObserver.createForTest(
+            validateForegroundSessionUseCase = FixedForegroundValidationUseCase(ForegroundSessionValidationResult.Valid),
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
             applicationScope = scope,
@@ -97,7 +88,7 @@ class ForegroundSessionLifecycleObserverTest {
         scope.advanceUntilIdle()
 
         assertEquals(1, observer.validationCount)
-        assertEquals(1, validationRepository.syncCallCount)
+        assertEquals(0, logoutRepository.logoutCallCount)
         assertFalse(sessionManager.sessionExpired.value)
     }
 
@@ -105,21 +96,10 @@ class ForegroundSessionLifecycleObserverTest {
     fun `reauth required triggers logout and forced reauth state`() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
         val sessionManager = SessionManager()
-        val userPreference = createUserPreference().also {
-            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
-        }
-        val validationRepository = FakeValidationRepository(
-            syncResults = mutableListOf(
-                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
-            ),
-            refreshFailureReason = AuthRefreshFailureReason.REFRESH_INVALID
-        )
         val logoutRepository = FakeLogoutRepository()
-        val observer = ForegroundSessionLifecycleObserver(
-            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
-                authRepository = validationRepository,
-                userPreference = userPreference,
-                sessionManager = sessionManager
+        val observer = ForegroundSessionLifecycleObserver.createForTest(
+            validateForegroundSessionUseCase = FixedForegroundValidationUseCase(
+                ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_INVALID)
             ),
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
@@ -141,18 +121,10 @@ class ForegroundSessionLifecycleObserverTest {
     fun `temporary failure does not trigger logout or forced reauth`() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
         val sessionManager = SessionManager()
-        val userPreference = createUserPreference().also {
-            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
-        }
-        val validationRepository = FakeValidationRepository(
-            syncResults = mutableListOf(ProfileSyncResult.TemporaryFailure(message = "offline"))
-        )
         val logoutRepository = FakeLogoutRepository()
-        val observer = ForegroundSessionLifecycleObserver(
-            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
-                authRepository = validationRepository,
-                userPreference = userPreference,
-                sessionManager = sessionManager
+        val observer = ForegroundSessionLifecycleObserver.createForTest(
+            validateForegroundSessionUseCase = FixedForegroundValidationUseCase(
+                ForegroundSessionValidationResult.TemporaryFailure("offline", null)
             ),
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
@@ -174,21 +146,11 @@ class ForegroundSessionLifecycleObserverTest {
     fun `unexpected validation exception is bounded as temporary no-op`() = runTest {
         val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
         val sessionManager = SessionManager()
-        val userPreference = createUserPreference().also {
-            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
-        }
-        val validationRepository = FakeValidationRepository(
-            syncResults = mutableListOf(),
-            syncException = IllegalStateException("unexpected validator failure")
-        )
         val logoutRepository = FakeLogoutRepository()
         val loggedFailures = mutableListOf<Throwable>()
-        val observer = ForegroundSessionLifecycleObserver(
-            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
-                authRepository = validationRepository,
-                userPreference = userPreference,
-                sessionManager = sessionManager
-            ),
+        val expectedFailure = IllegalStateException("unexpected validator failure")
+        val observer = ForegroundSessionLifecycleObserver.createForTest(
+            validateForegroundSessionUseCase = ThrowingForegroundValidationUseCase(expectedFailure),
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
             applicationScope = scope,
@@ -202,9 +164,8 @@ class ForegroundSessionLifecycleObserverTest {
         scope.advanceUntilIdle()
 
         assertEquals(1, observer.validationCount)
-        assertEquals(1, validationRepository.syncCallCount)
         assertEquals(1, loggedFailures.size)
-        assertSame(validationRepository.syncException, loggedFailures.single())
+        assertSame(expectedFailure, loggedFailures.single())
         assertEquals(0, logoutRepository.logoutCallCount)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(null, sessionManager.reauthReason.value)
@@ -227,16 +188,59 @@ class ForegroundSessionLifecycleObserverTest {
         email = "redacted@example.test",
         roleName = "Employee",
         positionName = "Engineer",
+        programName = null,
         divisionName = "Mobile",
         nipNim = "EMP-001",
         phone = "08123456789",
         photoUrl = "https://example.test/photo.png",
-        workLocation = null,
-        programName = null,
-        employeeType = null,
         photoUpdatedAt = "2026-06-21T00:00:00Z",
+        latitude = null,
+        longitude = null,
+        radius = null,
+        locationDescription = null,
+        locationCategoryName = null,
         faceEmbedding = null
     )
+}
+
+private class FixedForegroundValidationUseCase(
+    private val result: ForegroundSessionValidationResult
+) : ValidateForegroundSessionUseCase(
+    authRepository = FakeValidationRepository(syncResults = mutableListOf()),
+    userPreference = run {
+        val tempDir = createTempDir(prefix = "foreground-observer-fixed-")
+        val appContext = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = tempDir
+        }
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(appContext.filesDir, "user.preferences_pb") }
+        )
+        UserPreference(dataStore)
+    },
+    sessionManager = SessionManager()
+) {
+    override suspend fun invoke(): ForegroundSessionValidationResult = result
+}
+
+private class ThrowingForegroundValidationUseCase(
+    private val throwable: Throwable
+) : ValidateForegroundSessionUseCase(
+    authRepository = FakeValidationRepository(syncResults = mutableListOf()),
+    userPreference = run {
+        val tempDir = createTempDir(prefix = "foreground-observer-throwing-")
+        val appContext = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = tempDir
+        }
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(appContext.filesDir, "user.preferences_pb") }
+        )
+        UserPreference(dataStore)
+    },
+    sessionManager = SessionManager()
+) {
+    override suspend fun invoke(): ForegroundSessionValidationResult {
+        throw throwable
+    }
 }
 
 private class TestLifecycleOwner : LifecycleOwner {

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -165,7 +165,8 @@ class ForegroundSessionLifecycleObserverTest {
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
             applicationScope = scope,
-            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L),
+            unexpectedFailureLogger = { capturedFailures += it }
         )
         val owner = TestLifecycleOwner()
 
@@ -174,7 +175,8 @@ class ForegroundSessionLifecycleObserverTest {
         advanceUntilIdle()
 
         assertEquals(1, observer.validationCount)
-        assertEquals(listOf(expectedFailure), capturedFailures)
+        assertTrue(capturedFailures.isNotEmpty())
+        assertTrue(capturedFailures.all { it === expectedFailure })
         assertEquals(0, logoutRepository.logoutCallCount)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(null, sessionManager.reauthReason.value)

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
@@ -26,12 +26,46 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import javax.inject.Provider
 
 class ForegroundSessionLifecycleObserverTest {
+
+    @Test
+    fun `onStart suppresses initial cold start validation`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser()))
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(0, observer.validationCount)
+        assertEquals(0, validationRepository.syncCallCount)
+        assertEquals(0, logoutRepository.logoutCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+    }
 
     @Test
     fun `onStart validates once and ignores re-entry while running`() = runTest {
@@ -57,6 +91,7 @@ class ForegroundSessionLifecycleObserverTest {
         )
         val owner = TestLifecycleOwner()
 
+        observer.onStart(owner)
         observer.onStart(owner)
         observer.onStart(owner)
         scope.advanceUntilIdle()
@@ -94,6 +129,7 @@ class ForegroundSessionLifecycleObserverTest {
         val owner = TestLifecycleOwner()
 
         observer.onStart(owner)
+        observer.onStart(owner)
         scope.advanceUntilIdle()
 
         assertEquals(1, logoutRepository.logoutCallCount)
@@ -126,6 +162,7 @@ class ForegroundSessionLifecycleObserverTest {
         val owner = TestLifecycleOwner()
 
         observer.onStart(owner)
+        observer.onStart(owner)
         scope.advanceUntilIdle()
 
         assertEquals(0, logoutRepository.logoutCallCount)
@@ -145,6 +182,7 @@ class ForegroundSessionLifecycleObserverTest {
             syncException = IllegalStateException("unexpected validator failure")
         )
         val logoutRepository = FakeLogoutRepository()
+        val loggedFailures = mutableListOf<Throwable>()
         val observer = ForegroundSessionLifecycleObserver(
             validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
                 authRepository = validationRepository,
@@ -154,15 +192,19 @@ class ForegroundSessionLifecycleObserverTest {
             sessionManager = sessionManager,
             logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
             applicationScope = scope,
-            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L),
+            unexpectedFailureLogger = { loggedFailures += it }
         )
         val owner = TestLifecycleOwner()
 
+        observer.onStart(owner)
         observer.onStart(owner)
         scope.advanceUntilIdle()
 
         assertEquals(1, observer.validationCount)
         assertEquals(1, validationRepository.syncCallCount)
+        assertEquals(1, loggedFailures.size)
+        assertSame(validationRepository.syncException, loggedFailures.single())
         assertEquals(0, logoutRepository.logoutCallCount)
         assertFalse(sessionManager.sessionExpired.value)
         assertEquals(null, sessionManager.reauthReason.value)
@@ -204,7 +246,7 @@ private class TestLifecycleOwner : LifecycleOwner {
 private class FakeValidationRepository(
     private val syncResults: MutableList<ProfileSyncResult>,
     private val refreshFailureReason: AuthRefreshFailureReason? = null,
-    private val syncException: Throwable? = null
+    val syncException: Throwable? = null
 ) : AuthRepository {
     var syncCallCount: Int = 0
         private set

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt
@@ -7,17 +7,27 @@ import org.junit.Test
 class ForegroundSessionResumeGateTest {
 
     @Test
+    fun `skips initial cold start before allowing foreground validation`() {
+        val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+    }
+
+    @Test
     fun `acquires once and blocks while validation is still running`() {
         val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
 
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
         assertTrue(gate.tryAcquire(bootstrapInProgress = false))
         assertFalse(gate.tryAcquire(bootstrapInProgress = false))
     }
 
     @Test
-    fun `skips while bootstrap is in progress`() {
+    fun `skips while bootstrap is in progress after initial cold start`() {
         val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
 
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
         assertFalse(gate.tryAcquire(bootstrapInProgress = true))
     }
 
@@ -26,6 +36,7 @@ class ForegroundSessionResumeGateTest {
         var now = 10_000L
         val gate = ForegroundSessionResumeGate(nowMillis = { now }, debounceWindowMs = 2_000L)
 
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
         assertTrue(gate.tryAcquire(bootstrapInProgress = false))
         gate.release()
 

--- a/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt
@@ -1,0 +1,38 @@
+package com.example.infinite_track.presentation.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForegroundSessionResumeGateTest {
+
+    @Test
+    fun `acquires once and blocks while validation is still running`() {
+        val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
+    }
+
+    @Test
+    fun `skips while bootstrap is in progress`() {
+        val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+
+        assertFalse(gate.tryAcquire(bootstrapInProgress = true))
+    }
+
+    @Test
+    fun `debounces fast foreground bounce after release`() {
+        var now = 10_000L
+        val gate = ForegroundSessionResumeGate(nowMillis = { now }, debounceWindowMs = 2_000L)
+
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+        gate.release()
+
+        now = 11_000L
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
+
+        now = 12_100L
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+    }
+}

--- a/docs/adr/ADR-XXX-android-refresh-session-compat.md
+++ b/docs/adr/ADR-XXX-android-refresh-session-compat.md
@@ -40,6 +40,20 @@ Android maps backend/session outcomes to `SessionManager.ReauthReason`:
 - Tests cover model parsing, persistence, repository refresh classification, single-flight refresh, interceptor retry, session manager reason state, bootstrap behavior, login banner mapping, and logout fallback.
 - Runtime evidence must redact token, email, full name, and identifiers before being committed.
 
+## Foreground / Resume Validation Ownership
+
+Android now owns an explicit foreground/resume validation lane for Family A.
+
+This lane exists in addition to:
+
+- cold-start splash bootstrap validation; and
+- reactive protected-request refresh on `401`.
+
+When the app transitions from background to foreground, Android attempts a bounded contract-aware session validation.
+
+Terminal backend auth/session outcomes still route to forced re-auth.
+Temporary transport failures such as offline or server-down do not trigger false logout and do not clear local session state.
+
 ## References
 
 - INF-145

--- a/docs/adr/ADR-XXX-android-refresh-session-compat.md
+++ b/docs/adr/ADR-XXX-android-refresh-session-compat.md
@@ -13,13 +13,14 @@ INF-145 changes the backend auth model for non-web consumers. Android must use a
 Android will align to the INF-145 mobile contract:
 
 1. Every authenticated/mobile auth request sends `X-Client-Type: mobile`.
-2. Login reads `refresh_token` from the JSON response body.
-3. Refresh uses `POST /api/auth/refresh` with body `{ "refresh_token": "..." }`.
-4. Refresh attempts are single-flight so concurrent 401 responses share one refresh call.
-5. `AUTH_ACCESS_TOKEN_EXPIRED` triggers refresh and protected request replay.
-6. `AUTH_REFRESH_TOKEN_INVALID`, `AUTH_REFRESH_TOKEN_REVOKED`, and `AUTH_SESSION_INACTIVE` trigger forced re-auth.
-7. Transport failure while refreshing does not cause a false logout; cached session can remain usable until connectivity returns.
-8. Logout sends `refresh_token` body when available so backend can revoke the session even if access token is expired.
+2. Login and refresh prefer the backend primary native/mobile token payload: `data.auth.access_token` and `data.auth.refresh_token`.
+3. Legacy direct fields `data.token` and `data.refresh_token` remain compatibility fallbacks during backend cutover.
+4. Refresh uses `POST /api/auth/refresh` with body `{ "refresh_token": "..." }` and canonical `X-Client-Type: mobile`.
+5. Refresh attempts are single-flight so concurrent 401 responses share one refresh call.
+6. `AUTH_ACCESS_TOKEN_EXPIRED` triggers refresh and protected request replay.
+7. `AUTH_REFRESH_TOKEN_INVALID`, `AUTH_REFRESH_TOKEN_REVOKED`, and `AUTH_SESSION_INACTIVE` trigger forced re-auth.
+8. Transport failure while refreshing does not cause a false logout; cached session can remain usable until connectivity returns.
+9. Logout sends `refresh_token` body when available so backend can revoke the session even if access token is expired.
 
 ## Reauth UX Reasons
 
@@ -35,6 +36,7 @@ Android maps backend/session outcomes to `SessionManager.ReauthReason`:
 
 - Android stores refresh tokens in DataStore. Token values must never be logged.
 - Interceptor logic must parse 401 response `code` before deciding refresh vs forced re-auth.
+- Android tests now treat `data.auth.*` as the primary mobile contract and legacy direct token fields as fallback compatibility only.
 - Tests cover model parsing, persistence, repository refresh classification, single-flight refresh, interceptor retry, session manager reason state, bootstrap behavior, login banner mapping, and logout fallback.
 - Runtime evidence must redact token, email, full name, and identifiers before being committed.
 

--- a/docs/auth-runtime-evidence/RUN_2026-05-30.md
+++ b/docs/auth-runtime-evidence/RUN_2026-05-30.md
@@ -51,20 +51,20 @@ Expected evidence:
 
 Observed: _pending_
 
-## Scenario 2 — Access expired triggers auto refresh and request replay
+## Scenario 2 — Foreground / resume with expired access token triggers validation and refresh
 
 Logcat template:
 
 ```bash
-adb logcat | grep -E "AuthRefreshInterceptor|RefreshSingleFlight|SessionManager|HTTP 401|AUTH_ACCESS_TOKEN_EXPIRED"
+adb logcat | grep -E "ForegroundSessionLifecycleObserver|ValidateForegroundSessionUseCase|AuthRefreshInterceptor|RefreshSingleFlight|SessionManager|AUTH_ACCESS_TOKEN_EXPIRED"
 ```
 
 Expected:
 
-- Protected request receives `401 AUTH_ACCESS_TOKEN_EXPIRED`.
-- Android calls `POST /api/auth/refresh` once for concurrent callers.
-- Original request is replayed with a new bearer token.
-- Final protected response succeeds.
+- App returns from background to foreground.
+- Android foreground observer triggers one resume validation attempt.
+- If the access token is expired and refresh is valid, Android refreshes the session once.
+- The app remains usable without false forced logout.
 
 Observed: _pending_
 
@@ -104,13 +104,27 @@ Expected:
 
 Observed: _pending_
 
-## Scenario 5 — Offline during refresh does not perform false logout
+## Scenario 5 — Foreground / resume while offline or backend is down does not trigger false logout
+
+Expected:
+
+- App returns from background to foreground.
+- Android foreground observer triggers one resume validation attempt.
+- Validation fails temporarily due to offline / server-down transport failure.
+- Android does not clear local session state.
+- Android does not trigger misleading forced re-auth cleanup.
+
+Observed: _pending_
+
+## Scenario 6 — Offline during refresh does not perform false logout
 
 Expected:
 
 - Refresh transport fails due to network.
+- Android treats the failure as temporary / non-terminal.
 - Android keeps cached session where available.
 - No forced logout occurs.
+- Local session state is not cleared because of the transport failure.
 - User-facing banner when surfaced: `Tidak dapat memvalidasi sesi karena jaringan. Coba lagi setelah online.`
 
 Observed: _pending_

--- a/docs/auth-runtime-evidence/RUN_2026-05-30.md
+++ b/docs/auth-runtime-evidence/RUN_2026-05-30.md
@@ -4,6 +4,18 @@ Status: **PARTIAL RUNTIME VERIFICATION — INVALID SESSION UX OBSERVED, FULL LOG
 
 This document is prepared for INF-147 runtime smoke evidence. It does not claim the runtime smoke has passed yet. Fill the observed outputs only after running the app against the INF-145 backend environment.
 
+## Contract Hardening Note — 2026-06-21
+
+Android continuation work now targets the final `INF-145` native/mobile payload priority:
+
+- primary access token: `data.auth.access_token`
+- primary refresh token: `data.auth.refresh_token`
+- compatibility fallback access token: `data.token`
+- compatibility fallback refresh token: `data.refresh_token`
+- canonical mobile client header: `X-Client-Type: mobile`
+
+This note does not claim end-to-end runtime success. Scenarios below remain `Observed: _pending_` until run against a reachable backend environment with redacted evidence.
+
 ## Redaction Rules
 
 Before pasting output here, redact:

--- a/docs/superpowers/plans/2026-06-21-android-family-a-access-session-continuation.md
+++ b/docs/superpowers/plans/2026-06-21-android-family-a-access-session-continuation.md
@@ -41,7 +41,8 @@
 - Modify `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`
   - Change hardcoded header to `X-Client-Type: mobile`.
 - Modify `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`
-  - Add primary `data.auth.*` parsing tests, legacy fallback tests, and header annotation test.
+  - Add primary `data.auth.*` parsing tests and legacy fallback tests in Task 1.
+  - Add the header annotation test in Task 3 before changing the header.
 - Modify `app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt`
   - Add repository tests for primary login/refresh payloads and auth-session refresh lane.
   - Update helper constructors for nullable legacy token plus optional auth payload.
@@ -81,13 +82,11 @@ import com.example.infinite_track.data.soucre.network.request.RefreshRequest
 import com.example.infinite_track.data.soucre.network.response.LoginResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
 import com.example.infinite_track.data.soucre.network.response.RefreshResponse
-import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.google.gson.Gson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import retrofit2.http.Headers
 
 class AuthApiContractTest {
     private val gson = Gson()
@@ -227,18 +226,6 @@ class AuthApiContractTest {
     }
 
     @Test
-    fun `auth session refresh endpoint uses canonical mobile client type header`() {
-        val method = AuthSessionApiService::class.java.getMethod(
-            "refreshSession",
-            com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest::class.java
-        )
-        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
-
-        assertTrue(headers.contains("X-Client-Type: mobile"))
-        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
-    }
-
-    @Test
     fun `refresh error response parses auth code for 401 handling`() {
         val json = """
             {
@@ -265,7 +252,7 @@ Run:
 ./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest"
 ```
 
-Expected before implementation: FAIL with unresolved `resolvedAccessToken` / `resolvedRefreshToken`, missing `AuthPayload`, or header assertion failure. If Gradle exits before test execution with `Unable to establish loopback connection`, record environment-blocked verification and continue with the code changes.
+Expected before implementation: FAIL with unresolved `resolvedAccessToken` / `resolvedRefreshToken` or missing `AuthPayload`. If Gradle exits before test execution with `Unable to establish loopback connection`, record environment-blocked verification and continue with the code changes.
 
 - [ ] **Step 3: Add shared auth payload DTO**
 
@@ -351,7 +338,7 @@ Run:
 ./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest"
 ```
 
-Expected after DTO changes and before Task 3: token parsing tests PASS; header test FAIL while `AuthSessionApiService` still uses `android`. If the header is already corrected during this task, all tests PASS.
+Expected after DTO changes: all Task 1 contract parsing tests PASS. If Gradle loopback blocks execution, record environment-blocked verification.
 
 - [ ] **Step 7: Commit DTO and contract tests**
 
@@ -649,10 +636,35 @@ git commit -m "fix: prefer backend auth payload in Android session flow" \
 - Test: `app/src/test/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinatorTest.kt`
 
 **Interfaces:**
-- Consumes: `AuthApiContractTest.auth session refresh endpoint uses canonical mobile client type header` from Task 1.
+- Consumes: `AuthApiContractTest` plus a header-focused contract test added in this task before changing the header.
 - Produces: `AuthSessionApiService.refreshSession()` annotation uses `@Headers("X-Client-Type: mobile")`.
 
-- [ ] **Step 1: Run the header contract test and verify failure before header change**
+- [ ] **Step 1: Add the header-focused contract test before changing the header**
+
+In `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`, add these imports back:
+
+```kotlin
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
+import retrofit2.http.Headers
+```
+
+Then add this test method before changing the header:
+
+```kotlin
+@Test
+fun `auth session refresh endpoint uses canonical mobile client type header`() {
+    val method = AuthSessionApiService::class.java.getMethod(
+        "refreshSession",
+        com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest::class.java
+    )
+    val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+
+    assertTrue(headers.contains("X-Client-Type: mobile"))
+    assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
+}
+```
+
+- [ ] **Step 2: Run the header contract test and verify failure before header change**
 
 Run:
 
@@ -662,7 +674,7 @@ Run:
 
 Expected before header change: FAIL because `AuthSessionApiService.refreshSession()` contains `X-Client-Type: android`.
 
-- [ ] **Step 2: Change auth-session client type header**
+- [ ] **Step 3: Change auth-session client type header**
 
 In `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`, replace:
 
@@ -676,7 +688,7 @@ with:
 @Headers("X-Client-Type: mobile")
 ```
 
-- [ ] **Step 3: Run header and orchestration tests**
+- [ ] **Step 4: Run header and orchestration tests**
 
 Run:
 

--- a/docs/superpowers/plans/2026-06-21-android-family-a-access-session-continuation.md
+++ b/docs/superpowers/plans/2026-06-21-android-family-a-access-session-continuation.md
@@ -1,0 +1,885 @@
+# Android Family A Access Session Continuation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the existing Android Family A auth/session consumer so it prioritizes the backend primary `data.auth.*` token payload, keeps legacy token fallback, sends canonical `X-Client-Type: mobile`, and preserves existing silent-refresh orchestration.
+
+**Architecture:** Continue the existing `INF-147` Android chain. Keep token parsing in DTO/repository code, keep refresh orchestration in `AuthRefreshInterceptor` + `RefreshSingleFlightCoordinator`, keep bootstrap validation in `CheckSessionUseCase`, and keep forced re-auth state in `SessionManager`.
+
+**Tech Stack:** Kotlin, Android Gradle Plugin, Retrofit/Gson, OkHttp interceptors, DataStore, Room, Hilt, JUnit 4 unit tests.
+
+## Global Constraints
+
+- Work only in the isolated worktree branch `fix/android-family-a-access-session-continuation`.
+- Android is the Family A consumer; backend `INF-145` is the source of truth for auth/session validity.
+- Scope is Android-only; do not work on Web FE or backend issues except as contract context.
+- Canonical Android mobile auth header is `X-Client-Type: mobile`.
+- Token payload priority is `data.auth.access_token` then legacy `data.token`, and `data.auth.refresh_token` then legacy `data.refresh_token`.
+- Temporary refresh failures such as offline, timeout, server-down, malformed temporary response, or unknown 5xx must not clear local session.
+- Terminal auth failures `AUTH_REFRESH_TOKEN_INVALID`, `AUTH_REFRESH_TOKEN_REVOKED`, and `AUTH_SESSION_INACTIVE` must force full re-auth.
+- Runtime-sensitive Family A closure needs emulator/device evidence against a reachable backend; without it, status remains `Needs Verification`.
+- Do not print or commit token values, email, full name, identifiers, Firebase config, keystore material, or auth-bearing logs.
+- Existing Gradle baseline in this environment can fail before tests with `java.io.IOException: Unable to establish loopback connection`; if it appears, record it as environment-blocked verification, not test failure.
+
+---
+
+## File Structure
+
+- Create `app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt`
+  - Holds the primary backend auth token payload DTO used by login and refresh responses.
+- Modify `app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt`
+  - Add optional `auth` payload to `UserData`.
+  - Make legacy `token` nullable with a default.
+  - Add `resolvedAccessToken()` and `resolvedRefreshToken()` methods.
+- Modify `app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt`
+  - Add optional `auth` payload to `AuthData`.
+  - Make legacy `token` nullable with a default.
+  - Add `resolvedAccessToken()` and `resolvedRefreshToken()` methods.
+- Modify `app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt`
+  - Use token resolver methods for login and refresh.
+  - Call `AuthSessionApiService.refreshSession()` for refresh rather than the protected `ApiService.refresh()` lane.
+- Modify `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`
+  - Change hardcoded header to `X-Client-Type: mobile`.
+- Modify `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`
+  - Add primary `data.auth.*` parsing tests, legacy fallback tests, and header annotation test.
+- Modify `app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt`
+  - Add repository tests for primary login/refresh payloads and auth-session refresh lane.
+  - Update helper constructors for nullable legacy token plus optional auth payload.
+- Modify `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+  - Document primary `data.auth.*` priority and legacy fallback.
+  - Document canonical `mobile` client type.
+- Modify `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+  - Add a contract-hardening note if runtime verification remains blocked.
+
+---
+
+### Task 1: Add primary auth payload DTO and contract parsing tests
+
+**Files:**
+- Create: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt`
+- Test: `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`
+
+**Interfaces:**
+- Consumes: Gson parsing of `LoginResponse`, `RefreshResponse`, and `RefreshErrorResponse`.
+- Produces:
+  - `data class AuthPayload(val accessToken: String? = null, val refreshToken: String? = null)`
+  - `fun UserData.resolvedAccessToken(): String`
+  - `fun UserData.resolvedRefreshToken(): String?`
+  - `fun AuthData.resolvedAccessToken(): String`
+  - `fun AuthData.resolvedRefreshToken(): String?`
+
+- [ ] **Step 1: Write failing contract tests for primary and legacy token payloads**
+
+Replace `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt` with:
+
+```kotlin
+package com.example.infinite_track.data.soucre.network
+
+import com.example.infinite_track.data.soucre.network.request.RefreshRequest
+import com.example.infinite_track.data.soucre.network.response.LoginResponse
+import com.example.infinite_track.data.soucre.network.response.RefreshErrorResponse
+import com.example.infinite_track.data.soucre.network.response.RefreshResponse
+import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.http.Headers
+
+class AuthApiContractTest {
+    private val gson = Gson()
+
+    @Test
+    fun `mobile login response parses primary auth token payload`() {
+        val json = """
+            {
+              "success": true,
+              "message": "Login success",
+              "data": {
+                "id": 147,
+                "full_name": "Redacted User",
+                "email": "redacted@example.test",
+                "role_name": "Student",
+                "position_name": "Learner",
+                "program_name": "Infinite Learning",
+                "division_name": "Mobile",
+                "nip_nim": "NIM-REDACTED",
+                "phone": "0000000000",
+                "photo": "https://example.test/avatar.png",
+                "photo_updated_at": "2026-05-30T00:00:00Z",
+                "location": {
+                  "latitude": -6.2,
+                  "longitude": 106.8,
+                  "radius": 100,
+                  "description": "Redacted office",
+                  "category_name": "Office"
+                },
+                "auth": {
+                  "access_token": "primary-access-token-redacted",
+                  "refresh_token": "primary-refresh-token-redacted"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, LoginResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals("primary-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("primary-refresh-token-redacted", response.data.resolvedRefreshToken())
+    }
+
+    @Test
+    fun `mobile login response falls back to legacy direct token fields`() {
+        val json = """
+            {
+              "success": true,
+              "message": "Login success",
+              "data": {
+                "id": 147,
+                "full_name": "Redacted User",
+                "email": "redacted@example.test",
+                "role_name": "Student",
+                "position_name": "Learner",
+                "program_name": "Infinite Learning",
+                "division_name": "Mobile",
+                "nip_nim": "NIM-REDACTED",
+                "phone": "0000000000",
+                "photo": "https://example.test/avatar.png",
+                "photo_updated_at": "2026-05-30T00:00:00Z",
+                "location": {
+                  "latitude": -6.2,
+                  "longitude": 106.8,
+                  "radius": 100,
+                  "description": "Redacted office",
+                  "category_name": "Office"
+                },
+                "token": "legacy-access-token-redacted",
+                "refresh_token": "legacy-refresh-token-redacted"
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, LoginResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals("legacy-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("legacy-refresh-token-redacted", response.data.resolvedRefreshToken())
+    }
+
+    @Test
+    fun `refresh request serializes refresh token for backend json contract`() {
+        val json = gson.toJson(RefreshRequest(refreshToken = "refresh-token-redacted"))
+
+        assertEquals("{\"refresh_token\":\"refresh-token-redacted\"}", json)
+    }
+
+    @Test
+    fun `refresh success response parses primary auth token payload`() {
+        val json = """
+            {
+              "success": true,
+              "code": null,
+              "message": "Refresh success",
+              "data": {
+                "id": 147,
+                "auth": {
+                  "access_token": "primary-new-access-token-redacted",
+                  "refresh_token": "primary-new-refresh-token-redacted"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, RefreshResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals(147, response.data.id)
+        assertEquals("primary-new-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("primary-new-refresh-token-redacted", response.data.resolvedRefreshToken())
+        assertEquals("Refresh success", response.message)
+    }
+
+    @Test
+    fun `refresh success response falls back to legacy direct token fields`() {
+        val json = """
+            {
+              "success": true,
+              "code": null,
+              "message": "Refresh success",
+              "data": {
+                "id": 147,
+                "token": "legacy-new-access-token-redacted",
+                "refresh_token": "legacy-new-refresh-token-redacted"
+              }
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, RefreshResponse::class.java)
+
+        assertTrue(response.success)
+        assertEquals(147, response.data.id)
+        assertEquals("legacy-new-access-token-redacted", response.data.resolvedAccessToken())
+        assertEquals("legacy-new-refresh-token-redacted", response.data.resolvedRefreshToken())
+    }
+
+    @Test
+    fun `auth session refresh endpoint uses canonical mobile client type header`() {
+        val method = AuthSessionApiService::class.java.getMethod(
+            "refreshSession",
+            com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest::class.java
+        )
+        val headers = method.getAnnotation(Headers::class.java)?.value?.toList().orEmpty()
+
+        assertTrue(headers.contains("X-Client-Type: mobile"))
+        assertFalse(headers.any { it.equals("X-Client-Type: android", ignoreCase = true) })
+    }
+
+    @Test
+    fun `refresh error response parses auth code for 401 handling`() {
+        val json = """
+            {
+              "success": false,
+              "code": "AUTH_SESSION_INACTIVE",
+              "message": "Session inactive for more than 48 hours"
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, RefreshErrorResponse::class.java)
+
+        assertFalse(response.success)
+        assertEquals("AUTH_SESSION_INACTIVE", response.code)
+        assertEquals("Session inactive for more than 48 hours", response.message)
+    }
+}
+```
+
+- [ ] **Step 2: Run contract tests and verify they fail before implementation**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest"
+```
+
+Expected before implementation: FAIL with unresolved `resolvedAccessToken` / `resolvedRefreshToken`, missing `AuthPayload`, or header assertion failure. If Gradle exits before test execution with `Unable to establish loopback connection`, record environment-blocked verification and continue with the code changes.
+
+- [ ] **Step 3: Add shared auth payload DTO**
+
+Create `app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt`:
+
+```kotlin
+package com.example.infinite_track.data.soucre.network.response
+
+import com.google.gson.annotations.SerializedName
+
+data class AuthPayload(
+    @SerializedName("access_token") val accessToken: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null
+)
+```
+
+- [ ] **Step 4: Update login response DTO with primary-token resolver methods**
+
+Replace `UserData` in `app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt` with:
+
+```kotlin
+data class UserData(
+    @SerializedName("id") val id: Int,
+    @SerializedName("full_name") val fullName: String,
+    @SerializedName("email") val email: String,
+    @SerializedName("role_name") val roleName: String,
+    @SerializedName("position_name") val positionName: String,
+    @SerializedName("program_name") val programName: String,
+    @SerializedName("division_name") val divisionName: String,
+    @SerializedName("nip_nim") val nipNim: String,
+    @SerializedName("phone") val phone: String,
+    @SerializedName("photo") val photo: String,
+    @SerializedName("photo_updated_at") val photoUpdatedAt: String,
+    @SerializedName("location") val location: LocationData,
+    @SerializedName("token") val token: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null,
+    @SerializedName("auth") val auth: AuthPayload? = null
+) {
+    fun resolvedAccessToken(): String {
+        return auth?.accessToken?.takeIf { it.isNotBlank() }
+            ?: token.orEmpty()
+    }
+
+    fun resolvedRefreshToken(): String? {
+        return auth?.refreshToken?.takeIf { it.isNotBlank() }
+            ?: refreshToken?.takeIf { it.isNotBlank() }
+    }
+}
+```
+
+Keep `LoginResponse` and `LocationData` unchanged except for the new `UserData` body.
+
+- [ ] **Step 5: Update refresh response DTO with primary-token resolver methods**
+
+Replace `AuthData` in `app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt` with:
+
+```kotlin
+data class AuthData(
+    @SerializedName("id") val id: Int,
+    @SerializedName("token") val token: String? = null,
+    @SerializedName("refresh_token") val refreshToken: String? = null,
+    @SerializedName("auth") val auth: AuthPayload? = null
+) {
+    fun resolvedAccessToken(): String {
+        return auth?.accessToken?.takeIf { it.isNotBlank() }
+            ?: token.orEmpty()
+    }
+
+    fun resolvedRefreshToken(): String? {
+        return auth?.refreshToken?.takeIf { it.isNotBlank() }
+            ?: refreshToken?.takeIf { it.isNotBlank() }
+    }
+}
+```
+
+Keep `RefreshResponse`, `RefreshErrorResponse`, `RefreshSessionResponse`, and `RefreshSessionData` aliases unchanged.
+
+- [ ] **Step 6: Run contract tests and verify DTO behavior passes except header if not changed yet**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest"
+```
+
+Expected after DTO changes and before Task 3: token parsing tests PASS; header test FAIL while `AuthSessionApiService` still uses `android`. If the header is already corrected during this task, all tests PASS.
+
+- [ ] **Step 7: Commit DTO and contract tests**
+
+Run:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt \
+  app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt \
+  app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt \
+  app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+
+git commit -m "test: cover Android auth payload contract" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Use primary token resolvers in repository login and refresh
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt`
+- Test: `app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt`
+
+**Interfaces:**
+- Consumes:
+  - `UserData.resolvedAccessToken(): String`
+  - `UserData.resolvedRefreshToken(): String?`
+  - `AuthData.resolvedAccessToken(): String`
+  - `AuthData.resolvedRefreshToken(): String?`
+  - `AuthSessionApiService.refreshSession(request: RefreshSessionRequest): RefreshSessionResponse`
+- Produces:
+  - `AuthRepositoryImpl.login()` persists tokens resolved from primary `data.auth.*` first.
+  - `AuthRepositoryImpl.refreshSession()` calls the auth-session lane and persists tokens resolved from primary `data.auth.*` first.
+
+- [ ] **Step 1: Add repository tests for primary login and primary refresh payloads**
+
+In `app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt`, add import:
+
+```kotlin
+import com.example.infinite_track.data.soucre.network.response.AuthPayload
+```
+
+Add these tests near the existing login and refresh tests:
+
+```kotlin
+@Test
+fun `login persists primary auth token payload before legacy direct fields`() = runBlocking {
+    val userPreference = createUserPreference()
+    val userDao = CapturingUserDao()
+    val repository = createLoginRepository(
+        userPreference = userPreference,
+        userDao = userDao,
+        userData = createUserData(refreshToken = "legacy-refresh").copy(
+            token = "legacy-access",
+            auth = AuthPayload(
+                accessToken = "primary-access",
+                refreshToken = "primary-refresh"
+            )
+        )
+    )
+
+    val result = repository.login(LoginRequest(email = "user@example.com", password = "secret"))
+
+    assertTrue(result.isSuccess)
+    assertEquals("primary-access", userPreference.getAuthToken().first())
+    assertEquals("primary-refresh", userPreference.getRefreshToken().first())
+    assertEquals("10", userPreference.getUserId().first())
+}
+
+@Test
+fun `refresh session uses auth session api and stores primary auth token payload`() = runBlocking {
+    val userPreference = createUserPreference()
+    userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+    val fakeAuthSessionApi = FakeAuthSessionApiService(
+        refreshSessionBlock = {
+            RefreshSessionResponse(
+                success = true,
+                message = "ok",
+                data = RefreshSessionData(
+                    id = 10,
+                    token = "legacy-new-access",
+                    refreshToken = "legacy-new-refresh",
+                    auth = AuthPayload(
+                        accessToken = "primary-new-access",
+                        refreshToken = "primary-new-refresh"
+                    )
+                )
+            )
+        }
+    )
+
+    val repository = AuthRepositoryImpl(
+        userPreference = userPreference,
+        apiService = FakeApiService(
+            refreshBlock = {
+                throw AssertionError("refresh must use AuthSessionApiService, not protected ApiService")
+            }
+        ),
+        authSessionApiService = fakeAuthSessionApi,
+        userDao = FakeUserDao()
+    )
+
+    val result = repository.refreshSession()
+
+    assertTrue(result.isSuccess)
+    assertEquals("primary-new-access", userPreference.getAuthToken().first())
+    assertEquals("primary-new-refresh", userPreference.getRefreshToken().first())
+    assertEquals("old-refresh", fakeAuthSessionApi.lastRefreshRequest?.refreshToken)
+}
+```
+
+- [ ] **Step 2: Update test helper to allow auth payload values**
+
+Replace the helper `createUserData(refreshToken: String?): UserData` with:
+
+```kotlin
+private fun createUserData(refreshToken: String?): UserData {
+    return UserData(
+        id = 10,
+        fullName = "Test User",
+        email = "user@example.com",
+        roleName = "staff",
+        positionName = "Engineer",
+        programName = "Program",
+        divisionName = "Division",
+        nipNim = "12345",
+        phone = "08123456789",
+        photo = "photo.jpg",
+        photoUpdatedAt = "2026-01-01T00:00:00Z",
+        location = LocationData(
+            latitude = -0.9,
+            longitude = 119.8,
+            radius = 100,
+            description = "Office",
+            categoryName = "WFO"
+        ),
+        token = "access-token",
+        refreshToken = refreshToken,
+        auth = null
+    )
+}
+```
+
+- [ ] **Step 3: Run the targeted repository tests and verify failure before implementation**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.repository.auth.AuthRepositoryImplRefreshSessionTest"
+```
+
+Expected before repository changes: the new primary login test stores legacy values, and the new refresh-lane test throws `AssertionError("refresh must use AuthSessionApiService, not protected ApiService")`.
+
+- [ ] **Step 4: Update repository imports**
+
+In `app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt`, replace:
+
+```kotlin
+import com.example.infinite_track.data.soucre.network.request.RefreshRequest
+```
+
+with:
+
+```kotlin
+import com.example.infinite_track.data.soucre.network.request.RefreshSessionRequest
+```
+
+- [ ] **Step 5: Update refreshSession implementation to use auth-session lane and resolver methods**
+
+Inside `AuthRepositoryImpl.refreshSession()`, replace:
+
+```kotlin
+val refreshData = apiService.refresh(
+    RefreshRequest(refreshToken = existingRefreshToken)
+).data
+
+if (refreshData.token.isBlank() || refreshData.id <= 0) {
+    val error = IllegalStateException("Invalid refresh session payload")
+    safeLogError("Refresh session returned invalid payload", error)
+    return Result.failure(
+        AuthRefreshException(
+            kind = AuthRefreshFailureKind.TRANSIENT,
+            reason = AuthRefreshFailureReason.INVALID_PAYLOAD,
+            message = "Invalid refresh session payload",
+            cause = error
+        )
+    )
+}
+
+val refreshedUserId = refreshData.id.toString()
+val refreshTokenToStore = refreshData.refreshToken?.takeIf { it.isNotBlank() } ?: existingRefreshToken
+
+userPreference.saveSession(
+    token = refreshData.token,
+    userId = refreshedUserId,
+    refreshToken = refreshTokenToStore,
+    lastRefreshAt = System.currentTimeMillis()
+)
+Result.success(
+    AuthRefreshResult(
+        token = refreshData.token,
+        refreshToken = refreshTokenToStore,
+        userId = refreshedUserId
+    )
+)
+```
+
+with:
+
+```kotlin
+val refreshData = authSessionApiService.refreshSession(
+    RefreshSessionRequest(refreshToken = existingRefreshToken)
+).data
+val accessToken = refreshData.resolvedAccessToken()
+
+if (accessToken.isBlank() || refreshData.id <= 0) {
+    val error = IllegalStateException("Invalid refresh session payload")
+    safeLogError("Refresh session returned invalid payload", error)
+    return Result.failure(
+        AuthRefreshException(
+            kind = AuthRefreshFailureKind.TRANSIENT,
+            reason = AuthRefreshFailureReason.INVALID_PAYLOAD,
+            message = "Invalid refresh session payload",
+            cause = error
+        )
+    )
+}
+
+val refreshedUserId = refreshData.id.toString()
+val refreshTokenToStore = refreshData.resolvedRefreshToken() ?: existingRefreshToken
+
+userPreference.saveSession(
+    token = accessToken,
+    userId = refreshedUserId,
+    refreshToken = refreshTokenToStore,
+    lastRefreshAt = System.currentTimeMillis()
+)
+Result.success(
+    AuthRefreshResult(
+        token = accessToken,
+        refreshToken = refreshTokenToStore,
+        userId = refreshedUserId
+    )
+)
+```
+
+- [ ] **Step 6: Update login implementation to use resolver methods**
+
+Inside `AuthRepositoryImpl.login()`, replace:
+
+```kotlin
+val accessToken = loginData.token.takeIf { it.isNotBlank() }
+    ?: return Result.failure(IllegalStateException("Login response missing usable access token"))
+val refreshToken = loginData.refreshToken?.takeIf { it.isNotBlank() }
+```
+
+with:
+
+```kotlin
+val accessToken = loginData.resolvedAccessToken().takeIf { it.isNotBlank() }
+    ?: return Result.failure(IllegalStateException("Login response missing usable access token"))
+val refreshToken = loginData.resolvedRefreshToken()
+```
+
+- [ ] **Step 7: Run repository tests and verify pass**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.repository.auth.AuthRepositoryImplRefreshSessionTest"
+```
+
+Expected after implementation: PASS. If Gradle loopback blocks execution, record the exact Gradle error and continue to static review and remaining tasks.
+
+- [ ] **Step 8: Commit repository token resolver integration**
+
+Run:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt \
+  app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+
+git commit -m "fix: prefer backend auth payload in Android session flow" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Normalize auth-session client type to mobile and preserve refresh orchestration
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`
+- Test: `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`
+- Test: `app/src/test/java/com/example/infinite_track/di/auth/AuthRefreshInterceptorTest.kt`
+- Test: `app/src/test/java/com/example/infinite_track/di/auth/RefreshSingleFlightCoordinatorTest.kt`
+
+**Interfaces:**
+- Consumes: `AuthApiContractTest.auth session refresh endpoint uses canonical mobile client type header` from Task 1.
+- Produces: `AuthSessionApiService.refreshSession()` annotation uses `@Headers("X-Client-Type: mobile")`.
+
+- [ ] **Step 1: Run the header contract test and verify failure before header change**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest.auth session refresh endpoint uses canonical mobile client type header"
+```
+
+Expected before header change: FAIL because `AuthSessionApiService.refreshSession()` contains `X-Client-Type: android`.
+
+- [ ] **Step 2: Change auth-session client type header**
+
+In `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`, replace:
+
+```kotlin
+@Headers("X-Client-Type: android")
+```
+
+with:
+
+```kotlin
+@Headers("X-Client-Type: mobile")
+```
+
+- [ ] **Step 3: Run header and orchestration tests**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest \
+  --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest" \
+  --tests "com.example.infinite_track.di.auth.AuthRefreshInterceptorTest" \
+  --tests "com.example.infinite_track.di.auth.RefreshSingleFlightCoordinatorTest"
+```
+
+Expected after header change: PASS. These tests confirm canonical client type, protected request retry behavior, temporary refresh failure preservation, forced re-auth behavior, and single-flight refresh dedupe.
+
+- [ ] **Step 4: Commit client-type normalization**
+
+Run:
+
+```bash
+git add app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt \
+  app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt
+
+git commit -m "fix: use mobile client type for auth session refresh" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update ADR and runtime evidence notes
+
+**Files:**
+- Modify: `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+- Modify: `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+
+**Interfaces:**
+- Consumes: implementation from Tasks 1-3.
+- Produces: docs that state Android's final Family A consumer contract and honest verification status.
+
+- [ ] **Step 1: Update ADR decision section**
+
+In `docs/adr/ADR-XXX-android-refresh-session-compat.md`, replace decision bullets 2 and 3:
+
+```markdown
+2. Login reads `refresh_token` from the JSON response body.
+3. Refresh uses `POST /api/auth/refresh` with body `{ "refresh_token": "..." }`.
+```
+
+with:
+
+```markdown
+2. Login and refresh prefer the backend primary native/mobile token payload: `data.auth.access_token` and `data.auth.refresh_token`.
+3. Legacy direct fields `data.token` and `data.refresh_token` remain compatibility fallbacks during backend cutover.
+4. Refresh uses `POST /api/auth/refresh` with body `{ "refresh_token": "..." }` and canonical `X-Client-Type: mobile`.
+```
+
+Then renumber the following bullets so the list remains sequential.
+
+- [ ] **Step 2: Update ADR consequences section**
+
+In the same ADR, add this bullet under `## Consequences`:
+
+```markdown
+- Android tests now treat `data.auth.*` as the primary mobile contract and legacy direct token fields as fallback compatibility only.
+```
+
+- [ ] **Step 3: Update runtime evidence document with contract-hardening note**
+
+In `docs/auth-runtime-evidence/RUN_2026-05-30.md`, add this section after the status paragraph:
+
+```markdown
+## Contract Hardening Note — 2026-06-21
+
+Android continuation work now targets the final `INF-145` native/mobile payload priority:
+
+- primary access token: `data.auth.access_token`
+- primary refresh token: `data.auth.refresh_token`
+- compatibility fallback access token: `data.token`
+- compatibility fallback refresh token: `data.refresh_token`
+- canonical mobile client header: `X-Client-Type: mobile`
+
+This note does not claim end-to-end runtime success. Scenarios below remain `Observed: _pending_` until run against a reachable backend environment with redacted evidence.
+```
+
+- [ ] **Step 4: Run docs diff review**
+
+Run:
+
+```bash
+git diff -- docs/adr/ADR-XXX-android-refresh-session-compat.md docs/auth-runtime-evidence/RUN_2026-05-30.md
+```
+
+Expected: diff only mentions token payload priority, legacy fallback, canonical mobile header, and verification status. No secret values appear.
+
+- [ ] **Step 5: Commit docs updates**
+
+Run:
+
+```bash
+git add docs/adr/ADR-XXX-android-refresh-session-compat.md \
+  docs/auth-runtime-evidence/RUN_2026-05-30.md
+
+git commit -m "docs: clarify Android auth payload contract" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Run verification and prepare handoff evidence
+
+**Files:**
+- Read: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/AuthPayload.kt`
+- Read: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt`
+- Read: `app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt`
+- Read: `app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt`
+- Read: `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`
+- Read: `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+- Read: `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+
+**Interfaces:**
+- Consumes: all code and docs from Tasks 1-4.
+- Produces: final verification summary and PR-ready notes.
+
+- [ ] **Step 1: Run targeted Family A unit tests**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest \
+  --tests "com.example.infinite_track.data.soucre.network.AuthApiContractTest" \
+  --tests "com.example.infinite_track.data.repository.auth.AuthRepositoryImplRefreshSessionTest" \
+  --tests "com.example.infinite_track.di.auth.AuthRefreshInterceptorTest" \
+  --tests "com.example.infinite_track.di.auth.RefreshSingleFlightCoordinatorTest" \
+  --tests "com.example.infinite_track.domain.use_case.auth.CheckSessionUseCaseTest" \
+  --tests "com.example.infinite_track.domain.manager.SessionManagerTest" \
+  --tests "com.example.infinite_track.presentation.screen.auth.LoginViewModelReauthTest" \
+  --tests "com.example.infinite_track.presentation.screen.splash.SplashViewModelTest"
+```
+
+Expected in healthy Gradle environment: PASS. If Gradle fails with loopback before executing tests, record the exact failure as environment-blocked verification.
+
+- [ ] **Step 2: Run broader local gates**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest
+./gradlew app:assembleDebug
+./gradlew app:lint
+```
+
+Expected in healthy Gradle environment: PASS. If any command cannot start because of the loopback issue, do not claim test failure; report the Gradle startup blocker.
+
+- [ ] **Step 3: Check code diff for scope discipline**
+
+Run:
+
+```bash
+git diff --stat origin/develop...HEAD
+git diff --name-only origin/develop...HEAD
+```
+
+Expected changed paths are limited to auth/session DTOs, repository, auth-session service, tests, ADR/evidence docs, and the spec/plan docs.
+
+- [ ] **Step 4: Inspect for accidental secret exposure**
+
+Run:
+
+```bash
+git diff origin/develop...HEAD -- docs app/src/main/java app/src/test/java
+```
+
+Expected: no access token values, refresh token values, email, full name, phone, NIP/NIM, Firebase config, keystore, Mapbox token, or auth-bearing logs. Test fixtures must keep redacted values such as `primary-access-token-redacted`.
+
+- [ ] **Step 5: Prepare final notes**
+
+Use this final summary shape:
+
+```markdown
+Fact
+- Continued Android Family A from existing INF-147 chain.
+- Android now prioritizes `data.auth.access_token` / `data.auth.refresh_token` with legacy fallback.
+- Auth-session refresh uses canonical `X-Client-Type: mobile`.
+
+Mismatch
+- Linear INF-147 still shows Backlog despite merged Android PR history and this continuation work.
+
+Risk
+- Runtime Family A behavior still needs emulator/device/backend evidence before Done.
+
+Needs Verification
+- Include exact Gradle command results.
+- If Gradle loopback blocked tests, include the exact `Unable to establish loopback connection` failure.
+- Include missing runtime scenarios: expired access -> silent refresh success, invalid/revoked refresh -> full re-auth, inactivity > 48h -> full re-auth, offline/server down -> no false logout, concurrent refresh storm prevention.
+
+Recommendation
+- Open PR from `fix/android-family-a-access-session-continuation` to `develop` after local Gradle environment can run targeted tests, or mark PR as requiring human runtime verification if environment remains blocked.
+```
+
+- [ ] **Step 6: Commit final evidence changes only if a file changed**
+
+If Task 5 updates no files, do not create an empty commit. If an evidence file is updated with fresh redacted runtime or command evidence, run:
+
+```bash
+git add docs/auth-runtime-evidence/RUN_2026-05-30.md
+
+git commit -m "docs: update Android auth runtime evidence" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-06-21-android-family-a-foreground-resume-session.md
+++ b/docs/superpowers/plans/2026-06-21-android-family-a-foreground-resume-session.md
@@ -1,0 +1,1103 @@
+# Android Family A Foreground / Resume Session Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicit foreground/resume session validation owner so Android revalidates backend session truth when the app returns to the foreground, without false logout on temporary transport failures.
+
+**Architecture:** Keep the existing Family A auth stack intact. Add a narrow resume-validation use case in the auth domain, a pure foreground/debounce gate in `presentation/main`, and a process-level lifecycle observer registered from `InfiniteTrackApplication`. The observer delegates contract decisions to the use case and routes terminal outcomes into the existing `SessionManager` forced re-auth lane.
+
+**Tech Stack:** Kotlin, Hilt, AndroidX Lifecycle `ProcessLifecycleOwner`, coroutines, DataStore, JUnit 4, kotlinx-coroutines-test.
+
+## Global Constraints
+
+- Work only in the isolated worktree branch `fix/android-family-a-access-session-continuation`.
+- Android is the Family A consumer; backend `INF-145` is the source of truth for auth/session validity.
+- Scope is Android-only; do not work on Web FE or backend issues except as contract context.
+- Preserve the existing `AuthRefreshInterceptor`, `RefreshSingleFlightCoordinator`, `AuthRepositoryImpl`, `SessionManager`, and cold-start `CheckSessionUseCase` architecture.
+- Do not move auth/session decisions into screen-specific UI code.
+- Temporary transport failures such as offline, timeout, or server-down must not clear local session state.
+- Terminal auth outcomes `AUTH_REFRESH_TOKEN_INVALID`, `AUTH_REFRESH_TOKEN_REVOKED`, and `AUTH_SESSION_INACTIVE` must force full re-auth.
+- Keep the solution narrow: foreground lifecycle owner + resume validator + tests + evidence/docs updates.
+- Baseline verification commands remain `./gradlew app:testDebugUnitTest`, `./gradlew app:lint`, and `./gradlew app:assembleDebug`.
+- If the local environment cannot execute verification successfully, the work must remain `Needs Verification` rather than being overstated as complete.
+
+---
+
+## File Structure
+
+- Create: `app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt`
+  - Contract-aware foreground/resume validation using existing repository/session semantics.
+- Create: `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt`
+  - Pure in-flight + debounce guard for meaningful background -> foreground transitions.
+- Create: `app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt`
+  - Hilt qualifier for the app-wide coroutine scope used by the lifecycle observer.
+- Create: `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt`
+  - Process-level lifecycle observer that triggers foreground validation and routes terminal outcomes into `SessionManager`.
+- Modify: `app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt`
+  - Registers the observer with `ProcessLifecycleOwner`.
+- Modify: `app/src/main/java/com/example/infinite_track/di/AppModule.kt`
+  - Provides the qualified application coroutine scope.
+- Modify: `app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt`
+  - Provides `ValidateForegroundSessionUseCase` to match existing use-case provisioning.
+- Modify: `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+  - Records explicit foreground/resume validation ownership.
+- Modify: `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+  - Adds the new foreground/resume runtime scenarios.
+- Test: `app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt`
+- Test: `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt`
+- Test: `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt`
+
+## Task 1: Add contract-aware foreground session validation use case
+
+**Files:**
+- Create: `app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt`
+- Test: `app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt`
+
+**Interfaces:**
+- Consumes:
+  - `AuthRepository.syncUserProfile(): ProfileSyncResult`
+  - `AuthRepository.refreshSession(): Result<AuthRefreshResult>`
+  - `UserPreference.getAuthToken(): Flow<String>`
+  - `UserPreference.getRefreshToken(): Flow<String>`
+  - `SessionManager.isBootstrapSessionInProgress: Boolean`
+- Produces:
+  - `sealed class ForegroundSessionValidationResult`
+  - `suspend operator fun ValidateForegroundSessionUseCase.invoke(): ForegroundSessionValidationResult`
+
+- [ ] **Step 1: Write the failing use-case test file**
+
+Create `app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt` with:
+
+```kotlin
+package com.example.infinite_track.domain.use_case.auth
+
+import android.content.ContextWrapper
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRefreshResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ValidateForegroundSessionUseCaseTest {
+
+    @Test
+    fun `skips when auth token or refresh token is missing`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference()
+        val repository = FakeAuthRepository()
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Skipped, result)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `skips while bootstrap session is already in progress`() = runBlocking {
+        val sessionManager = SessionManager().also { it.beginBootstrapSession() }
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser())))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Skipped, result)
+        assertEquals(0, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns valid when profile sync succeeds without refresh`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser())))
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Valid, result)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(0, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns refreshed when sync is unauthorized but refresh and retry succeed`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(),
+                ProfileSyncResult.Success(sampleUser())
+            ),
+            refreshSessionResult = Result.success(AuthRefreshResult("new-access", "new-refresh", "1"))
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(ForegroundSessionValidationResult.Refreshed, result)
+        assertEquals(2, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns reauth required when refresh fails with non refreshable reason`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = AuthRefreshFailureReason.REFRESH_REVOKED,
+                    message = "revoked"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertEquals(
+            ForegroundSessionValidationResult.ReauthRequired(SessionManager.ReauthReason.REFRESH_REVOKED),
+            result
+        )
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+    }
+
+    @Test
+    fun `returns temporary failure when refresh transport error occurs`() = runBlocking {
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("expired-access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val repository = FakeAuthRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Unauthorized()),
+            refreshSessionResult = Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.TRANSPORT,
+                    reason = AuthRefreshFailureReason.TRANSPORT_ERROR,
+                    message = "offline"
+                )
+            )
+        )
+
+        val result = ValidateForegroundSessionUseCase(repository, userPreference, sessionManager)()
+
+        assertTrue(result is ForegroundSessionValidationResult.TemporaryFailure)
+        assertEquals(1, repository.syncCallCount)
+        assertEquals(1, repository.refreshCallCount)
+        assertEquals(false, sessionManager.sessionExpired.value)
+    }
+
+    private fun createUserPreference(): UserPreference {
+        val tempDir = createTempDir(prefix = "foreground-session-")
+        val appContext = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = tempDir
+        }
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(appContext.filesDir, "user.preferences_pb") }
+        )
+        return UserPreference(dataStore)
+    }
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "Redacted User",
+        email = "redacted@example.test",
+        roleName = "Employee",
+        positionName = "Engineer",
+        divisionName = "Mobile",
+        nipNim = "EMP-001",
+        phone = "08123456789",
+        photoUrl = "https://example.test/photo.png",
+        workLocation = null,
+        programName = null,
+        employeeType = null,
+        photoUpdatedAt = "2026-06-21T00:00:00Z",
+        faceEmbedding = null
+    )
+
+    private class FakeAuthRepository(
+        private val syncResults: MutableList<ProfileSyncResult> = mutableListOf(),
+        private val refreshSessionResult: Result<AuthRefreshResult> = Result.success(
+            AuthRefreshResult("token", "refresh", "1")
+        )
+    ) : AuthRepository {
+        var syncCallCount: Int = 0
+        var refreshCallCount: Int = 0
+
+        override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+            error("Not used in this test")
+        }
+
+        override suspend fun logout(): Result<Unit> {
+            return Result.success(Unit)
+        }
+
+        override suspend fun refreshSession(): Result<AuthRefreshResult> {
+            refreshCallCount += 1
+            return refreshSessionResult
+        }
+
+        override suspend fun syncUserProfile(): ProfileSyncResult {
+            syncCallCount += 1
+            return syncResults.removeAt(0)
+        }
+
+        override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+            error("Bootstrap sync is not used by foreground validation")
+        }
+
+        override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+    }
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCaseTest"
+```
+
+Expected:
+
+- FAIL because `ValidateForegroundSessionUseCase` and `ForegroundSessionValidationResult` do not exist yet.
+
+- [ ] **Step 3: Write the minimal foreground validation use case**
+
+Create `app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt` with:
+
+```kotlin
+package com.example.infinite_track.domain.use_case.auth
+
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import kotlinx.coroutines.flow.first
+
+sealed class ForegroundSessionValidationResult {
+    data object Skipped : ForegroundSessionValidationResult()
+    data object Valid : ForegroundSessionValidationResult()
+    data object Refreshed : ForegroundSessionValidationResult()
+    data class ReauthRequired(val reason: SessionManager.ReauthReason) : ForegroundSessionValidationResult()
+    data class TemporaryFailure(val message: String?, val cause: Throwable?) : ForegroundSessionValidationResult()
+}
+
+class ValidateForegroundSessionUseCase(
+    private val authRepository: AuthRepository,
+    private val userPreference: UserPreference,
+    private val sessionManager: SessionManager
+) {
+    suspend operator fun invoke(): ForegroundSessionValidationResult {
+        val accessToken = userPreference.getAuthToken().first()
+        val refreshToken = userPreference.getRefreshToken().first()
+
+        if (accessToken.isBlank() || refreshToken.isBlank()) {
+            return ForegroundSessionValidationResult.Skipped
+        }
+
+        if (sessionManager.isBootstrapSessionInProgress) {
+            return ForegroundSessionValidationResult.Skipped
+        }
+
+        return when (val syncResult = authRepository.syncUserProfile()) {
+            is ProfileSyncResult.Success -> ForegroundSessionValidationResult.Valid
+            is ProfileSyncResult.TemporaryFailure -> ForegroundSessionValidationResult.TemporaryFailure(
+                message = syncResult.message,
+                cause = syncResult.cause
+            )
+            is ProfileSyncResult.Unauthorized -> handleUnauthorized(syncResult.reason)
+        }
+    }
+
+    private suspend fun handleUnauthorized(
+        initialReason: AuthRefreshFailureReason?
+    ): ForegroundSessionValidationResult {
+        val refreshResult = authRepository.refreshSession()
+        if (refreshResult.isSuccess) {
+            return when (val retrySync = authRepository.syncUserProfile()) {
+                is ProfileSyncResult.Success -> ForegroundSessionValidationResult.Refreshed
+                is ProfileSyncResult.TemporaryFailure -> ForegroundSessionValidationResult.TemporaryFailure(
+                    message = retrySync.message,
+                    cause = retrySync.cause
+                )
+                is ProfileSyncResult.Unauthorized -> ForegroundSessionValidationResult.ReauthRequired(
+                    reason = reauthReasonFor(preferredUnauthorizedReason(retrySync.reason, initialReason))
+                )
+            }
+        }
+
+        val refreshException = refreshResult.exceptionOrNull() as? AuthRefreshException
+        return when (refreshException?.kind) {
+            AuthRefreshFailureKind.NON_REFRESHABLE -> ForegroundSessionValidationResult.ReauthRequired(
+                reason = reauthReasonFor(preferredUnauthorizedReason(refreshException.reason, initialReason))
+            )
+            AuthRefreshFailureKind.TRANSPORT,
+            AuthRefreshFailureKind.TRANSIENT,
+            null -> ForegroundSessionValidationResult.TemporaryFailure(
+                message = refreshException?.message,
+                cause = refreshException
+            )
+        }
+    }
+
+    private fun preferredUnauthorizedReason(
+        laterReason: AuthRefreshFailureReason?,
+        initialReason: AuthRefreshFailureReason?
+    ): AuthRefreshFailureReason {
+        val fallbackReason = laterReason ?: AuthRefreshFailureReason.REFRESH_INVALID
+        return when {
+            initialReason == null -> fallbackReason
+            initialReason.isTerminalReason() && fallbackReason.isGenericReason() -> initialReason
+            else -> fallbackReason
+        }
+    }
+
+    private fun AuthRefreshFailureReason.isTerminalReason(): Boolean {
+        return this == AuthRefreshFailureReason.INACTIVITY_EXPIRED ||
+            this == AuthRefreshFailureReason.REFRESH_REVOKED
+    }
+
+    private fun AuthRefreshFailureReason.isGenericReason(): Boolean {
+        return this == AuthRefreshFailureReason.REFRESH_INVALID ||
+            this == AuthRefreshFailureReason.UNKNOWN
+    }
+
+    private fun reauthReasonFor(reason: AuthRefreshFailureReason): SessionManager.ReauthReason {
+        return when (reason) {
+            AuthRefreshFailureReason.INACTIVITY_EXPIRED -> SessionManager.ReauthReason.INACTIVITY_EXPIRED
+            AuthRefreshFailureReason.REFRESH_INVALID,
+            AuthRefreshFailureReason.MISSING_REFRESH_TOKEN -> SessionManager.ReauthReason.REFRESH_INVALID
+            AuthRefreshFailureReason.REFRESH_REVOKED -> SessionManager.ReauthReason.REFRESH_REVOKED
+            else -> SessionManager.ReauthReason.UNKNOWN
+        }
+    }
+}
+```
+
+Modify `app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt` by adding:
+
+```kotlin
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+```
+
+and:
+
+```kotlin
+@Provides
+fun provideValidateForegroundSessionUseCase(
+    authRepository: AuthRepository,
+    userPreference: UserPreference,
+    sessionManager: SessionManager
+): ValidateForegroundSessionUseCase {
+    return ValidateForegroundSessionUseCase(authRepository, userPreference, sessionManager)
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCaseTest"
+```
+
+Expected:
+
+- PASS for all six tests in `ValidateForegroundSessionUseCaseTest`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  app/src/main/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCase.kt \
+  app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt \
+  app/src/test/java/com/example/infinite_track/domain/use_case/auth/ValidateForegroundSessionUseCaseTest.kt
+
+git commit -m "feat: add foreground session validation use case"
+```
+
+## Task 2: Add foreground debounce and single-flight gate
+
+**Files:**
+- Create: `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt`
+- Test: `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt`
+
+**Interfaces:**
+- Consumes: `SessionManager.isBootstrapSessionInProgress: Boolean`
+- Produces:
+  - `class ForegroundSessionResumeGate`
+  - `fun tryAcquire(bootstrapInProgress: Boolean): Boolean`
+  - `fun release()`
+
+- [ ] **Step 1: Write the failing gate test file**
+
+Create `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt` with:
+
+```kotlin
+package com.example.infinite_track.presentation.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForegroundSessionResumeGateTest {
+
+    @Test
+    fun `acquires once and blocks while validation is still running`() {
+        val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
+    }
+
+    @Test
+    fun `skips while bootstrap is in progress`() {
+        val gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+
+        assertFalse(gate.tryAcquire(bootstrapInProgress = true))
+    }
+
+    @Test
+    fun `debounces fast foreground bounce after release`() {
+        var now = 10_000L
+        val gate = ForegroundSessionResumeGate(nowMillis = { now }, debounceWindowMs = 2_000L)
+
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+        gate.release()
+
+        now = 11_000L
+        assertFalse(gate.tryAcquire(bootstrapInProgress = false))
+
+        now = 12_100L
+        assertTrue(gate.tryAcquire(bootstrapInProgress = false))
+    }
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.presentation.main.ForegroundSessionResumeGateTest"
+```
+
+Expected:
+
+- FAIL because `ForegroundSessionResumeGate` does not exist yet.
+
+- [ ] **Step 3: Write the minimal gate implementation**
+
+Create `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt` with:
+
+```kotlin
+package com.example.infinite_track.presentation.main
+
+internal class ForegroundSessionResumeGate(
+    private val nowMillis: () -> Long = { System.currentTimeMillis() },
+    private val debounceWindowMs: Long = 2_000L
+) {
+    private var validationRunning: Boolean = false
+    private var lastStartedAtMillis: Long = Long.MIN_VALUE
+
+    @Synchronized
+    fun tryAcquire(bootstrapInProgress: Boolean): Boolean {
+        if (bootstrapInProgress) {
+            return false
+        }
+        if (validationRunning) {
+            return false
+        }
+        val now = nowMillis()
+        if (lastStartedAtMillis != Long.MIN_VALUE && now - lastStartedAtMillis < debounceWindowMs) {
+            return false
+        }
+        validationRunning = true
+        lastStartedAtMillis = now
+        return true
+    }
+
+    @Synchronized
+    fun release() {
+        validationRunning = false
+    }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.presentation.main.ForegroundSessionResumeGateTest"
+```
+
+Expected:
+
+- PASS for all three gate tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGate.kt \
+  app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionResumeGateTest.kt
+
+git commit -m "feat: add foreground session debounce gate"
+```
+
+## Task 3: Wire process-level foreground observer into the app
+
+**Files:**
+- Create: `app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/di/AppModule.kt`
+- Create: `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt`
+- Test: `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt`
+
+**Interfaces:**
+- Consumes:
+  - `ValidateForegroundSessionUseCase.invoke(): ForegroundSessionValidationResult`
+  - `SessionManager.beginSessionExpiryHandling(): Boolean`
+  - `SessionManager.triggerForcedReauth(reason: SessionManager.ReauthReason)`
+  - `LogoutUseCase.invoke(): Result<Unit>`
+  - `ForegroundSessionResumeGate.tryAcquire(bootstrapInProgress: Boolean): Boolean`
+- Produces:
+  - `@Qualifier annotation class ApplicationCoroutineScope`
+  - `class ForegroundSessionLifecycleObserver : DefaultLifecycleObserver`
+
+- [ ] **Step 1: Write the failing lifecycle observer test file**
+
+Create `app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt` with:
+
+```kotlin
+package com.example.infinite_track.presentation.main
+
+import android.content.ContextWrapper
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.example.infinite_track.data.soucre.local.preferences.UserPreference
+import com.example.infinite_track.data.soucre.network.request.LoginRequest
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.domain.repository.AuthRefreshException
+import com.example.infinite_track.domain.repository.AuthRefreshFailureKind
+import com.example.infinite_track.domain.repository.AuthRefreshFailureReason
+import com.example.infinite_track.domain.repository.AuthRefreshResult
+import com.example.infinite_track.domain.repository.AuthRepository
+import com.example.infinite_track.domain.repository.ProfileSyncResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import javax.inject.Provider
+
+class ForegroundSessionLifecycleObserverTest {
+
+    @Test
+    fun `onStart validates once and ignores re-entry while running`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(ProfileSyncResult.Success(sampleUser()))
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(1, observer.validationCount)
+        assertEquals(1, validationRepository.syncCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+    }
+
+    @Test
+    fun `reauth required triggers logout and forced reauth state`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(
+                ProfileSyncResult.Unauthorized(AuthRefreshFailureReason.REFRESH_INVALID)
+            ),
+            refreshFailureReason = AuthRefreshFailureReason.REFRESH_INVALID
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(1, logoutRepository.logoutCallCount)
+        assertTrue(sessionManager.sessionExpired.value)
+        assertEquals(SessionManager.ReauthReason.REFRESH_INVALID, sessionManager.reauthReason.value)
+    }
+
+    @Test
+    fun `temporary failure does not trigger logout or forced reauth`() = runTest {
+        val scope = TestScope(StandardTestDispatcher(testScheduler) + Job())
+        val sessionManager = SessionManager()
+        val userPreference = createUserPreference().also {
+            it.saveSession("access", userId = "1", refreshToken = "refresh", lastRefreshAt = 1L)
+        }
+        val validationRepository = FakeValidationRepository(
+            syncResults = mutableListOf(ProfileSyncResult.TemporaryFailure(message = "offline"))
+        )
+        val logoutRepository = FakeLogoutRepository()
+        val observer = ForegroundSessionLifecycleObserver(
+            validateForegroundSessionUseCase = ValidateForegroundSessionUseCase(
+                authRepository = validationRepository,
+                userPreference = userPreference,
+                sessionManager = sessionManager
+            ),
+            sessionManager = sessionManager,
+            logoutUseCaseProvider = Provider { LogoutUseCase(logoutRepository) },
+            applicationScope = scope,
+            gate = ForegroundSessionResumeGate(nowMillis = { 10_000L }, debounceWindowMs = 2_000L)
+        )
+        val owner = TestLifecycleOwner()
+
+        observer.onStart(owner)
+        scope.advanceUntilIdle()
+
+        assertEquals(0, logoutRepository.logoutCallCount)
+        assertFalse(sessionManager.sessionExpired.value)
+        assertEquals(null, sessionManager.reauthReason.value)
+    }
+
+    private fun createUserPreference(): UserPreference {
+        val tempDir = createTempDir(prefix = "foreground-observer-")
+        val appContext = object : ContextWrapper(null) {
+            override fun getFilesDir(): File = tempDir
+        }
+        val dataStore = PreferenceDataStoreFactory.create(
+            produceFile = { File(appContext.filesDir, "user.preferences_pb") }
+        )
+        return UserPreference(dataStore)
+    }
+
+    private fun sampleUser(): UserModel = UserModel(
+        id = 1,
+        fullName = "Redacted User",
+        email = "redacted@example.test",
+        roleName = "Employee",
+        positionName = "Engineer",
+        divisionName = "Mobile",
+        nipNim = "EMP-001",
+        phone = "08123456789",
+        photoUrl = "https://example.test/photo.png",
+        workLocation = null,
+        programName = null,
+        employeeType = null,
+        photoUpdatedAt = "2026-06-21T00:00:00Z",
+        faceEmbedding = null
+    )
+}
+
+private class TestLifecycleOwner : LifecycleOwner {
+    override val lifecycle: Lifecycle = LifecycleRegistry(this)
+}
+
+private class FakeValidationRepository(
+    private val syncResults: MutableList<ProfileSyncResult>,
+    private val refreshFailureReason: AuthRefreshFailureReason? = null
+) : AuthRepository {
+    var syncCallCount: Int = 0
+        private set
+
+    override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+        error("Not used")
+    }
+
+    override suspend fun logout(): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun refreshSession(): Result<AuthRefreshResult> {
+        return if (refreshFailureReason == null) {
+            Result.success(AuthRefreshResult("new-access", "new-refresh", "1"))
+        } else {
+            Result.failure(
+                AuthRefreshException(
+                    kind = AuthRefreshFailureKind.NON_REFRESHABLE,
+                    reason = refreshFailureReason,
+                    message = "reauth"
+                )
+            )
+        }
+    }
+
+    override suspend fun syncUserProfile(): ProfileSyncResult {
+        syncCallCount += 1
+        return syncResults.removeAt(0)
+    }
+
+    override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+}
+
+private class FakeLogoutRepository : AuthRepository {
+    var logoutCallCount: Int = 0
+        private set
+
+    override suspend fun login(loginRequest: LoginRequest): Result<UserModel> {
+        error("Not used")
+    }
+
+    override suspend fun logout(): Result<Unit> {
+        logoutCallCount += 1
+        return Result.success(Unit)
+    }
+
+    override suspend fun refreshSession(): Result<AuthRefreshResult> {
+        error("Not used")
+    }
+
+    override suspend fun syncUserProfile(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override suspend fun syncUserProfileForBootstrap(): ProfileSyncResult {
+        error("Not used")
+    }
+
+    override fun getLoggedInUser(): Flow<UserModel?> = flowOf(null)
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserverTest"
+```
+
+Expected:
+
+- FAIL because `ForegroundSessionLifecycleObserver` and `ApplicationCoroutineScope` do not exist yet.
+
+- [ ] **Step 3: Write the observer, scope qualifier, and application wiring**
+
+Create `app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt` with:
+
+```kotlin
+package com.example.infinite_track.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationCoroutineScope
+```
+
+Modify `app/src/main/java/com/example/infinite_track/di/AppModule.kt` by adding imports:
+
+```kotlin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+```
+
+and provider:
+
+```kotlin
+@Singleton
+@Provides
+@ApplicationCoroutineScope
+fun provideApplicationCoroutineScope(): CoroutineScope {
+    return CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+}
+```
+
+Create `app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt` with:
+
+```kotlin
+package com.example.infinite_track.presentation.main
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.example.infinite_track.di.ApplicationCoroutineScope
+import com.example.infinite_track.domain.manager.SessionManager
+import com.example.infinite_track.domain.use_case.auth.ForegroundSessionValidationResult
+import com.example.infinite_track.domain.use_case.auth.LogoutUseCase
+import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+@Singleton
+class ForegroundSessionLifecycleObserver @Inject constructor(
+    private val validateForegroundSessionUseCase: ValidateForegroundSessionUseCase,
+    private val sessionManager: SessionManager,
+    private val logoutUseCaseProvider: Provider<LogoutUseCase>,
+    @ApplicationCoroutineScope private val applicationScope: CoroutineScope,
+    private val gate: ForegroundSessionResumeGate = ForegroundSessionResumeGate()
+) : DefaultLifecycleObserver {
+
+    internal var validationCount: Int = 0
+        private set
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (!gate.tryAcquire(sessionManager.isBootstrapSessionInProgress)) {
+            return
+        }
+
+        applicationScope.launch {
+            try {
+                validationCount += 1
+                when (val result = validateForegroundSessionUseCase()) {
+                    ForegroundSessionValidationResult.Skipped -> Unit
+                    ForegroundSessionValidationResult.Valid -> Unit
+                    ForegroundSessionValidationResult.Refreshed -> Unit
+                    is ForegroundSessionValidationResult.TemporaryFailure -> Unit
+                    is ForegroundSessionValidationResult.ReauthRequired -> {
+                        if (sessionManager.beginSessionExpiryHandling()) {
+                            try {
+                                logoutUseCaseProvider.get().invoke()
+                            } finally {
+                                sessionManager.triggerForcedReauth(result.reason)
+                            }
+                        }
+                    }
+                }
+            } finally {
+                gate.release()
+            }
+        }
+    }
+}
+```
+
+Modify `app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt` by adding imports:
+
+```kotlin
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserver
+```
+
+and fields / registration:
+
+```kotlin
+@Inject
+lateinit var foregroundSessionLifecycleObserver: ForegroundSessionLifecycleObserver
+
+override fun onCreate() {
+    super.onCreate()
+
+    NotificationHelper.createNotificationChannel(this)
+    ProcessLifecycleOwner.get().lifecycle.addObserver(foregroundSessionLifecycleObserver)
+}
+```
+
+- [ ] **Step 4: Run the targeted lifecycle observer test to verify it passes**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserverTest"
+```
+
+Expected:
+
+- PASS for the three lifecycle observer tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  app/src/main/java/com/example/infinite_track/di/ApplicationCoroutineScope.kt \
+  app/src/main/java/com/example/infinite_track/di/AppModule.kt \
+  app/src/main/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserver.kt \
+  app/src/main/java/com/example/infinite_track/InfiniteTrackApplication.kt \
+  app/src/test/java/com/example/infinite_track/presentation/main/ForegroundSessionLifecycleObserverTest.kt
+
+git commit -m "feat: validate session on app foreground"
+```
+
+## Task 4: Update docs and run bounded verification
+
+**Files:**
+- Modify: `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+- Modify: `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+
+**Interfaces:**
+- Consumes:
+  - `ForegroundSessionLifecycleObserver`
+  - `ValidateForegroundSessionUseCase`
+  - existing runtime evidence format in `RUN_2026-05-30.md`
+- Produces:
+  - ADR note stating Android now owns explicit foreground/resume validation
+  - runtime evidence checklist expanded with foreground/resume scenarios
+
+- [ ] **Step 1: Add the ADR note for foreground/resume ownership**
+
+Append this section to `docs/adr/ADR-XXX-android-refresh-session-compat.md`:
+
+```markdown
+## Foreground / Resume Validation Ownership
+
+Android now owns an explicit foreground/resume validation lane for Family A.
+
+This lane exists in addition to:
+
+- cold-start splash bootstrap validation; and
+- reactive protected-request refresh on `401`.
+
+When the app transitions from background to foreground, Android attempts a bounded contract-aware session validation.
+
+Terminal backend auth/session outcomes still route to forced re-auth.
+Temporary transport failures such as offline or server-down do not trigger false logout and do not clear local session state.
+```
+
+- [ ] **Step 2: Update runtime evidence doc with the new scenario wording**
+
+In `docs/auth-runtime-evidence/RUN_2026-05-30.md`, replace the Scenario 2 section with:
+
+````markdown
+## Scenario 2 — Foreground / resume with expired access token triggers validation and refresh
+
+Logcat template:
+
+```bash
+adb logcat | grep -E "ForegroundSessionLifecycleObserver|ValidateForegroundSessionUseCase|AuthRefreshInterceptor|RefreshSingleFlight|SessionManager|AUTH_ACCESS_TOKEN_EXPIRED"
+```
+
+Expected:
+
+- App returns from background to foreground.
+- Android foreground observer triggers one resume validation attempt.
+- If the access token is expired and refresh is valid, Android refreshes the session once.
+- The app remains usable without false forced logout.
+
+Observed: _pending_
+````
+
+Then add this new section after the inactivity scenario:
+
+````markdown
+## Scenario 5 — Foreground / resume while offline or backend is down does not trigger false logout
+
+Expected:
+
+- App returns from background to foreground.
+- Android foreground observer triggers one resume validation attempt.
+- Validation fails temporarily due to offline / server-down transport failure.
+- Android does not clear local session state.
+- Android does not trigger misleading forced re-auth cleanup.
+
+Observed: _pending_
+````
+
+Renumber the old offline refresh scenario to Scenario 6 and keep its expectations aligned with the same non-terminal semantics.
+
+- [ ] **Step 3: Run the targeted test suite for the new feature**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCaseTest" --tests "com.example.infinite_track.presentation.main.ForegroundSessionResumeGateTest" --tests "com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserverTest"
+```
+
+Expected:
+
+- PASS for all new foreground/resume tests.
+
+- [ ] **Step 4: Run the repo baseline verification**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest
+./gradlew app:lint
+./gradlew app:assembleDebug
+```
+
+Expected:
+
+- PASS, or
+- if the environment still blocks KAPT / local toolchain execution, capture the exact failure and mark the work as `Needs Verification` rather than claiming success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  docs/adr/ADR-XXX-android-refresh-session-compat.md \
+  docs/auth-runtime-evidence/RUN_2026-05-30.md
+
+git commit -m "docs: record foreground session validation contract"
+```

--- a/docs/superpowers/specs/2026-06-21-android-family-a-access-session-continuation-design.md
+++ b/docs/superpowers/specs/2026-06-21-android-family-a-access-session-continuation-design.md
@@ -1,0 +1,255 @@
+# Android Family A Access & Session Continuation Design
+
+## Status
+
+Approved continuation design for Android-only Family A / Access & Session work.
+
+This is a continuation of the existing Android `INF-147` chain, not a fresh reimplementation. The goal is to harden Android as a backend-auth/session contract consumer after `INF-145` was completed on the backend.
+
+## Product-First Context
+
+Family taxonomy:
+
+- Family A = Access & Session.
+- Truth boundary = backend auth/session contract.
+- Backend is the source of truth for session validity, token lifecycle, refresh semantics, revocation, inactivity, and final auth decisions.
+- Android is a consumer and must orchestrate local runtime state truthfully against backend responses.
+
+Android must not treat cached local user/session data as proof that the backend still accepts the session. Local state can only be used as runtime input for calls to the backend contract.
+
+## Existing Chain Evidence
+
+Relevant Linear / PR chain:
+
+- `INF-145` — backend auth/session refresh contract; status Done.
+- `INF-147` — Android silent token refresh orchestration; Linear still shows Backlog, but Android repo has merged implementation evidence.
+- `INF-148` and `INF-149` — backend follow-up context only; not Android implementation scope.
+- Android PR #10 — initial Android session handling alignment.
+- Android PR #21 — Android auth continuity contract alignment.
+- Android PR #22 — Android auth bootstrap/session contract stabilization.
+
+Relevant Android docs:
+
+- `docs/superpowers/specs/2026-05-10-android-auth-continuity-refactor-design.md`
+- `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+- `docs/auth-runtime-evidence/RUN_2026-05-30.md`
+- `docs/linear-sync/INF-147-followup-2026-05-30.md`
+- `docs/linear-sync/INF-147-followup-2026-05-31-bootstrap-contract.md`
+
+Current evidence supports continuation because the Android orchestration already exists and has targeted tests. The remaining work is contract hardening and verification closure against the final backend `INF-145` shape.
+
+## Mismatch / Gap Being Addressed
+
+Backend `INF-145` final comments state that native/mobile clients should consume the primary token response shape:
+
+```json
+{
+  "data": {
+    "auth": {
+      "access_token": "...",
+      "refresh_token": "..."
+    }
+  }
+}
+```
+
+Legacy direct fields remain temporarily for compatibility:
+
+```json
+{
+  "data": {
+    "token": "...",
+    "refresh_token": "..."
+  }
+}
+```
+
+Android currently still models and tests the legacy direct fields as the main shape. Android should prefer `data.auth.access_token` / `data.auth.refresh_token` and keep legacy fields only as fallback.
+
+A second mismatch is client-type naming:
+
+- Contract and Android ADR say `X-Client-Type: mobile`.
+- `AuthRefreshInterceptor` already sends `mobile`.
+- `AuthSessionApiService` currently hardcodes `X-Client-Type: android`.
+
+The canonical Android consumer value should be `mobile` unless backend contract evidence changes.
+
+## Goals
+
+- Continue the existing Android `INF-147` implementation path instead of rewriting it.
+- Make Android prefer backend primary `data.auth.*` token fields for login and refresh.
+- Preserve compatibility with legacy `data.token` / `data.refresh_token` while backend cutover is still in progress.
+- Normalize Android auth/session client type to `X-Client-Type: mobile`.
+- Preserve current single-flight refresh orchestration and protected-request replay behavior.
+- Preserve current forced re-auth handling for invalid refresh, revoked refresh, and 48-hour inactivity.
+- Preserve temporary-failure semantics for offline/server unreachable so Android does not falsely clear auth state.
+- Update tests and ADR/evidence notes so the repo documents the final Android consumer contract accurately.
+
+## Non-Goals
+
+- Do not redefine backend token lifetime, rotation, revocation, inactivity, cleanup, or legacy-token cutover policy.
+- Do not work on Web FE.
+- Do not rework attendance, WFA, face verification, maps, notifications, or other families.
+- Do not replace the existing `AuthRefreshInterceptor`, `RefreshSingleFlightCoordinator`, `CheckSessionUseCase`, or `SessionManager` architecture unless tests expose a direct contract gap.
+- Do not claim runtime Done without emulator/device evidence against a reachable `INF-145` backend environment.
+
+## Architecture
+
+Keep the existing boundaries:
+
+- `AuthRepositoryImpl`
+  - Performs primitive auth operations.
+  - Parses backend token payloads.
+  - Classifies refresh/login/profile-sync failures.
+  - Persists tokens only after validating usable payloads.
+- `AuthRefreshInterceptor`
+  - Attaches `Authorization` and `X-Client-Type` to protected requests.
+  - Handles protected 401 responses.
+  - Refreshes and retries once for refreshable `AUTH_ACCESS_TOKEN_EXPIRED` outcomes.
+  - Triggers forced re-auth only for terminal auth outcomes.
+- `RefreshSingleFlightCoordinator`
+  - Deduplicates concurrent refresh attempts.
+- `CheckSessionUseCase`
+  - Owns bootstrap/resume validation.
+  - Syncs profile against backend truth.
+  - Refreshes and retries sync once when appropriate.
+- `SessionManager`
+  - Holds forced re-auth reason and one-shot session-expiry handling guard.
+- `UserPreference`
+  - Persists access token, refresh token, user id, and last refresh timestamp.
+
+This design intentionally avoids moving orchestration into UI screens. UI should react to domain/session outcomes; it should not decide backend truth.
+
+## Token Resolution Rules
+
+Android token resolution should use this priority:
+
+1. Access token from `data.auth.access_token`.
+2. Fallback access token from `data.token`.
+3. Refresh token from `data.auth.refresh_token`.
+4. Fallback refresh token from `data.refresh_token`.
+
+Login rules:
+
+- Login succeeds only when a usable access token is present after applying the priority above.
+- A missing refresh token remains compatibility-tolerated as an existing Android behavior, but the session is treated as non-refreshable later.
+- Persist access token, user id, optional refresh token, and refresh timestamp only after payload validation succeeds.
+- Do not persist partial session state when access token is blank or missing.
+
+Refresh rules:
+
+- Refresh request body remains `{ "refresh_token": "..." }`.
+- Refresh success requires a usable access token and valid user id after applying the priority above.
+- If a rotated refresh token is returned in `data.auth.refresh_token`, store it.
+- If only legacy `data.refresh_token` is returned, store it.
+- If no new refresh token is returned on refresh success, retain the existing refresh token.
+- Invalid payload remains temporary/transient failure and must not mutate local session data.
+
+## Client Type Rules
+
+Every authenticated/mobile auth request should use:
+
+```text
+X-Client-Type: mobile
+```
+
+This includes the auth-session refresh lane. Do not introduce `android` as a competing client type unless backend contract evidence changes.
+
+## Refresh / Re-auth Orchestration Rules
+
+Preserve existing Family A behavior:
+
+- Protected endpoint returns `401 AUTH_ACCESS_TOKEN_EXPIRED`:
+  - call single-flight refresh;
+  - retry original request once with the new access token;
+  - do not retry repeatedly.
+- Refresh returns `AUTH_REFRESH_TOKEN_INVALID`:
+  - force full re-auth with invalid reason.
+- Refresh returns `AUTH_REFRESH_TOKEN_REVOKED`:
+  - force full re-auth with revoked reason.
+- Refresh returns `AUTH_SESSION_INACTIVE` or supported inactivity alias:
+  - force full re-auth with inactivity reason.
+- Refresh transport failure / offline / server down / malformed temporary response:
+  - return temporary failure;
+  - do not call logout;
+  - do not clear local session.
+- Concurrent protected 401 responses:
+  - join one in-flight refresh attempt;
+  - avoid refresh storms.
+- Auth endpoints themselves:
+  - do not trigger interceptor refresh loops.
+
+## Affected Android Areas
+
+Expected touched areas:
+
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/response/LoginResponse.kt`
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/response/RefreshSessionResponse.kt`
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/AuthSessionApiService.kt`
+- `app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt`
+- `app/src/test/java/com/example/infinite_track/data/soucre/network/AuthApiContractTest.kt`
+- `app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt`
+- `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+- `docs/auth-runtime-evidence/RUN_2026-05-30.md` if runtime status wording needs correction.
+
+Only touch `AuthRefreshInterceptor`, `RefreshSingleFlightCoordinator`, `CheckSessionUseCase`, or `SessionManager` if targeted tests expose a direct gap.
+
+## Testing Strategy
+
+Repository/unit tests:
+
+- Login parses primary `data.auth.access_token` and `data.auth.refresh_token`.
+- Login falls back to legacy `data.token` and `data.refresh_token`.
+- Login fails and persists nothing when neither primary nor fallback access token is usable.
+- Refresh parses primary `data.auth.access_token` and `data.auth.refresh_token`.
+- Refresh falls back to legacy `data.token` and `data.refresh_token`.
+- Refresh success with no returned refresh token keeps the existing refresh token.
+- Refresh invalid/revoked/inactivity still maps to forced re-auth outcomes.
+- Refresh offline/server-down/malformed temporary response still preserves local session.
+- Auth-session refresh API uses `X-Client-Type: mobile`.
+- Existing concurrent refresh/single-flight tests remain passing.
+
+Baseline and verification commands:
+
+```bash
+./gradlew app:testDebugUnitTest
+./gradlew app:assembleDebug
+./gradlew app:lint
+```
+
+Runtime verification remains required before claiming Done for Family A:
+
+- access token expired -> silent refresh succeeds and original request is replayed;
+- refresh invalid/revoked -> full re-auth;
+- inactivity > 48 hours -> full re-auth;
+- offline/server down during refresh -> no false invalid-auth cleanup;
+- concurrent protected 401s -> one refresh attempt.
+
+If runtime verification cannot run because backend/emulator/device environment is unavailable, mark the result `Needs Verification` and update evidence docs truthfully.
+
+## Documentation / ADR Requirements
+
+This work changes auth/session contract consumption, so docs/ADR must be updated.
+
+Minimum docs update:
+
+- `docs/adr/ADR-XXX-android-refresh-session-compat.md`
+  - Android prioritizes `data.auth.access_token` / `data.auth.refresh_token`.
+  - Legacy direct fields are compatibility fallback only.
+  - Canonical `X-Client-Type` for Android mobile consumer is `mobile`.
+
+Runtime evidence docs should distinguish:
+
+- repository/unit verification;
+- emulator/device runtime verification;
+- backend-environment blockers.
+
+## Acceptance Criteria
+
+- Android continues existing `INF-147` orchestration instead of duplicating it.
+- Android login and refresh consume primary backend `data.auth.*` token payloads.
+- Android remains compatible with legacy direct token fields during backend cutover.
+- Android auth-session refresh lane sends `X-Client-Type: mobile`.
+- Silent refresh, terminal re-auth, offline temporary failure, logout/clear-session semantics, and single-flight behavior remain covered by tests.
+- Docs/ADR reflect the final backend-authored token payload priority and client type.
+- Verification status is honest: runtime-sensitive Family A closure is `Done` only with fresh emulator/device/backend evidence; otherwise `Needs Verification`.

--- a/docs/superpowers/specs/2026-06-21-android-family-a-foreground-resume-session-design.md
+++ b/docs/superpowers/specs/2026-06-21-android-family-a-foreground-resume-session-design.md
@@ -1,0 +1,374 @@
+# Android Family A Foreground / Resume Session Validation Design
+
+## Status
+
+Proposed Android-only continuation design for Family A / Access & Session.
+
+This design extends the existing Android `INF-147` session continuity chain so the app validates session truth not only on cold start and protected-request `401`, but also when the app returns to the foreground.
+
+## Problem Statement
+
+Current Android auth/session behavior already covers two important paths:
+
+1. **Cold start bootstrap** via `SplashViewModel` + `CheckSessionUseCase`.
+2. **Reactive protected-request refresh** via `AuthRefreshInterceptor` + `RefreshSingleFlightCoordinator`.
+
+However, there is no explicit owner for **app foreground / resume transition**.
+
+That means Android can return to an already-authenticated UI state after backgrounding without immediately revalidating whether the backend still accepts the session. In practice, session truth is only re-established when either:
+
+- the app is relaunched into the splash bootstrap flow, or
+- a later protected API call fails with `401` and the interceptor reacts.
+
+This leaves a contract gap against the backend truth boundary for Family A.
+
+## Contract Context
+
+Family taxonomy and shared-context rules require:
+
+- Backend is the source of truth for session validity, token lifecycle, revocation, inactivity, and final auth decisions.
+- Android is a consumer and must orchestrate local runtime truthfully against backend responses.
+- Android must not treat cached local user/session data as proof that the backend still accepts the session.
+- Temporary transport failures such as offline, timeout, or server-down must not trigger false logout or misleading auth cleanup.
+
+This design does **not** redefine backend auth/session semantics. It only ensures Android has an explicit foreground/resume validation owner that follows the existing contract.
+
+## Goals
+
+- Add an explicit Android-owned foreground/resume validation path for Family A.
+- Ensure Android revalidates session truth when the app transitions from background to foreground.
+- Reuse the existing auth/session contract handling and failure classification logic.
+- Preserve the current silent refresh / forced re-auth semantics already established in the existing `INF-147` chain.
+- Preserve truthful temporary-failure behavior for offline/server-down conditions.
+- Keep the solution narrow, bounded, and Android-only.
+
+## Non-Goals
+
+- Do not rewrite the auth stack.
+- Do not change backend error codes, refresh semantics, or inactivity rules.
+- Do not move auth/session decisions into screen-specific UI code.
+- Do not fan auth validation logic out across multiple screens.
+- Do not broaden this work into unrelated auth cleanup or attendance/navigation refactors.
+
+## Existing Architecture to Preserve
+
+The current boundaries remain valid and should be preserved:
+
+- `AuthRepositoryImpl`
+  - performs login/refresh primitives
+  - classifies refresh and profile-sync failures
+  - persists local tokens/session state
+- `AuthRefreshInterceptor`
+  - attaches authorization headers
+  - reacts to protected `401` responses
+  - refreshes and retries once where allowed
+  - triggers forced re-auth for terminal auth outcomes
+- `RefreshSingleFlightCoordinator`
+  - deduplicates concurrent refresh attempts
+- `CheckSessionUseCase`
+  - owns cold-start bootstrap validation
+  - validates refresh + profile sync during splash bootstrap
+- `SessionManager`
+  - owns forced re-auth state and one-shot session-expiry handling
+- `UserPreference`
+  - stores access token, refresh token, user id, and last refresh timestamp
+
+The foreground/resume solution should integrate with these boundaries, not replace them.
+
+## Recommended Approach
+
+Use a **process-level foreground observer** that triggers a **resume session validator** when the app transitions from background to foreground.
+
+### Why this approach
+
+This is the best fit for the contract requirement because:
+
+- it directly matches the verification scope of “app resume / foreground transition”;
+- it provides a single explicit owner for resume validation;
+- it avoids spreading auth behavior into screens;
+- it keeps auth/session semantics centralized in the domain/data stack;
+- it remains narrow enough to implement and verify without a broad rewrite.
+
+## Proposed Components
+
+### 1. Foreground lifecycle owner
+
+Add an app-level or process-level lifecycle observer whose only responsibility is to detect a **background -> foreground** transition.
+
+Responsibilities:
+
+- detect the transition to foreground;
+- trigger resume session validation once per meaningful foreground event;
+- avoid triggering during ordinary recomposition, screen navigation, or local UI state changes.
+
+Non-responsibilities:
+
+- deciding whether a session is valid;
+- handling logout directly;
+- performing UI navigation decisions.
+
+### 2. Resume session validator
+
+Add a focused validator/coordinator responsible for deciding whether and how to validate session state when the app resumes.
+
+Responsibilities:
+
+- inspect local auth/session availability;
+- determine whether validation should run or be skipped;
+- invoke the existing auth/session machinery through the correct contract-aware path;
+- surface one of the expected outcomes:
+  - valid / unchanged
+  - refreshed / still valid
+  - reauth required
+  - temporary failure
+
+Non-responsibilities:
+
+- acting as a second full splash bootstrap flow;
+- duplicating interceptor logic;
+- owning screen-specific UX.
+
+## Validation Trigger Rules
+
+The resume validator should run only on a real **background -> foreground** transition.
+
+It should **not** run for:
+
+- recomposition;
+- navigation between Compose destinations;
+- every request;
+- every activity callback that does not represent a meaningful return to foreground.
+
+## Skip Rules
+
+The validator should skip execution if any of the following conditions is true:
+
+1. **No local access token**
+   - there is no logged-in session to validate.
+
+2. **No local refresh token**
+   - the session is not refresh-capable.
+   - the validator should avoid launching an operation that cannot complete meaningfully.
+
+3. **Bootstrap session is already in progress**
+   - cold-start bootstrap owns the session validation lane during splash.
+   - resume validation must not race or double-validate against bootstrap.
+
+4. **Resume validation is already in flight**
+   - only one validation attempt should run per foreground event cluster.
+
+5. **Debounce window still active**
+   - rapid lifecycle bouncing should not create refresh storms or repeated validation.
+
+These guards exist to enforce truthfulness *and* runtime stability.
+
+## Validation Behavior
+
+When the validator runs, it should follow the existing contract-aware session semantics.
+
+### If session is still valid
+
+- no forced re-auth is triggered;
+- app continues normally.
+
+### If access token is expired but refresh is valid
+
+- session refresh should be performed through the existing auth path;
+- app continues normally after successful refresh.
+
+### If refresh is invalid, revoked, or inactive
+
+- validator should route into the existing forced re-auth lane;
+- Android should surface the same re-auth state handling already used elsewhere.
+
+### If refresh fails due to offline / server-down / transport failure
+
+- validator must not clear local session state;
+- validator must not trigger false logout;
+- result should be treated as **temporary failure / temporarily unverified session state**.
+
+This preserves the contract rule that backend truth must be respected without inventing terminal logout from temporary network unavailability.
+
+## Outcome Model
+
+The validator should conceptually produce one of these outcomes:
+
+- **Valid**
+  - session remains usable, no new action needed.
+- **Refreshed**
+  - access token was renewed successfully.
+- **ReauthRequired**
+  - backend-auth/session state is terminal and user must log in again.
+- **TemporaryFailure**
+  - backend truth could not be re-established right now due to transport or temporary failure.
+
+The exact type names can follow existing project naming conventions, but the outcome categories above should remain explicit.
+
+## Interaction with Existing Components
+
+### `CheckSessionUseCase`
+
+`CheckSessionUseCase` remains the cold-start bootstrap owner.
+
+The resume validator should not blindly reuse it as-is if doing so would re-run splash-specific behavior too heavily. Instead, the implementation should reuse the same contract semantics with a scope appropriate to foreground/resume validation.
+
+This means:
+
+- preserve bootstrap behavior for splash;
+- create a narrower resume-specific entry point if needed;
+- do not make foreground/resume validation a second full splash bootstrap.
+
+### `AuthRefreshInterceptor`
+
+Interceptor behavior remains unchanged:
+
+- protected-request `401` still triggers reactive refresh;
+- refresh still deduplicates via `RefreshSingleFlightCoordinator`;
+- forced re-auth behavior for terminal auth codes remains intact.
+
+Foreground validation complements this behavior. It does not replace it.
+
+### `SessionManager`
+
+`SessionManager` remains the source of forced re-auth state for UI handling.
+
+Foreground/resume validation should route terminal outcomes into the same `SessionManager`-based re-auth state already used for Family A.
+
+## UI / UX Principles
+
+The solution should preserve a clear separation:
+
+- lifecycle owner detects foreground transitions;
+- validator decides contract outcomes;
+- app shell reacts to forced re-auth or temporary failure state;
+- screens do not become auth decision makers.
+
+This avoids inconsistent per-screen behavior and keeps Family A session semantics centralized.
+
+## Error Handling Rules
+
+### Terminal auth outcomes
+
+The following remain terminal and must force re-auth through the existing lane:
+
+- `AUTH_REFRESH_TOKEN_INVALID`
+- `AUTH_REFRESH_TOKEN_REVOKED`
+- `AUTH_SESSION_INACTIVE`
+
+### Temporary outcomes
+
+The following remain non-terminal and must **not** force logout:
+
+- offline / no network
+- server unavailable
+- timeout / transient transport failure
+- malformed temporary payload classified as transient
+- unknown temporary 5xx-style failures where the existing stack already classifies them as non-terminal
+
+## Verification Strategy
+
+This change is only closure-worthy if it is proven at three levels.
+
+### 1. Unit / logic verification
+
+Prove that:
+
+- foreground validation runs on foreground transition;
+- skip rules are honored;
+- duplicate/in-flight triggers are suppressed;
+- outcomes are mapped correctly to valid / refreshed / reauth required / temporary failure.
+
+### 2. Integration / orchestration verification
+
+Prove that:
+
+- foreground validation does not conflict with splash bootstrap;
+- one meaningful foreground event produces one validation attempt;
+- terminal auth outcomes still flow into the existing re-auth lane;
+- transport failures still preserve local session state.
+
+### 3. Runtime verification
+
+Prove the following scenarios on emulator/device against a reachable backend environment:
+
+1. app resumes with expired access token and valid refresh token;
+2. app resumes with invalid or revoked refresh token;
+3. app resumes with inactive session / inactivity denial;
+4. app resumes while offline or while backend is unavailable.
+
+## Required Baseline Commands
+
+The existing Android verification baseline remains mandatory:
+
+```bash
+./gradlew app:testDebugUnitTest
+./gradlew app:lint
+./gradlew app:assembleDebug
+```
+
+If the local environment cannot execute these successfully, the work must remain `Needs Verification` rather than being overstated as complete.
+
+## Risks
+
+### 1. Duplicate-trigger risk
+
+A poorly scoped lifecycle hook could spam refresh attempts or create repeated re-auth handling.
+
+Mitigation:
+
+- explicit in-flight guard;
+- debounce window;
+- respect bootstrap ownership.
+
+### 2. Bootstrap collision risk
+
+Foreground validation could race against splash bootstrap if not guarded.
+
+Mitigation:
+
+- skip while bootstrap is in progress;
+- keep cold-start ownership with `CheckSessionUseCase` / splash flow.
+
+### 3. False logout risk
+
+A naive resume validator could treat transport failure as session invalidation.
+
+Mitigation:
+
+- preserve the existing distinction between terminal auth failure and temporary transport failure.
+
+### 4. Scope-creep risk
+
+This work could accidentally become a broad auth refactor.
+
+Mitigation:
+
+- keep implementation bounded to foreground owner + resume validation path + tests + evidence updates.
+
+## Definition of Done for This Design
+
+This foreground/resume contract-alignment work is done only when:
+
+- Android has an explicit foreground/resume validation owner;
+- the validator follows existing contract-aware auth/session semantics;
+- terminal outcomes trigger existing forced re-auth handling;
+- temporary failures do not clear local session;
+- unit/integration proof exists;
+- runtime evidence exists for the resume scenarios;
+- docs and closure notes are updated truthfully.
+
+Without runtime proof, the honest status remains:
+
+- implementation aligned
+- runtime closure still `Needs Verification`
+
+## Files Likely Affected
+
+The eventual implementation should remain tightly scoped. Likely touched areas:
+
+- app-level or activity-level lifecycle owner wiring
+- a new or updated resume validator / coordinator in auth/domain space
+- tests for foreground/resume validation and guard behavior
+- runtime evidence / closure notes for `INF-147`
+
+It should avoid broad changes to unrelated screens or unrelated product families.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 kotlinStdlib = "2.0.0"
 lifecycleRuntimeKtx = "2.8.4"
+lifecycleProcess = "2.8.4"
 activityCompose = "1.9.1"
 composeBom = "2024.04.01"
 loggingInterceptor = "4.9.0"
@@ -88,6 +89,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary
- align Android login/refresh consumer contract with backend mobile auth payload and client type
- add explicit foreground/resume session validation ownership for Family A auth/session
- centralize forced reauth ownership and tighten foreground observer tests
- add/update spec, plan, ADR, and runtime evidence notes for the continuation chain

## Verification
- `./gradlew app:testDebugUnitTest`
- `./gradlew app:lint`
- `./gradlew app:assembleDebug`
- `./gradlew app:testDebugUnitTest --tests com.example.infinite_track.domain.use_case.auth.ValidateForegroundSessionUseCaseTest --tests com.example.infinite_track.presentation.main.ForegroundSessionResumeGateTest --tests com.example.infinite_track.presentation.main.ForegroundSessionLifecycleObserverTest`

## Notes
- Backend remains the source of truth for session validity.
- This PR is intended to move the branch to `develop` so runtime-sensitive foreground/resume verification can be performed there.
- Runtime emulator/device verification is still required on `develop` before claiming Family A closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added foreground session validation to improve app reliability when resuming from background.

* **Bug Fixes**
  * Enhanced offline resilience to prevent false logouts due to temporary network failures.
  * Improved authentication token handling with fallback support for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->