### PR TITLE
INF-222: Add Infinite Track Material 3 UI foundation

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/button/InfiniteButton.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/button/InfiniteButton.kt
@@ -1,0 +1,132 @@
+package com.example.infinite_track.presentation.design.components.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteRadius
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+enum class InfiniteButtonVariant {
+    Primary,
+    Secondary,
+    Tonal,
+    Outlined,
+    Ghost,
+    Glass,
+    Danger,
+    Success,
+    Warning
+}
+
+enum class InfiniteButtonState {
+    Enabled,
+    Disabled,
+    Loading,
+    Selected
+}
+
+@Composable
+fun InfiniteButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    variant: InfiniteButtonVariant = InfiniteButtonVariant.Primary,
+    size: InfiniteSize = InfiniteSize.Medium,
+    state: InfiniteButtonState = InfiniteButtonState.Enabled,
+    fullWidth: Boolean = false,
+    leadingIcon: ImageVector? = null,
+    trailingIcon: ImageVector? = null
+) {
+    val enabled = state != InfiniteButtonState.Disabled && state != InfiniteButtonState.Loading
+    val colors = infiniteButtonColors(variant, selected = state == InfiniteButtonState.Selected)
+    val height = when (size) {
+        InfiniteSize.Small -> 40.dp
+        InfiniteSize.Medium -> 48.dp
+        InfiniteSize.Large -> 56.dp
+    }
+    val buttonModifier = if (fullWidth) modifier.fillMaxWidth().height(height) else modifier.height(height)
+    val content: @Composable () -> Unit = {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (state == InfiniteButtonState.Loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = colors.content
+                )
+            } else {
+                leadingIcon?.let { Icon(imageVector = it, contentDescription = null, modifier = Modifier.size(18.dp)) }
+            }
+            Text(text = text)
+            trailingIcon?.let { Icon(imageVector = it, contentDescription = null, modifier = Modifier.size(18.dp)) }
+        }
+    }
+
+    if (variant == InfiniteButtonVariant.Outlined || variant == InfiniteButtonVariant.Ghost) {
+        OutlinedButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = enabled,
+            shape = InfiniteRadius.shape(size),
+            border = if (variant == InfiniteButtonVariant.Ghost) null else BorderStroke(1.dp, colors.container),
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = colors.container,
+                disabledContentColor = colors.container.copy(alpha = 0.42f)
+            )
+        ) { content() }
+    } else {
+        Button(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = enabled,
+            shape = InfiniteRadius.shape(size),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.container,
+                contentColor = colors.content,
+                disabledContainerColor = colors.container.copy(alpha = 0.42f),
+                disabledContentColor = colors.content.copy(alpha = 0.56f)
+            ),
+            elevation = ButtonDefaults.buttonElevation(defaultElevation = if (variant == InfiniteButtonVariant.Glass) 0.dp else 3.dp)
+        ) { content() }
+    }
+}
+
+private data class InfiniteButtonColorSet(
+    val container: Color,
+    val content: Color
+)
+
+private fun infiniteButtonColors(
+    variant: InfiniteButtonVariant,
+    selected: Boolean
+): InfiniteButtonColorSet {
+    return when (variant) {
+        InfiniteButtonVariant.Primary -> InfiniteButtonColorSet(InfiniteColors.Primary, InfiniteColors.Surface)
+        InfiniteButtonVariant.Secondary -> InfiniteButtonColorSet(InfiniteColors.Secondary, InfiniteColors.Text)
+        InfiniteButtonVariant.Tonal -> InfiniteButtonColorSet(InfiniteColors.Primary.copy(alpha = if (selected) 0.24f else 0.14f), InfiniteColors.Primary)
+        InfiniteButtonVariant.Outlined -> InfiniteButtonColorSet(InfiniteColors.Primary, InfiniteColors.Primary)
+        InfiniteButtonVariant.Ghost -> InfiniteButtonColorSet(InfiniteColors.Primary, InfiniteColors.Primary)
+        InfiniteButtonVariant.Glass -> InfiniteButtonColorSet(InfiniteColors.Surface.copy(alpha = 0.62f), InfiniteColors.Primary)
+        InfiniteButtonVariant.Danger -> InfiniteButtonColorSet(InfiniteColors.SoftAlert, InfiniteColors.Surface)
+        InfiniteButtonVariant.Success -> InfiniteButtonColorSet(InfiniteColors.Success, InfiniteColors.Text)
+        InfiniteButtonVariant.Warning -> InfiniteButtonColorSet(InfiniteColors.Warning, InfiniteColors.Text)
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/button/InfiniteIconButton.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/button/InfiniteIconButton.kt
@@ -1,0 +1,40 @@
+package com.example.infinite_track.presentation.design.components.button
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+@Composable
+fun InfiniteIconButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: InfiniteSize = InfiniteSize.Medium,
+    enabled: Boolean = true,
+    selected: Boolean = false
+) {
+    val buttonSize = when (size) {
+        InfiniteSize.Small -> 36.dp
+        InfiniteSize.Medium -> 44.dp
+        InfiniteSize.Large -> 52.dp
+    }
+    IconButton(
+        onClick = onClick,
+        modifier = modifier.size(buttonSize),
+        enabled = enabled,
+        colors = IconButtonDefaults.iconButtonColors(
+            containerColor = if (selected) InfiniteColors.Primary.copy(alpha = 0.14f) else InfiniteColors.Surface.copy(alpha = 0.42f),
+            contentColor = if (selected) InfiniteColors.Primary else InfiniteColors.Text
+        )
+    ) {
+        Icon(imageVector = icon, contentDescription = contentDescription, modifier = Modifier.size(buttonSize * 0.48f))
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteBottomActionBar.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteBottomActionBar.kt
@@ -1,0 +1,76 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.surface.InfiniteSurface
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+data class InfiniteAction(
+    val text: String,
+    val icon: ImageVector? = null,
+    val variant: InfiniteButtonVariant = InfiniteButtonVariant.Primary,
+    val state: InfiniteButtonState = InfiniteButtonState.Enabled,
+    val onClick: () -> Unit
+)
+
+enum class InfiniteActionLayout {
+    Horizontal,
+    Vertical
+}
+
+@Composable
+fun InfiniteBottomActionBar(
+    primaryAction: InfiniteAction,
+    modifier: Modifier = Modifier,
+    secondaryAction: InfiniteAction? = null,
+    tertiaryAction: InfiniteAction? = null,
+    layout: InfiniteActionLayout = InfiniteActionLayout.Horizontal
+) {
+    val actions = listOfNotNull(secondaryAction, tertiaryAction, primaryAction)
+    InfiniteSurface(
+        modifier = modifier.fillMaxWidth(),
+        variant = InfiniteSurfaceVariant.Glass,
+        semantic = InfiniteSemantic.Neutral,
+        size = InfiniteSize.Medium,
+        density = InfiniteDensity.Compact
+    ) {
+        if (layout == InfiniteActionLayout.Vertical) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                actions.forEach { action -> ActionButton(action = action, fullWidth = true) }
+            }
+        } else {
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                actions.forEach { action -> ActionButton(action = action, modifier = Modifier.weight(1f), fullWidth = true) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionButton(
+    action: InfiniteAction,
+    modifier: Modifier = Modifier,
+    fullWidth: Boolean
+) {
+    InfiniteButton(
+        text = action.text,
+        onClick = action.onClick,
+        modifier = modifier,
+        variant = action.variant,
+        state = action.state,
+        leadingIcon = action.icon,
+        fullWidth = fullWidth
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
@@ -1,0 +1,56 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+data class InfiniteFilterOption(
+    val key: String,
+    val label: String,
+    val icon: ImageVector? = null
+)
+
+@Composable
+fun InfiniteFilterChips(
+    options: List<InfiniteFilterOption>,
+    selectedKey: String,
+    onSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    size: InfiniteSize = InfiniteSize.Medium
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        options.forEach { option ->
+            val selected = option.key == selectedKey
+            FilterChip(
+                selected = selected,
+                onClick = { onSelected(option.key) },
+                label = { Text(option.label) },
+                leadingIcon = option.icon?.let { icon ->
+                    { Icon(imageVector = icon, contentDescription = null) }
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = InfiniteColors.Primary.copy(alpha = 0.16f),
+                    selectedLabelColor = InfiniteColors.Primary,
+                    containerColor = InfiniteColors.Surface.copy(alpha = 0.62f),
+                    labelColor = InfiniteColors.Text
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteInfoRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteInfoRow.kt
@@ -1,0 +1,58 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
+
+enum class InfiniteInfoRowOrientation {
+    Horizontal,
+    Vertical
+}
+
+@Composable
+fun InfiniteInfoRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    semantic: InfiniteSemantic = InfiniteSemantic.Neutral,
+    orientation: InfiniteInfoRowOrientation = InfiniteInfoRowOrientation.Horizontal,
+    statusContent: (@Composable (() -> Unit))? = null
+) {
+    val colors = infiniteSemanticColors(semantic)
+    val leading: @Composable RowScope.() -> Unit = {
+        icon?.let { Icon(imageVector = it, contentDescription = null, tint = colors.accent, modifier = Modifier.size(18.dp)) }
+    }
+    if (orientation == InfiniteInfoRowOrientation.Vertical) {
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                leading()
+                Text(text = label, color = colors.content.copy(alpha = 0.66f))
+            }
+            Text(text = value, fontWeight = FontWeight.SemiBold, color = colors.content)
+            statusContent?.invoke()
+        }
+    } else {
+        Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            leading()
+            Text(text = label, color = colors.content.copy(alpha = 0.66f), modifier = Modifier.weight(1f))
+            statusContent?.invoke() ?: Text(text = value, fontWeight = FontWeight.SemiBold, color = colors.content)
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteMetricCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteMetricCard.kt
@@ -1,0 +1,52 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
+
+@Composable
+fun InfiniteMetricCard(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    icon: ImageVector? = null,
+    semantic: InfiniteSemantic = InfiniteSemantic.Primary,
+    size: InfiniteSize = InfiniteSize.Medium,
+    variant: InfiniteSurfaceVariant = InfiniteSurfaceVariant.Glass,
+    onClick: (() -> Unit)? = null
+) {
+    val colors = infiniteSemanticColors(semantic)
+    InfiniteCard(
+        modifier = modifier,
+        variant = variant,
+        semantic = semantic,
+        size = size,
+        clickable = onClick != null,
+        onClick = onClick
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            icon?.let { Icon(imageVector = it, contentDescription = null, tint = colors.accent, modifier = Modifier.size(28.dp)) }
+            androidx.compose.foundation.layout.Column {
+                Text(text = title, color = colors.content.copy(alpha = 0.70f))
+                Text(text = value, color = colors.content, fontWeight = FontWeight.Bold)
+                subtitle?.let { Text(text = it, color = colors.content.copy(alpha = 0.58f)) }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteSectionHeader.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteSectionHeader.kt
@@ -1,0 +1,55 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun InfiniteSectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    leadingIcon: ImageVector? = null,
+    trailingText: String? = null,
+    trailingIcon: ImageVector? = null,
+    onTrailingClick: (() -> Unit)? = null
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        leadingIcon?.let {
+            Icon(imageVector = it, contentDescription = null, tint = InfiniteColors.Primary, modifier = Modifier.size(22.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title, fontWeight = FontWeight.SemiBold, color = InfiniteColors.Text)
+            subtitle?.let { Text(text = it, color = InfiniteColors.Text.copy(alpha = 0.64f)) }
+        }
+        if (trailingText != null || trailingIcon != null) {
+            Row(
+                modifier = Modifier.clickable(enabled = onTrailingClick != null) { onTrailingClick?.invoke() },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                trailingText?.let { Text(text = it, color = InfiniteColors.Primary) }
+                trailingIcon?.let { Icon(imageVector = it, contentDescription = trailingText, tint = InfiniteColors.Primary, modifier = Modifier.size(18.dp)) }
+            }
+        } else {
+            Spacer(modifier = Modifier.size(0.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
@@ -1,0 +1,86 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+enum class TimelineConnectorPosition {
+    None,
+    First,
+    Middle,
+    Last
+}
+
+@Composable
+fun InfiniteTimelineRow(
+    dateLabel: String,
+    modeLabel: String,
+    timeRange: String,
+    statusLabel: String,
+    statusVariant: InfiniteStatusVariant,
+    modifier: Modifier = Modifier,
+    leadingIcon: ImageVector? = Icons.Rounded.CalendarMonth,
+    connectorPosition: TimelineConnectorPosition = TimelineConnectorPosition.None,
+    onClick: (() -> Unit)? = null,
+    supportingContent: (@Composable ColumnScope.() -> Unit)? = null,
+    trailingContent: (@Composable RowScope.() -> Unit)? = null
+) {
+    Row(
+        modifier = modifier
+            .clickable(enabled = onClick != null) { onClick?.invoke() }
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TimelineMarker(connectorPosition = connectorPosition, leadingIcon = leadingIcon)
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = dateLabel, fontWeight = FontWeight.SemiBold, color = InfiniteColors.Text)
+            Text(text = modeLabel, color = InfiniteColors.Text.copy(alpha = 0.66f))
+            Text(text = timeRange, color = InfiniteColors.Text.copy(alpha = 0.56f))
+            supportingContent?.invoke(this)
+        }
+        InfiniteStatusPill(label = statusLabel, variant = statusVariant)
+        trailingContent?.invoke(this)
+    }
+}
+
+@Composable
+private fun TimelineMarker(
+    connectorPosition: TimelineConnectorPosition,
+    leadingIcon: ImageVector?
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Canvas(modifier = Modifier.size(2.dp, 10.dp)) {
+            if (connectorPosition == TimelineConnectorPosition.Middle || connectorPosition == TimelineConnectorPosition.Last) {
+                drawLine(InfiniteColors.Primary.copy(alpha = 0.35f), Offset(size.width / 2, 0f), Offset(size.width / 2, size.height), strokeWidth = size.width)
+            }
+        }
+        leadingIcon?.let { Icon(imageVector = it, contentDescription = null, tint = InfiniteColors.Primary, modifier = Modifier.size(22.dp)) }
+        Canvas(modifier = Modifier.size(2.dp, 10.dp)) {
+            if (connectorPosition == TimelineConnectorPosition.Middle || connectorPosition == TimelineConnectorPosition.First) {
+                drawLine(InfiniteColors.Primary.copy(alpha = 0.35f), Offset(size.width / 2, 0f), Offset(size.width / 2, size.height), strokeWidth = size.width)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/input/InfiniteTextField.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/input/InfiniteTextField.kt
@@ -1,0 +1,47 @@
+package com.example.infinite_track.presentation.design.components.input
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteRadius
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InfiniteTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    placeholder: String? = null,
+    leadingIcon: ImageVector? = null,
+    trailingIcon: ImageVector? = null,
+    enabled: Boolean = true,
+    singleLine: Boolean = true,
+    size: InfiniteSize = InfiniteSize.Medium
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        singleLine = singleLine,
+        shape = InfiniteRadius.shape(size),
+        label = label?.let { { Text(it) } },
+        placeholder = placeholder?.let { { Text(it) } },
+        leadingIcon = leadingIcon?.let { { Icon(imageVector = it, contentDescription = null) } },
+        trailingIcon = trailingIcon?.let { { Icon(imageVector = it, contentDescription = null) } },
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = InfiniteColors.Primary,
+            unfocusedBorderColor = InfiniteColors.Neutral.copy(alpha = 0.22f),
+            cursorColor = InfiniteColors.Primary,
+            focusedLabelColor = InfiniteColors.Primary
+        )
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/navigation/InfiniteBottomBar.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/navigation/InfiniteBottomBar.kt
@@ -1,0 +1,52 @@
+package com.example.infinite_track.presentation.design.components.navigation
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+data class InfiniteBottomBarItem(
+    val key: String,
+    val label: String,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector = selectedIcon
+)
+
+@Composable
+fun InfiniteBottomBar(
+    items: List<InfiniteBottomBarItem>,
+    selectedKey: String,
+    onItemSelected: (String) -> Unit
+) {
+    NavigationBar(containerColor = InfiniteColors.Surface.copy(alpha = 0.72f)) {
+        items.forEach { item ->
+            val selected = item.key == selectedKey
+            NavigationBarItem(
+                selected = selected,
+                onClick = { onItemSelected(item.key) },
+                icon = {
+                    Icon(
+                        imageVector = if (selected) item.selectedIcon else item.unselectedIcon,
+                        contentDescription = item.label,
+                        modifier = Modifier.size(22.dp)
+                    )
+                },
+                label = { Text(item.label) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = InfiniteColors.Primary,
+                    selectedTextColor = InfiniteColors.Primary,
+                    indicatorColor = InfiniteColors.Primary.copy(alpha = 0.12f),
+                    unselectedIconColor = InfiniteColors.Text.copy(alpha = 0.62f),
+                    unselectedTextColor = InfiniteColors.Text.copy(alpha = 0.62f)
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/navigation/InfiniteTopBar.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/navigation/InfiniteTopBar.kt
@@ -1,0 +1,39 @@
+package com.example.infinite_track.presentation.design.components.navigation
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InfiniteTopBar(
+    title: String,
+    navigationIcon: ImageVector? = null,
+    navigationContentDescription: String? = null,
+    onNavigationClick: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = title, color = InfiniteColors.Text) },
+        navigationIcon = {
+            if (navigationIcon != null && onNavigationClick != null) {
+                IconButton(onClick = onNavigationClick) {
+                    Icon(imageVector = navigationIcon, contentDescription = navigationContentDescription, tint = InfiniteColors.Text)
+                }
+            }
+        },
+        actions = actions,
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = InfiniteColors.Surface.copy(alpha = 0.72f),
+            titleContentColor = InfiniteColors.Text,
+            actionIconContentColor = InfiniteColors.Primary
+        )
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/state/InfiniteStateComponents.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/state/InfiniteStateComponents.kt
@@ -1,0 +1,66 @@
+package com.example.infinite_track.presentation.design.components.state
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.components.loading.LoadingAnimation
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+
+@Composable
+fun InfiniteEmptyState(
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    StateColumn(modifier = modifier) {
+        Text(text = title, fontWeight = FontWeight.SemiBold, textAlign = TextAlign.Center)
+        Text(text = message, textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+fun InfiniteLoadingState(
+    modifier: Modifier = Modifier,
+    message: String = "Loading..."
+) {
+    StateColumn(modifier = modifier) {
+        LoadingAnimation()
+        Text(text = message, textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+fun InfiniteErrorState(
+    title: String,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    InfiniteInlineAlert(
+        title = title,
+        message = message,
+        semantic = InfiniteSemantic.Error,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun StateColumn(
+    modifier: Modifier,
+    content: @Composable () -> Unit
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
@@ -1,0 +1,85 @@
+package com.example.infinite_track.presentation.design.components.status
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.infinite_track.presentation.components.status.InfiniteTrackConfirmDialog
+import com.example.infinite_track.presentation.components.status.InfiniteTrackInlineAlert
+import com.example.infinite_track.presentation.components.status.InfiniteTrackStatusDialog
+import com.example.infinite_track.presentation.components.status.StatusStateSpec
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+
+@Composable
+fun InfiniteInlineAlert(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    modifier: Modifier = Modifier,
+    onDismiss: (() -> Unit)? = null
+) {
+    InfiniteTrackInlineAlert(
+        status = semantic.toStatusStateSpec(),
+        title = title,
+        message = message,
+        modifier = modifier,
+        onDismiss = onDismiss
+    )
+}
+
+@Composable
+fun InfiniteStatusDialog(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    showDialog: Boolean,
+    modifier: Modifier = Modifier,
+    confirmText: String = "OK",
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit = onDismiss
+) {
+    InfiniteTrackStatusDialog(
+        status = semantic.toStatusStateSpec(),
+        title = title,
+        message = message,
+        showDialog = showDialog,
+        modifier = modifier,
+        confirmText = confirmText,
+        onDismiss = onDismiss,
+        onConfirm = onConfirm
+    )
+}
+
+@Composable
+fun InfiniteConfirmDialog(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    showDialog: Boolean,
+    modifier: Modifier = Modifier,
+    confirmText: String = "Confirm",
+    cancelText: String = "Cancel",
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    InfiniteTrackConfirmDialog(
+        status = semantic.toStatusStateSpec(),
+        title = title,
+        message = message,
+        showDialog = showDialog,
+        modifier = modifier,
+        confirmText = confirmText,
+        cancelText = cancelText,
+        isDestructive = semantic == InfiniteSemantic.Error,
+        onDismiss = onDismiss,
+        onConfirm = onConfirm
+    )
+}
+
+private fun InfiniteSemantic.toStatusStateSpec(): StatusStateSpec = when (this) {
+    InfiniteSemantic.Success -> StatusStateSpec("success", "Success")
+    InfiniteSemantic.Warning -> StatusStateSpec("warning", "Warning")
+    InfiniteSemantic.Error -> StatusStateSpec("error", "Error")
+    InfiniteSemantic.Info,
+    InfiniteSemantic.Primary,
+    InfiniteSemantic.Secondary,
+    InfiniteSemantic.Neutral -> StatusStateSpec("info", "Info")
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
@@ -1,0 +1,107 @@
+package com.example.infinite_track.presentation.design.components.status
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
+
+enum class InfiniteStatusVariant {
+    Active,
+    Completed,
+    NotStarted,
+    Unavailable,
+    OnTime,
+    Late,
+    Early,
+    Alpha,
+    Pending,
+    Approved,
+    Rejected,
+    Inside,
+    Outside,
+    Unknown,
+    Recommended,
+    Excellent,
+    Good,
+    NeedsReview,
+    PdfReady,
+    Neutral
+}
+
+@Composable
+fun InfiniteStatusPill(
+    label: String,
+    variant: InfiniteStatusVariant,
+    modifier: Modifier = Modifier,
+    size: InfiniteSize = InfiniteSize.Medium,
+    leadingIcon: ImageVector? = null,
+    selected: Boolean = false
+) {
+    val semantic = variant.toSemantic()
+    val colors = infiniteSemanticColors(semantic)
+    val horizontal = when (size) {
+        InfiniteSize.Small -> 8.dp
+        InfiniteSize.Medium -> 10.dp
+        InfiniteSize.Large -> 12.dp
+    }
+    val vertical = when (size) {
+        InfiniteSize.Small -> 4.dp
+        InfiniteSize.Medium -> 6.dp
+        InfiniteSize.Large -> 8.dp
+    }
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(999.dp),
+        color = colors.container,
+        contentColor = colors.content,
+        border = BorderStroke(if (selected) 1.5.dp else 1.dp, colors.border)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = horizontal, vertical = vertical),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            leadingIcon?.let {
+                Icon(imageVector = it, contentDescription = null, tint = colors.accent, modifier = Modifier.size(14.dp))
+            }
+            Text(text = label)
+        }
+    }
+}
+
+fun InfiniteStatusVariant.toSemantic(): InfiniteSemantic = when (this) {
+    InfiniteStatusVariant.Active,
+    InfiniteStatusVariant.Approved,
+    InfiniteStatusVariant.Inside,
+    InfiniteStatusVariant.Completed,
+    InfiniteStatusVariant.OnTime,
+    InfiniteStatusVariant.Excellent,
+    InfiniteStatusVariant.PdfReady -> InfiniteSemantic.Success
+    InfiniteStatusVariant.Pending,
+    InfiniteStatusVariant.NeedsReview,
+    InfiniteStatusVariant.Late,
+    InfiniteStatusVariant.Early -> InfiniteSemantic.Warning
+    InfiniteStatusVariant.Rejected,
+    InfiniteStatusVariant.Outside,
+    InfiniteStatusVariant.Alpha -> InfiniteSemantic.Error
+    InfiniteStatusVariant.Recommended,
+    InfiniteStatusVariant.Good -> InfiniteSemantic.Info
+    InfiniteStatusVariant.NotStarted,
+    InfiniteStatusVariant.Unavailable,
+    InfiniteStatusVariant.Unknown,
+    InfiniteStatusVariant.Neutral -> InfiniteSemantic.Neutral
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/surface/InfiniteCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/surface/InfiniteCard.kt
@@ -1,0 +1,40 @@
+package com.example.infinite_track.presentation.design.components.surface
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+@Composable
+fun InfiniteCard(
+    modifier: Modifier = Modifier,
+    variant: InfiniteSurfaceVariant = InfiniteSurfaceVariant.Glass,
+    semantic: InfiniteSemantic = InfiniteSemantic.Neutral,
+    size: InfiniteSize = InfiniteSize.Medium,
+    density: InfiniteDensity = InfiniteDensity.Comfortable,
+    selected: Boolean = false,
+    enabled: Boolean = true,
+    clickable: Boolean = false,
+    showBorder: Boolean = true,
+    showShadow: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    InfiniteSurface(
+        modifier = modifier,
+        variant = variant,
+        semantic = semantic,
+        size = size,
+        density = density,
+        selected = selected,
+        enabled = enabled,
+        clickable = clickable,
+        showBorder = showBorder,
+        showShadow = showShadow,
+        onClick = onClick,
+        content = content
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/surface/InfiniteSurface.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/surface/InfiniteSurface.kt
@@ -1,0 +1,80 @@
+package com.example.infinite_track.presentation.design.components.surface
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteElevation
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSpacing
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
+
+@Composable
+fun InfiniteSurface(
+    modifier: Modifier = Modifier,
+    variant: InfiniteSurfaceVariant = InfiniteSurfaceVariant.Glass,
+    semantic: InfiniteSemantic = InfiniteSemantic.Neutral,
+    size: InfiniteSize = InfiniteSize.Medium,
+    density: InfiniteDensity = InfiniteDensity.Comfortable,
+    selected: Boolean = false,
+    enabled: Boolean = true,
+    clickable: Boolean = false,
+    showBorder: Boolean = true,
+    showShadow: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val semanticColors = infiniteSemanticColors(semantic)
+    val shape = com.example.infinite_track.presentation.design.tokens.InfiniteRadius.shape(size)
+    val backgroundModifier = if (variant == InfiniteSurfaceVariant.Glass || variant == InfiniteSurfaceVariant.SoftGradient) {
+        Modifier.background(InfiniteColors.GlassGradient, shape)
+    } else {
+        Modifier
+    }
+    val clickAction = onClick
+    val clickModifier = if (clickable && enabled && clickAction != null) {
+        Modifier.clickable { clickAction() }
+    } else Modifier
+
+    Card(
+        modifier = modifier
+            .then(backgroundModifier)
+            .then(clickModifier),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = when (variant) {
+                InfiniteSurfaceVariant.StatusTint -> semanticColors.container
+                InfiniteSurfaceVariant.Default -> InfiniteColors.Surface
+                InfiniteSurfaceVariant.Outlined -> InfiniteColors.Surface.copy(alpha = 0.72f)
+                InfiniteSurfaceVariant.Elevated -> InfiniteColors.Surface
+                InfiniteSurfaceVariant.Glass,
+                InfiniteSurfaceVariant.SoftGradient -> InfiniteColors.Surface.copy(alpha = 0.58f)
+            },
+            contentColor = semanticColors.content,
+            disabledContainerColor = InfiniteColors.Surface.copy(alpha = 0.42f),
+            disabledContentColor = semanticColors.content.copy(alpha = 0.45f)
+        ),
+        border = if (showBorder || selected) {
+            com.example.infinite_track.presentation.design.tokens.InfiniteBorder.stroke(
+                semantic = semantic,
+                selected = selected,
+                enabled = enabled
+            )
+        } else null,
+        elevation = InfiniteElevation.cardElevation(variant, showShadow)
+    ) {
+        Column(
+            modifier = Modifier.padding(InfiniteSpacing.contentPadding(size, density)),
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/preview/InfiniteComponentGallery.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/preview/InfiniteComponentGallery.kt
@@ -1,0 +1,139 @@
+package com.example.infinite_track.presentation.design.preview
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.data.InfiniteAction
+import com.example.infinite_track.presentation.design.components.data.InfiniteBottomActionBar
+import com.example.infinite_track.presentation.design.components.data.InfiniteFilterChips
+import com.example.infinite_track.presentation.design.components.data.InfiniteFilterOption
+import com.example.infinite_track.presentation.design.components.data.InfiniteInfoRow
+import com.example.infinite_track.presentation.design.components.data.InfiniteMetricCard
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.components.data.InfiniteTimelineRow
+import com.example.infinite_track.presentation.design.components.data.TimelineConnectorPosition
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.components.state.InfiniteEmptyState
+import com.example.infinite_track.presentation.design.components.state.InfiniteErrorState
+import com.example.infinite_track.presentation.design.components.state.InfiniteLoadingState
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
+
+@Preview(showBackground = true, widthDp = 390, heightDp = 1400)
+@Composable
+fun InfiniteComponentGalleryPreview() {
+    Infinite_TrackTheme {
+        InfiniteComponentGallery()
+    }
+}
+
+@Composable
+fun InfiniteComponentGallery() {
+    val selectedFilter = remember { mutableStateOf("week") }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(InfiniteColors.Background)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        InfiniteSectionHeader(
+            title = "Infinite Track Material 3",
+            subtitle = "Reusable component foundation",
+            leadingIcon = InfiniteIcons.More,
+            trailingText = "Preview"
+        )
+
+        InfiniteCard(variant = InfiniteSurfaceVariant.Glass, semantic = InfiniteSemantic.Primary) {
+            InfiniteInfoRow(label = "Design direction", value = "Premium academic SaaS", icon = InfiniteIcons.Info)
+            InfiniteInfoRow(label = "Theme", value = "Light only", icon = InfiniteIcons.Success)
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            InfiniteButton(text = "Primary", onClick = {}, modifier = Modifier.weight(1f), fullWidth = true)
+            InfiniteButton(text = "Tonal", onClick = {}, modifier = Modifier.weight(1f), variant = InfiniteButtonVariant.Tonal, fullWidth = true)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            InfiniteButton(text = "Loading", onClick = {}, modifier = Modifier.weight(1f), state = InfiniteButtonState.Loading, fullWidth = true)
+            InfiniteButton(text = "Danger", onClick = {}, modifier = Modifier.weight(1f), variant = InfiniteButtonVariant.Danger, fullWidth = true)
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            InfiniteMetricCard(title = "Attendance", value = "96%", subtitle = "On track", icon = InfiniteIcons.Calendar, modifier = Modifier.weight(1f))
+            InfiniteMetricCard(title = "Late", value = "2", subtitle = "This month", icon = InfiniteIcons.Time, semantic = InfiniteSemantic.Warning, modifier = Modifier.weight(1f))
+        }
+
+        InfiniteFilterChips(
+            options = listOf(
+                InfiniteFilterOption("week", "Week", InfiniteIcons.Calendar),
+                InfiniteFilterOption("month", "Month", InfiniteIcons.Filter),
+                InfiniteFilterOption("pdf", "PDF Ready", InfiniteIcons.Download)
+            ),
+            selectedKey = selectedFilter.value,
+            onSelected = { selectedFilter.value = it }
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            InfiniteStatusPill("Active", InfiniteStatusVariant.Active)
+            InfiniteStatusPill("Pending", InfiniteStatusVariant.Pending)
+            InfiniteStatusPill("Rejected", InfiniteStatusVariant.Rejected)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            InfiniteStatusPill("Inside", InfiniteStatusVariant.Inside)
+            InfiniteStatusPill("PDF Ready", InfiniteStatusVariant.PdfReady)
+            InfiniteStatusPill("Review", InfiniteStatusVariant.NeedsReview)
+        }
+
+        InfiniteTimelineRow(
+            dateLabel = "Mon, 07 Jul",
+            modeLabel = "Work From Office",
+            timeRange = "08:00 - 17:00",
+            statusLabel = "On Time",
+            statusVariant = InfiniteStatusVariant.OnTime,
+            connectorPosition = TimelineConnectorPosition.First
+        )
+        InfiniteTimelineRow(
+            dateLabel = "Tue, 08 Jul",
+            modeLabel = "Work From Anywhere",
+            timeRange = "09:10 - 17:00",
+            statusLabel = "Late",
+            statusVariant = InfiniteStatusVariant.Late,
+            connectorPosition = TimelineConnectorPosition.Last
+        )
+
+        InfiniteInlineAlert(title = "Success", message = "Your request has been saved.", semantic = InfiniteSemantic.Success)
+        InfiniteInlineAlert(title = "Warning", message = "Please review this state before continuing.", semantic = InfiniteSemantic.Warning)
+        InfiniteErrorState(title = "Unable to load", message = "Try again after checking your connection.")
+        InfiniteLoadingState(message = "Preparing component preview...")
+        InfiniteEmptyState(title = "No data yet", message = "Reusable empty state for report and WFA lists.")
+
+        InfiniteBottomActionBar(
+            primaryAction = InfiniteAction("Save", InfiniteIcons.Success) {},
+            secondaryAction = InfiniteAction("Share", InfiniteIcons.Share, InfiniteButtonVariant.Outlined) {},
+            tertiaryAction = InfiniteAction("PDF", InfiniteIcons.Download, InfiniteButtonVariant.Tonal) {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteBorder.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteBorder.kt
@@ -1,0 +1,34 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.unit.dp
+
+object InfiniteBorder {
+    val Hairline = 1.dp
+    val Selected = 1.5.dp
+
+    fun stroke(
+        semantic: InfiniteSemantic,
+        selected: Boolean = false,
+        enabled: Boolean = true
+    ): BorderStroke {
+        val colors = InfiniteBorderColors.resolve(semantic)
+        val alpha = if (enabled) 1f else 0.35f
+        return BorderStroke(
+            width = if (selected) Selected else Hairline,
+            color = colors.copy(alpha = alpha)
+        )
+    }
+}
+
+private object InfiniteBorderColors {
+    fun resolve(semantic: InfiniteSemantic) = when (semantic) {
+        InfiniteSemantic.Primary -> InfiniteColors.Primary.copy(alpha = 0.34f)
+        InfiniteSemantic.Secondary -> InfiniteColors.Secondary.copy(alpha = 0.45f)
+        InfiniteSemantic.Success -> InfiniteColors.Success.copy(alpha = 0.45f)
+        InfiniteSemantic.Info -> InfiniteColors.Info.copy(alpha = 0.30f)
+        InfiniteSemantic.Warning -> InfiniteColors.Warning.copy(alpha = 0.55f)
+        InfiniteSemantic.Error -> InfiniteColors.SoftAlert.copy(alpha = 0.42f)
+        InfiniteSemantic.Neutral -> InfiniteColors.Neutral.copy(alpha = 0.20f)
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
@@ -1,0 +1,96 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Blue_Accent_500
+import com.example.infinite_track.presentation.theme.Green_Success
+import com.example.infinite_track.presentation.theme.Orange_500
+import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Red_Error
+import com.example.infinite_track.presentation.theme.Violet_100
+import com.example.infinite_track.presentation.theme.White
+import com.example.infinite_track.presentation.theme.Yellow_Warning
+
+@Immutable
+data class InfiniteSemanticColors(
+    val container: Color,
+    val content: Color,
+    val border: Color,
+    val accent: Color
+)
+
+object InfiniteColors {
+    val Primary = Blue_500
+    val Secondary = Orange_500
+    val Accent = Blue_Accent_500
+    val Text = Purple_500
+    val Background = Violet_100
+    val Surface = White
+    val SoftAlert = Color(0xFFFF6B6B)
+    val Success = Green_Success
+    val Info = Color(0xFF214CE0)
+    val Warning = Yellow_Warning
+    val Error = Red_Error
+    val Neutral = Color(0xFF746D74)
+
+    val GlassGradient: Brush
+        get() = Brush.verticalGradient(
+            colors = listOf(
+                White.copy(alpha = 0.72f),
+                Violet_100.copy(alpha = 0.42f)
+            )
+        )
+}
+
+@Composable
+fun infiniteSemanticColors(semantic: InfiniteSemantic): InfiniteSemanticColors {
+    val fallbackSurface = MaterialTheme.colorScheme.surface
+    return when (semantic) {
+        InfiniteSemantic.Primary -> InfiniteSemanticColors(
+            container = InfiniteColors.Primary.copy(alpha = 0.12f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Primary.copy(alpha = 0.34f),
+            accent = InfiniteColors.Primary
+        )
+        InfiniteSemantic.Secondary -> InfiniteSemanticColors(
+            container = InfiniteColors.Secondary.copy(alpha = 0.16f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Secondary.copy(alpha = 0.45f),
+            accent = InfiniteColors.Secondary
+        )
+        InfiniteSemantic.Success -> InfiniteSemanticColors(
+            container = InfiniteColors.Success.copy(alpha = 0.16f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Success.copy(alpha = 0.45f),
+            accent = InfiniteColors.Success
+        )
+        InfiniteSemantic.Info -> InfiniteSemanticColors(
+            container = InfiniteColors.Primary.copy(alpha = 0.10f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Info.copy(alpha = 0.30f),
+            accent = InfiniteColors.Info
+        )
+        InfiniteSemantic.Warning -> InfiniteSemanticColors(
+            container = InfiniteColors.Warning.copy(alpha = 0.24f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Warning.copy(alpha = 0.55f),
+            accent = InfiniteColors.Warning
+        )
+        InfiniteSemantic.Error -> InfiniteSemanticColors(
+            container = InfiniteColors.SoftAlert.copy(alpha = 0.14f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.SoftAlert.copy(alpha = 0.42f),
+            accent = InfiniteColors.SoftAlert
+        )
+        InfiniteSemantic.Neutral -> InfiniteSemanticColors(
+            container = fallbackSurface.copy(alpha = 0.74f),
+            content = InfiniteColors.Text,
+            border = InfiniteColors.Neutral.copy(alpha = 0.20f),
+            accent = InfiniteColors.Neutral
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteComponentTokens.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteComponentTokens.kt
@@ -1,0 +1,39 @@
+package com.example.infinite_track.presentation.design.tokens
+
+enum class InfiniteSize {
+    Small,
+    Medium,
+    Large
+}
+
+enum class InfiniteDensity {
+    Compact,
+    Comfortable,
+    Spacious
+}
+
+enum class InfiniteSemantic {
+    Primary,
+    Secondary,
+    Success,
+    Info,
+    Warning,
+    Error,
+    Neutral
+}
+
+enum class InfiniteSurfaceVariant {
+    Default,
+    Glass,
+    Elevated,
+    Outlined,
+    SoftGradient,
+    StatusTint
+}
+
+enum class InfiniteComponentState {
+    Enabled,
+    Disabled,
+    Loading,
+    Selected
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteElevation.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteElevation.kt
@@ -1,0 +1,31 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object InfiniteElevation {
+    val None: Dp = 0.dp
+    val Soft: Dp = 2.dp
+    val Medium: Dp = 6.dp
+    val High: Dp = 10.dp
+
+    fun elevation(variant: InfiniteSurfaceVariant, showShadow: Boolean): Dp {
+        if (!showShadow) return None
+        return when (variant) {
+            InfiniteSurfaceVariant.Elevated -> Medium
+            InfiniteSurfaceVariant.SoftGradient -> Soft
+            InfiniteSurfaceVariant.Glass -> Soft
+            InfiniteSurfaceVariant.StatusTint -> Soft
+            InfiniteSurfaceVariant.Default,
+            InfiniteSurfaceVariant.Outlined -> None
+        }
+    }
+
+    @Composable
+    fun cardElevation(variant: InfiniteSurfaceVariant, showShadow: Boolean): CardElevation {
+        return CardDefaults.cardElevation(defaultElevation = elevation(variant, showShadow))
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
@@ -1,0 +1,33 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AccessTime
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.FileDownload
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.LocationOn
+import androidx.compose.material.icons.rounded.MoreHoriz
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.ui.graphics.vector.ImageVector
+
+object InfiniteIcons {
+    val Calendar = Icons.Rounded.CalendarMonth
+    val Time = Icons.Rounded.AccessTime
+    val Success = Icons.Rounded.CheckCircle
+    val Info = Icons.Rounded.Info
+    val Warning = Icons.Rounded.Warning
+    val Error = Icons.Rounded.Error
+    val Location = Icons.Rounded.LocationOn
+    val Search = Icons.Rounded.Search
+    val Filter = Icons.Rounded.FilterList
+    val Download = Icons.Rounded.FileDownload
+    val Share = Icons.Rounded.Share
+    val Person = Icons.Rounded.Person
+    val More: ImageVector = Icons.Rounded.MoreHoriz
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteMotion.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteMotion.kt
@@ -1,0 +1,15 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+
+object InfiniteMotion {
+    const val FastDurationMillis = 160
+    const val NormalDurationMillis = 240
+    const val SlowDurationMillis = 320
+
+    fun <T> normalTween() = tween<T>(
+        durationMillis = NormalDurationMillis,
+        easing = FastOutSlowInEasing
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteRadius.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteRadius.kt
@@ -1,0 +1,24 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object InfiniteRadius {
+    val Small: Dp = 10.dp
+    val Medium: Dp = 14.dp
+    val Large: Dp = 18.dp
+    val XLarge: Dp = 24.dp
+    val Pill: Dp = 999.dp
+
+    fun radius(size: InfiniteSize): Dp {
+        return when (size) {
+            InfiniteSize.Small -> Small
+            InfiniteSize.Medium -> Medium
+            InfiniteSize.Large -> Large
+        }
+    }
+
+    fun shape(size: InfiniteSize) = RoundedCornerShape(radius(size))
+    fun pillShape() = RoundedCornerShape(Pill)
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteSpacing.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteSpacing.kt
@@ -1,0 +1,47 @@
+package com.example.infinite_track.presentation.design.tokens
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class InfiniteSpacingSet(
+    val xs: Dp = 4.dp,
+    val sm: Dp = 8.dp,
+    val md: Dp = 12.dp,
+    val lg: Dp = 16.dp,
+    val xl: Dp = 24.dp,
+    val xxl: Dp = 32.dp
+)
+
+object InfiniteSpacing {
+    val Default = InfiniteSpacingSet()
+
+    fun contentPadding(size: InfiniteSize, density: InfiniteDensity): Dp {
+        return when (density) {
+            InfiniteDensity.Compact -> when (size) {
+                InfiniteSize.Small -> 8.dp
+                InfiniteSize.Medium -> 10.dp
+                InfiniteSize.Large -> 12.dp
+            }
+            InfiniteDensity.Comfortable -> when (size) {
+                InfiniteSize.Small -> 10.dp
+                InfiniteSize.Medium -> 14.dp
+                InfiniteSize.Large -> 18.dp
+            }
+            InfiniteDensity.Spacious -> when (size) {
+                InfiniteSize.Small -> 14.dp
+                InfiniteSize.Medium -> 18.dp
+                InfiniteSize.Large -> 24.dp
+            }
+        }
+    }
+
+    fun gap(size: InfiniteSize): Dp {
+        return when (size) {
+            InfiniteSize.Small -> 6.dp
+            InfiniteSize.Medium -> 10.dp
+            InfiniteSize.Large -> 14.dp
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-07-07-inf-222-material3-ui-system-foundation.md
+++ b/docs/superpowers/specs/2026-07-07-inf-222-material3-ui-system-foundation.md
@@ -1,0 +1,61 @@
+# INF-222 — Infinite Track Material 3 UI Component System Foundation
+
+## Scope
+
+INF-222 adds an additive Material 3 friendly reusable UI foundation under `presentation/design/`.
+
+The issue intentionally does not redesign Home Dashboard, Profile, My Attendance Report, WFA Requests, Attendance, Permission, WFA Recommendation, PDF preview, or other full screens.
+
+## Worktree / branch
+
+- Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-infinite-material3-ui-system`
+- Branch: `fix/android-infinite-material3-ui-system`
+- Base: `develop` at `079c6a3`
+
+## Mapping answers
+
+1. The isolated worktree is correct and is on `fix/android-infinite-material3-ui-system`.
+2. Existing reusable attempts include button, status, calendar, textfield, navigation, empty, loading, and card components.
+3. Existing screen-specific components, especially cards and attendance/navigation helpers, are preserved and not expanded blindly.
+4. Existing repo tokens are mostly colors in `presentation/theme/Color.kt`; spacing, radius, elevation, border, motion, and icon mapping tokens were absent.
+5. Material 3 is present but not consistently tokenized; several legacy components hardcode color/radius/elevation and some use heavy blur.
+6. `StatefulButton` is limited; INF-222 adds a new `InfiniteButton` wrapper instead of changing legacy behavior in place.
+7. INF-219 status components exist and are wrapped by new `InfiniteInlineAlert`, `InfiniteStatusDialog`, and `InfiniteConfirmDialog` foundation APIs.
+8. Adding `presentation/design` is safe because it is additive and does not delete legacy components.
+9. No additional dependency is required; Material icons extended already exists.
+10. Build risk is mainly local Gradle loopback; CI/local Android Studio should provide compile evidence.
+
+## Architecture added
+
+```text
+presentation/design/
+├── tokens/
+├── components/
+│   ├── surface/
+│   ├── button/
+│   ├── status/
+│   ├── input/
+│   ├── navigation/
+│   ├── data/
+│   └── state/
+└── preview/
+```
+
+## Design decisions
+
+- Light theme only foundation.
+- Material 3 primitives are used internally.
+- Rounded Material icons are centralized in `InfiniteIcons`.
+- Legacy `presentation/components/*` remains intact for gradual adoption.
+- New foundation components use controlled variants such as size, semantic, density, state, selected, enabled, and loading.
+- No backend, navigation graph, auth/session, or attendance business logic changes.
+
+## Verification note
+
+Local Gradle build was attempted but blocked before Kotlin compile by:
+
+```text
+java.io.IOException: Unable to establish loopback connection
+```
+
+This blocker is environment-level and has appeared on prior Android work. CI or a local Android Studio environment should be used for final compile/build and preview screenshot evidence.


### PR DESCRIPTION
## Summary

- Add additive Infinite Track Material 3 UI foundation under `presentation/design/`.
- Add reusable design tokens for colors, spacing, radius, elevation, border, motion, and rounded icon mapping.
- Add reusable primitive/pattern components:
  - `InfiniteSurface` / `InfiniteCard`
  - `InfiniteButton` / `InfiniteIconButton`
  - `InfiniteStatusPill`
  - `InfiniteInlineAlert`, `InfiniteStatusDialog`, `InfiniteConfirmDialog` wrappers over INF-219 status components
  - `InfiniteTextField`
  - `InfiniteTopBar` / `InfiniteBottomBar`
  - `InfiniteMetricCard`, `InfiniteTimelineRow`, `InfiniteSectionHeader`, `InfiniteInfoRow`, `InfiniteFilterChips`, `InfiniteBottomActionBar`
  - `InfiniteEmptyState`, `InfiniteLoadingState`, `InfiniteErrorState`
- Add component gallery preview: `InfiniteComponentGallery.kt`.
- Add focused foundation note under `docs/superpowers/specs/`.

## Scope guardrails

- Work done in isolated branch/worktree: `fix/android-infinite-material3-ui-system`.
- No full screen redesign included.
- No backend integration included.
- No navigation graph ownership changes.
- No auth/session changes.
- No attendance business logic changes.
- Legacy `presentation/components/*` preserved; no blind deletion.
- No new external UI dependency added.

## Mapping answers

- Existing reusable attempts found in button, status, calendar, textfield, navigation, empty/loading, and cards packages.
- Existing token coverage was mostly color-only in `Color.kt`; spacing/radius/elevation/border/motion/icon mapping tokens were absent.
- `StatefulButton` remains untouched; new `InfiniteButton` is added as a safer foundation component.
- INF-219 status components are wrapped instead of replaced.
- `presentation/design` is additive and safe for gradual adoption.

## Verification

Completed:

- `git diff --check`: passed before commit.
- Search for disallowed one-off names returned no matches:
  - `HomeButton|ReportButton|ProfileButton|WfaButton|SmartReminderCard|PersonalInsightCard|DisciplineScoreCard`
- Boundary search inside `presentation/design` returned no matches for navigation/auth/session/attendance/network ownership terms.

Needs Verification:

- Local executor cannot complete Gradle because it fails before Kotlin compile with baseline/environment error:
  - `java.io.IOException: Unable to establish loopback connection`
- Please use CI/Android Studio for:
  - `./gradlew app:assembleDebug`
  - component gallery screenshots/previews

## Preview evidence target

Component gallery preview added at:

`app/src/main/java/com/example/infinite_track/presentation/design/preview/InfiniteComponentGallery.kt`

It covers:

- button variants and loading state
- card/surface variants
- status pills
- metric cards
- timeline rows
- filter chips
- bottom action bar
- inline alert/error/loading/empty states

## Docs / ADR

- Added: `docs/superpowers/specs/2026-07-07-inf-222-material3-ui-system-foundation.md`
- ADR not added yet. If this foundation becomes the long-term UI contract after CI/review, a follow-up ADR can formalize it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)