### PR TITLE
INF-218: Implement WFA requests tab API UI

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
@@ -1,46 +1,116 @@
 package com.example.infinite_track.data.mapper.booking
 
+import com.example.infinite_track.data.soucre.network.response.booking.BookingData
+import com.example.infinite_track.data.soucre.network.response.booking.BookingHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.booking.BookingItem
+import com.example.infinite_track.data.soucre.network.response.booking.BookingSummaryData
+import com.example.infinite_track.data.soucre.network.response.booking.PaginationData
 import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.model.booking.BookingHistoryPage
+import com.example.infinite_track.domain.model.booking.BookingHistoryPagination
+import com.example.infinite_track.domain.model.booking.BookingHistorySummary
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+fun BookingHistoryResponse.toDomain(): BookingHistoryPage {
+    val responseData = data
+    return BookingHistoryPage(
+        bookings = responseData?.bookings.orEmpty().map { it.toDomain() },
+        summary = responseData?.summary.toDomain(),
+        pagination = responseData?.pagination.toDomain()
+    )
+}
+
+fun BookingData.toDomain(): BookingHistoryPage {
+    return BookingHistoryPage(
+        bookings = bookings.map { it.toDomain() },
+        summary = summary.toDomain(),
+        pagination = pagination.toDomain()
+    )
+}
+
 fun BookingItem.toDomain(): BookingHistoryItem {
-	return BookingHistoryItem(
-		id = this.bookingId.toString(),
-		locationDescription = this.location.description,
-		scheduleDate = formatScheduleDateId(this.scheduleDate),
-		status = formatStatusTitle(this.status),
-		notes = this.notes ?: "",
-		suitabilityLabel = this.suitabilityLabel ?: mapSuitabilityLabelId(this.suitabilityScore),
-		bookingId = this.bookingId,
-		scheduleDateRaw = this.scheduleDate,
-		statusRaw = this.status
-	)
+    val rawStatus = statusKey?.takeIf { it.isNotBlank() }
+        ?: status?.takeIf { it.isNotBlank() }
+        ?: "unknown"
+    val displayStatus = statusLabel?.takeIf { it.isNotBlank() } ?: formatStatusTitle(rawStatus)
+    val rawScheduleDate = scheduleDate.orEmpty()
+    val rawCreatedAt = createdAt.orEmpty()
+    val displayProcessedAt = formatProcessedAt(processedAt, rawStatus)
+
+    return BookingHistoryItem(
+        id = bookingId.toString(),
+        locationDescription = location?.description?.takeIf { it.isNotBlank() } ?: "Location not available",
+        scheduleDate = formatScheduleDateId(rawScheduleDate),
+        status = displayStatus,
+        notes = notes?.takeIf { it.isNotBlank() } ?: "No notes provided",
+        suitabilityLabel = suitabilityLabel?.takeIf { it.isNotBlank() } ?: "Not available",
+        bookingId = bookingId,
+        scheduleDateRaw = rawScheduleDate,
+        statusRaw = status.orEmpty(),
+        statusKey = rawStatus.lowercase(Locale.getDefault()),
+        statusLabel = displayStatus,
+        suitabilityScore = suitabilityScore,
+        createdAtRaw = rawCreatedAt,
+        createdAt = formatDateTimeId(rawCreatedAt),
+        processedAtRaw = processedAt,
+        processedAt = displayProcessedAt
+    )
+}
+
+private fun BookingSummaryData?.toDomain(): BookingHistorySummary {
+    return BookingHistorySummary(
+        total = this?.total ?: 0,
+        pending = this?.pending ?: 0,
+        approved = this?.approved ?: 0,
+        rejected = this?.rejected ?: 0
+    )
+}
+
+private fun PaginationData?.toDomain(): BookingHistoryPagination {
+    return BookingHistoryPagination(
+        currentPage = this?.currentPage ?: 1,
+        totalPages = this?.totalPages ?: 1,
+        totalItems = this?.totalItems ?: 0,
+        itemsPerPage = this?.itemsPerPage ?: 10,
+        hasNextPage = this?.hasNextPage ?: false,
+        hasPreviousPage = this?.hasPreviousPage ?: false
+    )
 }
 
 private fun formatScheduleDateId(dateString: String): String {
-	return try {
-		val date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-		date.format(DateTimeFormatter.ofPattern("d MMM yyyy", Locale("id", "ID")))
-	} catch (e: Exception) {
-		dateString // Return original if parsing fails
-	}
+    if (dateString.isBlank()) return "-"
+    return try {
+        val date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        date.format(DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.ENGLISH))
+    } catch (e: Exception) {
+        dateString
+    }
+}
+
+private fun formatDateTimeId(dateTimeString: String): String {
+    if (dateTimeString.isBlank()) return "-"
+    return try {
+        val dateTime = LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        dateTime.format(DateTimeFormatter.ofPattern("dd MMM yyyy", Locale.ENGLISH))
+    } catch (e: Exception) {
+        dateTimeString
+    }
+}
+
+private fun formatProcessedAt(processedAt: String?, statusKey: String): String {
+    if (!processedAt.isNullOrBlank()) return formatDateTimeId(processedAt)
+    return if (statusKey.equals("pending", ignoreCase = true)) {
+        "Waiting approval"
+    } else {
+        "Not processed yet"
+    }
 }
 
 private fun formatStatusTitle(status: String): String {
-	return status.lowercase().replaceFirstChar {
-		if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-	}
-}
-
-private fun mapSuitabilityLabelId(score: Float?): String {
-	val s = score ?: return ""
-	return when {
-		s >= 85f -> "Sangat Sesuai"
-		s >= 70f -> "Sesuai"
-		s >= 50f -> "Cukup Sesuai"
-		else -> "Kurang Sesuai"
-	}
+    return status.lowercase(Locale.getDefault()).replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+    }
 }

--- a/app/src/main/java/com/example/infinite_track/data/repository/booking/BookingRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/booking/BookingRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.example.infinite_track.data.mapper.booking.toDomain
 import com.example.infinite_track.data.soucre.network.request.BookingRequest
 import com.example.infinite_track.data.soucre.network.response.ErrorResponse
 import com.example.infinite_track.data.soucre.network.retrofit.ApiService
-import com.example.infinite_track.domain.model.booking.BookingHistoryItem
 import com.example.infinite_track.domain.model.booking.BookingHistoryPage
 import com.example.infinite_track.domain.repository.BookingRepository
 import com.google.gson.Gson
@@ -14,79 +13,78 @@ import retrofit2.HttpException
 import javax.inject.Inject
 
 class BookingRepositoryImpl @Inject constructor(
-	private val apiService: ApiService,
-	private val gson: Gson
+    private val apiService: ApiService,
+    private val gson: Gson
 ) : BookingRepository {
 
-	override suspend fun getBookingHistory(
-		status: String?,
-		page: Int,
-		limit: Int,
-		sortBy: String,
-		sortOrder: String
-	): Result<BookingHistoryPage> {
-		return withContext(Dispatchers.IO) {
-			try {
-				val response = apiService.getBookingHistory(
-					status = status,
-					page = page,
-					limit = limit,
-					sortBy = sortBy,
-					sortOrder = sortOrder
-				)
-				val bookingHistoryItems = response.data.bookings.map { it.toDomain() }
-				val pageResult = BookingHistoryPage(
-					bookings = bookingHistoryItems,
-					hasNextPage = response.data.pagination.hasNextPage
-				)
-				Result.success(pageResult)
-			} catch (e: Exception) {
-				Result.failure(e)
-			}
-		}
-	}
+    override suspend fun getBookingHistory(
+        status: String?,
+        page: Int,
+        limit: Int,
+        sortBy: String,
+        sortOrder: String
+    ): Result<BookingHistoryPage> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = apiService.getBookingHistory(
+                    status = status,
+                    page = page,
+                    limit = limit,
+                    sortBy = sortBy,
+                    sortOrder = sortOrder
+                )
+                if (response.success) {
+                    Result.success(response.toDomain())
+                } else {
+                    Result.failure(Exception(response.message ?: "Riwayat booking gagal diambil."))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
 
-	override suspend fun submitBooking(
-		scheduleDate: String,
-		latitude: Double,
-		longitude: Double,
-		radius: Int,
-		description: String,
-		notes: String
-	): Result<Unit> {
-		return withContext(Dispatchers.IO) {
-			try {
-				val request = BookingRequest(
-					scheduleDate = scheduleDate,
-					latitude = latitude,
-					longitude = longitude,
-					radius = radius,
-					description = description,
-					notes = notes
-				)
+    override suspend fun submitBooking(
+        scheduleDate: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Int,
+        description: String,
+        notes: String
+    ): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val request = BookingRequest(
+                    scheduleDate = scheduleDate,
+                    latitude = latitude,
+                    longitude = longitude,
+                    radius = radius,
+                    description = description,
+                    notes = notes
+                )
 
-				val response = apiService.submitWfaBooking(request)
+                val response = apiService.submitWfaBooking(request)
 
-				if (response.success) {
-					Result.success(Unit)
-				} else {
-					// If success=false, use message from server
-					Result.failure(Exception(response.message))
-				}
-			} catch (e: HttpException) {
-				// Handle HTTP errors (like 400 or 500)
-				val errorBody = e.response()?.errorBody()?.string()
-				val errorResponse = try {
-					gson.fromJson(errorBody, ErrorResponse::class.java)
-				} catch (e: Exception) {
-					null
-				}
-				val errorMessage = errorResponse?.message ?: "Terjadi kesalahan jaringan."
-				Result.failure(Exception(errorMessage))
-			} catch (e: Exception) {
-				// For other errors (like no connection)
-				Result.failure(Exception("Tidak dapat terhubung ke server."))
-			}
-		}
-	}
+                if (response.success) {
+                    Result.success(Unit)
+                } else {
+                    // If success=false, use message from server
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: HttpException) {
+                // Handle HTTP errors (like 400 or 500)
+                val errorBody = e.response()?.errorBody()?.string()
+                val errorResponse = try {
+                    gson.fromJson(errorBody, ErrorResponse::class.java)
+                } catch (e: Exception) {
+                    null
+                }
+                val errorMessage = errorResponse?.message ?: "Terjadi kesalahan jaringan."
+                Result.failure(Exception(errorMessage))
+            } catch (e: Exception) {
+                // For other errors (like no connection)
+                Result.failure(Exception("Tidak dapat terhubung ke server."))
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/booking/BookingHistoryResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/booking/BookingHistoryResponse.kt
@@ -4,90 +4,107 @@ import com.google.gson.annotations.SerializedName
 
 data class BookingHistoryResponse(
     @SerializedName("success")
-    val success: Boolean,
+    val success: Boolean = false,
     @SerializedName("message")
-    val message: String,
+    val message: String? = null,
     @SerializedName("data")
-    val data: BookingData
+    val data: BookingData? = null
 )
 
 data class BookingData(
+    @SerializedName("summary")
+    val summary: BookingSummaryData? = null,
     @SerializedName("bookings")
-    val bookings: List<BookingItem>,
+    val bookings: List<BookingItem> = emptyList(),
     @SerializedName("pagination")
-    val pagination: PaginationData,
+    val pagination: PaginationData? = null,
     @SerializedName("filters")
-    val filters: FilterData
+    val filters: FilterData? = null
+)
+
+data class BookingSummaryData(
+    @SerializedName("total")
+    val total: Int = 0,
+    @SerializedName("pending")
+    val pending: Int = 0,
+    @SerializedName("approved")
+    val approved: Int = 0,
+    @SerializedName("rejected")
+    val rejected: Int = 0
 )
 
 data class BookingItem(
     @SerializedName("booking_id")
-    val bookingId: Int,
+    val bookingId: Int = 0,
     @SerializedName("user_id")
-    val userId: Int,
+    val userId: Int? = null,
     @SerializedName("user_full_name")
-    val userFullName: String?,
+    val userFullName: String? = null,
     @SerializedName("user_email")
-    val userEmail: String?,
+    val userEmail: String? = null,
     @SerializedName("user_nip_nim")
-    val userNipNim: String?,
+    val userNipNim: String? = null,
     @SerializedName("user_position_name")
-    val userPositionName: String?,
+    val userPositionName: String? = null,
     @SerializedName("user_role_name")
-    val userRoleName: String?,
+    val userRoleName: String? = null,
     @SerializedName("schedule_date")
-    val scheduleDate: String,
+    val scheduleDate: String? = null,
     @SerializedName("status")
-    val status: String,
+    val status: String? = null,
+    @SerializedName("status_key")
+    val statusKey: String? = null,
+    @SerializedName("status_label")
+    val statusLabel: String? = null,
     @SerializedName("location")
-    val location: BookingLocation,
+    val location: BookingLocation? = null,
     @SerializedName("notes")
-    val notes: String?,
+    val notes: String? = null,
     @SerializedName("suitability_score")
-    val suitabilityScore: Float?,
+    val suitabilityScore: Double? = null,
     @SerializedName("suitability_label")
-    val suitabilityLabel: String?,
+    val suitabilityLabel: String? = null,
     @SerializedName("created_at")
-    val createdAt: String,
+    val createdAt: String? = null,
     @SerializedName("processed_at")
-    val processedAt: String?,
+    val processedAt: String? = null,
     @SerializedName("approved_by")
-    val approvedBy: Int?
+    val approvedBy: Int? = null
 )
 
 data class BookingLocation(
     @SerializedName("location_id")
-    val locationId: Int,
+    val locationId: Int? = null,
     @SerializedName("latitude")
-    val latitude: Double,
+    val latitude: Double? = null,
     @SerializedName("longitude")
-    val longitude: Double,
+    val longitude: Double? = null,
     @SerializedName("radius")
-    val radius: Float,
+    val radius: Float? = null,
     @SerializedName("description")
-    val description: String
+    val description: String? = null
 )
 
 data class PaginationData(
     @SerializedName("current_page")
-    val currentPage: Int,
+    val currentPage: Int = 1,
     @SerializedName("total_pages")
-    val totalPages: Int,
+    val totalPages: Int = 1,
     @SerializedName("total_items")
-    val totalItems: Int,
+    val totalItems: Int = 0,
     @SerializedName("items_per_page")
-    val itemsPerPage: Int,
+    val itemsPerPage: Int = 10,
     @SerializedName("has_next_page")
-    val hasNextPage: Boolean,
+    val hasNextPage: Boolean = false,
     @SerializedName("has_previous_page")
-    val hasPreviousPage: Boolean
+    val hasPreviousPage: Boolean = false
 )
 
 data class FilterData(
     @SerializedName("status")
-    val status: String?,
+    val status: String? = null,
     @SerializedName("sort_by")
-    val sortBy: String,
+    val sortBy: String? = null,
     @SerializedName("sort_order")
-    val sortOrder: String
+    val sortOrder: String? = null
 )

--- a/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
@@ -9,5 +9,12 @@ data class BookingHistoryItem(
     val suitabilityLabel: String,
     val bookingId: Int = 0,
     val scheduleDateRaw: String = "",
-    val statusRaw: String = ""
+    val statusRaw: String = "",
+    val statusKey: String = statusRaw,
+    val statusLabel: String = status,
+    val suitabilityScore: Double? = null,
+    val createdAtRaw: String = "",
+    val createdAt: String = "-",
+    val processedAtRaw: String? = null,
+    val processedAt: String = "Not processed yet"
 )

--- a/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryPage.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryPage.kt
@@ -1,6 +1,24 @@
 package com.example.infinite_track.domain.model.booking
 
 data class BookingHistoryPage(
-	val bookings: List<BookingHistoryItem>,
-	val hasNextPage: Boolean
-) 
+    val bookings: List<BookingHistoryItem>,
+    val summary: BookingHistorySummary = BookingHistorySummary(),
+    val pagination: BookingHistoryPagination = BookingHistoryPagination(),
+    val hasNextPage: Boolean = pagination.hasNextPage
+)
+
+data class BookingHistorySummary(
+    val total: Int = 0,
+    val pending: Int = 0,
+    val approved: Int = 0,
+    val rejected: Int = 0
+)
+
+data class BookingHistoryPagination(
+    val currentPage: Int = 1,
+    val totalPages: Int = 1,
+    val totalItems: Int = 0,
+    val itemsPerPage: Int = 10,
+    val hasNextPage: Boolean = false,
+    val hasPreviousPage: Boolean = false
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/components/cards/BookingHistoryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/cards/BookingHistoryCard.kt
@@ -31,6 +31,7 @@ import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_400
 import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.requestStatusColor
 
 @Composable
 fun BookingHistoryCard(
@@ -173,14 +174,7 @@ fun BookingHistoryCard(
 			modifier = Modifier
 				.align(Alignment.TopEnd)
 				.clip(RoundedCornerShape(topEnd = 16.dp, bottomStart = 8.dp))
-				.background(
-					when (booking.status) {
-						"Pending" -> Color(0xFFFFC107)
-						"Approved" -> Color(0xFF4CAF50)
-						"Rejected" -> Color(0xFFF44336)
-						else -> Color(0xFFFFC107)
-					}
-				)
+				.background(requestStatusColor(booking.statusKey.ifBlank { booking.status }))
 				.padding(horizontal = 12.dp, vertical = 4.dp)
 		) {
 			Text(

--- a/app/src/main/java/com/example/infinite_track/presentation/components/loading/InlineRefreshingIndicator.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/loading/InlineRefreshingIndicator.kt
@@ -1,0 +1,56 @@
+package com.example.infinite_track.presentation.components.loading
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.White
+
+@Composable
+fun InlineRefreshingIndicator(
+    message: String,
+    modifier: Modifier = Modifier,
+    indicatorSize: Dp = 20.dp,
+    backgroundColor: Color = White.copy(alpha = 0.82f),
+    indicatorColor: Color = Blue_500,
+    contentColor: Color = Purple_300,
+    shape: Shape = RoundedCornerShape(16.dp)
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(backgroundColor, shape)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(indicatorSize),
+            color = indicatorColor,
+            strokeWidth = 2.dp
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = contentColor
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -46,8 +46,7 @@ fun NavGraphBuilder.mainContentNavGraph(
             viewModel = homeViewModel,
             navigateAttendance = { navController.safeNavigate(Screen.Attendance.route) },
             navigateTimeOffRequest = { navController.safeNavigate(Screen.TimeOffRequest.route) },
-            navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) },
-            navigateToBookingHistory = { navController.safeNavigate(Screen.DetailsMyBooking.route) }
+            navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) }
         )
     }
 
@@ -93,7 +92,9 @@ fun NavGraphBuilder.mainContentNavGraph(
     }
 
     composable(Screen.Wfa.route) {
-        WfaHistoryScreen()
+        WfaHistoryScreen(
+            onOpenAttendance = { navController.safeNavigate(Screen.Attendance.route) }
+        )
     }
 
     // Profile Feature Flow

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
@@ -27,12 +27,9 @@ fun HomeScreen(
     navigateAttendance: () -> Unit = {},
     navigateTimeOffRequest: () -> Unit = {},
     navigateListMyAttendance: () -> Unit = {},
-    navigateToBookingHistory: () -> Unit = {},
 ) {
-    // Collect all state from centralized HomeViewModel
     val userProfile by viewModel.userProfileState.collectAsState()
     val attendanceState by viewModel.topAttendanceHistoryState.collectAsState()
-    val bookingHistoryState by viewModel.bookingHistoryState.collectAsState()
     val annualBalance by viewModel.annualBalance.collectAsState()
     val annualUsed by viewModel.annualUsed.collectAsState()
     val currentLocation by viewModel.currentAddressState.collectAsState()
@@ -50,10 +47,8 @@ fun HomeScreen(
                 contentAlignment = Alignment.Center
             ) {
                 if (userProfile == null) {
-                    // Show loading indicator when user profile is not yet loaded
                     LoadingAnimation()
                 } else {
-                    // Display content based on user role
                     Column(
                         modifier = modifier
                             .fillMaxSize()
@@ -61,37 +56,30 @@ fun HomeScreen(
                     ) {
                         when (userProfile?.roleName) {
                             "Internship" -> {
-                                // Use InternshipContent with both attendance and booking history data
                                 InternshipContent(
                                     user = userProfile,
                                     summaryData = internshipSummary,
                                     currentLocation = currentLocation,
                                     attendanceState = attendanceState,
-                                    bookingHistoryState = bookingHistoryState,
-                                    navigateToListMyAttendance = navigateListMyAttendance,
-                                    navigateToBookingHistory = navigateToBookingHistory
+                                    navigateToListMyAttendance = navigateListMyAttendance
                                 )
                             }
 
                             "Admin", "Employee", "Management" -> {
-                                // Use EmployeeAndManagerComponent with both attendance and booking history data
                                 EmployeeAndManagerComponent(
                                     user = userProfile,
                                     attendanceState = attendanceState,
-                                    bookingHistoryState = bookingHistoryState,
                                     annualBalance = annualBalance,
                                     annualUsed = annualUsed,
                                     currentLocation = currentLocation,
                                     isLoading = isLoading,
                                     navigateAttendance = navigateAttendance,
                                     navigateTimeOffRequest = navigateTimeOffRequest,
-                                    navigateListMyAttendance = navigateListMyAttendance,
-                                    navigateToBookingHistory = navigateToBookingHistory
+                                    navigateListMyAttendance = navigateListMyAttendance
                                 )
                             }
 
                             else -> {
-                                // Display a message for unknown role
                                 Text("Unknown user role: ${userProfile?.roleName}")
                             }
                         }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
@@ -52,11 +52,7 @@ class HomeViewModel @Inject constructor(
 	private val _annualUsed = MutableStateFlow(5)
 	val annualUsed: StateFlow<Int> = _annualUsed
 
-	// Booking history state for WFA
-	private val _bookingHistoryState =
-		MutableStateFlow<UiState<List<BookingHistoryItem>>>(UiState.Loading)
-	val bookingHistoryState: StateFlow<UiState<List<BookingHistoryItem>>> = _bookingHistoryState
-
+	// Detailed booking history state for legacy DetailsMyBooking route; WFA tab owns the primary booking history UI.
 	// Detailed booking history state for DetailsMyBooking screen
 	data class BookingHistoryDetailsState(
 		val isLoading: Boolean = true,
@@ -79,7 +75,6 @@ class HomeViewModel @Inject constructor(
 		fetchCurrentAddress()
 		loadDummyLeaveData()
 		fetchInternshipDashboardData()
-		fetchTopBookingHistory()
 	}
 
 	private fun fetchUserProfile() {
@@ -131,27 +126,6 @@ class HomeViewModel @Inject constructor(
 			}.onFailure {
 				// On failure, just leave the state as null
 				_internshipSummaryState.value = null
-			}
-		}
-	}
-
-	private fun fetchTopBookingHistory() {
-		viewModelScope.launch {
-			_bookingHistoryState.value = UiState.Loading
-			try {
-				val result = getBookingHistoryUseCase(
-					status = null, // null means all
-					page = 1,
-					limit = 3
-				)
-				result.onSuccess { bookingPage ->
-					_bookingHistoryState.value = UiState.Success(bookingPage.bookings)
-				}.onFailure { exception ->
-					_bookingHistoryState.value =
-						UiState.Error(exception.message ?: "Unknown error occurred")
-				}
-			} catch (e: Exception) {
-				_bookingHistoryState.value = UiState.Error(e.message ?: "Unknown error occurred")
 			}
 		}
 	}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -19,10 +19,8 @@ import androidx.compose.ui.unit.dp
 import com.example.infinite_track.R
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.domain.model.booking.BookingHistoryItem
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.cards.BookingHistoryCard
 import com.example.infinite_track.presentation.components.cards.MenuCard
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
@@ -37,7 +35,6 @@ fun EmployeeAndManagerComponent(
     modifier: Modifier = Modifier,
     user: UserModel?,
     attendanceState: UiState<List<AttendanceRecord>>,
-    bookingHistoryState: UiState<List<BookingHistoryItem>>,
     annualBalance: Int,
     annualUsed: Int,
     currentLocation: String,
@@ -45,7 +42,6 @@ fun EmployeeAndManagerComponent(
     navigateAttendance: () -> Unit,
     navigateTimeOffRequest: () -> Unit,
     navigateListMyAttendance: () -> Unit,
-    navigateToBookingHistory: () -> Unit,
 ) {
     val annualLeft = annualBalance - annualUsed
 
@@ -81,7 +77,6 @@ fun EmployeeAndManagerComponent(
 
                 Spacer(modifier.height(12.dp))
 
-                // Loading (jika sedang memuat data)
                 if (isLoading) {
                     Box(
                         modifier = Modifier
@@ -94,7 +89,6 @@ fun EmployeeAndManagerComponent(
                 } else {
                     Spacer(modifier.height(12.dp))
 
-                    // Tombol lihat semua absensi
                     SeeAllButton(
                         label = stringResource(R.string.attendance_history),
                         onClickButton = navigateListMyAttendance
@@ -102,7 +96,6 @@ fun EmployeeAndManagerComponent(
 
                     Spacer(modifier.height(12.dp))
 
-                    // Data Absensi
                     when (attendanceState) {
                         is UiState.Success -> {
                             if (attendanceState.data.isEmpty()) {
@@ -112,9 +105,7 @@ fun EmployeeAndManagerComponent(
                                         .padding(vertical = 24.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Column(
-                                        horizontalAlignment = Alignment.CenterHorizontally,
-                                    ) {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                         EmptyListAnimation(modifier = Modifier.size(150.dp))
                                         Text(
                                             text = "No attendance records found",
@@ -123,9 +114,7 @@ fun EmployeeAndManagerComponent(
                                     }
                                 }
                             } else {
-                                // Using Column instead of LazyColumn for better height management
-                                val attendanceItems =
-                                    attendanceState.data.take(5) // Max 5 items for employee/manager
+                                val attendanceItems = attendanceState.data.take(5)
                                 Column(
                                     modifier = Modifier.fillMaxWidth(),
                                     verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -142,9 +131,7 @@ fun EmployeeAndManagerComponent(
                                 modifier = Modifier.fillMaxWidth(),
                                 contentAlignment = Alignment.Center
                             ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                     EmptyListAnimation(modifier = Modifier.size(150.dp))
                                     Text(
                                         text = attendanceState.errorMessage,
@@ -165,91 +152,8 @@ fun EmployeeAndManagerComponent(
                             }
                         }
 
-                        is UiState.Idle -> {
-                            // Do nothing or show a placeholder if needed
-                        }
+                        is UiState.Idle -> Unit
                     }
-                    Spacer(modifier.height(12.dp))
-
-                    SeeAllButton(
-                        label = "Riwayat Booking WFA",
-                        onClickButton = navigateToBookingHistory
-                    )
-
-                    Spacer(modifier.height(12.dp))
-
-                    // Data Booking History
-                    when (bookingHistoryState) {
-                        is UiState.Success -> {
-                            if (bookingHistoryState.data.isEmpty()) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Column(
-                                        horizontalAlignment = Alignment.CenterHorizontally,
-                                    ) {
-                                        EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                        Text(
-                                            text = "No booking records found",
-                                            style = headline4,
-                                        )
-                                    }
-                                }
-                            } else {
-                                // Using Column instead of LazyColumn for better height management
-                                val bookingItems = bookingHistoryState.data.take(3) // Max 3 items
-                                Column(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    bookingItems.forEach { booking ->
-                                        BookingHistoryCard(booking = booking)
-                                    }
-                                }
-                            }
-                        }
-
-                        is UiState.Error -> {
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                    Text(
-                                        text = bookingHistoryState.errorMessage,
-                                        style = headline4,
-                                    )
-                                }
-                            }
-                        }
-
-                        is UiState.Loading -> {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 24.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                LoadingAnimation()
-                            }
-                        }
-
-                        is UiState.Idle -> {
-                            // Do nothing or show a placeholder if needed
-                        }
-                    }
-
-                    // Dynamic spacing - only add spacer if there are booking items
-                    if (bookingHistoryState is UiState.Success && bookingHistoryState.data.isNotEmpty()) {
-                        Spacer(modifier.height(12.dp))
-                    }
-
                 }
             }
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -22,11 +22,9 @@ import androidx.compose.ui.unit.dp
 import com.example.infinite_track.R
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.domain.model.booking.BookingHistoryItem
 import com.example.infinite_track.domain.model.dashboard.InternshipSummary
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.cards.BookingHistoryCard
 import com.example.infinite_track.presentation.components.cards.CardAbsence
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.images.ImageSlider
@@ -44,9 +42,7 @@ fun InternshipContent(
     summaryData: InternshipSummary?,
     currentLocation: String,
     attendanceState: UiState<List<AttendanceRecord>>,
-    bookingHistoryState: UiState<List<BookingHistoryItem>>,
     navigateToListMyAttendance: () -> Unit,
-    navigateToBookingHistory: () -> Unit,
 ) {
     Box(
         modifier = modifier.fillMaxSize()
@@ -77,7 +73,6 @@ fun InternshipContent(
             Spacer(modifier = Modifier.height(16.dp))
 
             if (summaryData != null) {
-                // Define card configurations for the grid
                 val cardConfigurations = listOf(
                     Triple(
                         "Checked In",
@@ -97,7 +92,6 @@ fun InternshipContent(
                     )
                 )
 
-                // Create a 2x2 grid of summary cards
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(2),
                     modifier = Modifier
@@ -112,12 +106,11 @@ fun InternshipContent(
                             cardTitle = cardTitle,
                             cardText = cardText,
                             cardImage = cardImage,
-                            onClick = { /* Handle card click if needed */ }
+                            onClick = { }
                         )
                     }
                 }
             } else {
-                // Add a spacer when data is not available
                 Spacer(modifier = Modifier.height(180.dp))
             }
 
@@ -125,7 +118,6 @@ fun InternshipContent(
             ImageSlider()
             Spacer(modifier = Modifier.height(12.dp))
 
-            // First: Attendance History Section
             SeeAllButton(
                 label = stringResource(R.string.attendance_history),
                 onClickButton = navigateToListMyAttendance
@@ -133,7 +125,6 @@ fun InternshipContent(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // Display attendance history
             when (attendanceState) {
                 is UiState.Loading -> {
                     Box(
@@ -154,9 +145,7 @@ fun InternshipContent(
                                 .padding(vertical = 24.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                            ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 EmptyListAnimation(modifier = Modifier.size(150.dp))
                                 Text(
                                     text = "No attendance records found",
@@ -165,8 +154,7 @@ fun InternshipContent(
                             }
                         }
                     } else {
-                        // Using Column instead of LazyColumn for better height management
-                        val attendanceItems = attendanceState.data.take(3) // Max 3 items
+                        val attendanceItems = attendanceState.data.take(3)
                         Column(
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -185,9 +173,7 @@ fun InternshipContent(
                             .padding(vertical = 24.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             EmptyListAnimation(modifier = Modifier.size(150.dp))
                             Text(
                                 text = attendanceState.errorMessage,
@@ -197,92 +183,7 @@ fun InternshipContent(
                     }
                 }
 
-                is UiState.Idle -> {
-                    // Do nothing or show a placeholder if needed
-                }
-            }
-
-            // Dynamic spacing - only add spacer if there are attendance items
-            if (attendanceState is UiState.Success && attendanceState.data.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Second: Booking History Section
-            SeeAllButton(
-                label = "Riwayat Booking WFA",
-                onClickButton = navigateToBookingHistory
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Display booking history
-            when (bookingHistoryState) {
-                is UiState.Loading -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        LoadingAnimation()
-                    }
-                }
-
-                is UiState.Success -> {
-                    if (bookingHistoryState.data.isEmpty()) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 24.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                            ) {
-                                EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                Text(
-                                    text = "No booking records found",
-                                    style = headline4,
-                                )
-                            }
-                        }
-                    } else {
-                        // Using Column instead of LazyColumn for better height management
-                        val bookingItems = bookingHistoryState.data.take(3) // Max 3 items
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            bookingItems.forEach { booking ->
-                                BookingHistoryCard(booking = booking)
-                            }
-                        }
-                    }
-                }
-
-                is UiState.Error -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            EmptyListAnimation(modifier = Modifier.size(150.dp))
-                            Text(
-                                text = bookingHistoryState.errorMessage,
-                                style = headline4,
-                            )
-                        }
-                    }
-                }
-
-                is UiState.Idle -> {
-                    // Do nothing or show a placeholder if needed
-                }
+                is UiState.Idle -> Unit
             }
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaHistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaHistoryScreen.kt
@@ -1,64 +1,19 @@
 package com.example.infinite_track.presentation.screen.wfa
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.example.infinite_track.presentation.core.headline2
 import com.example.infinite_track.presentation.screen.home.HomeViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 fun WfaHistoryScreen(
-    viewModel: HomeViewModel = hiltViewModel()
+    onOpenAttendance: () -> Unit
 ) {
-    val uiState by viewModel.bookingHistoryDetailsState.collectAsStateWithLifecycle()
-    val listState = rememberLazyListState()
-
-    InitializeBookingHistoryEffect(
-        uiState = uiState,
-        onLoadAllBookings = { viewModel.onBookingStatusFilterChanged("all") }
-    )
-    BookingHistoryPaginationEffect(
-        uiState = uiState,
-        listState = listState,
-        onLoadMoreBookings = viewModel::loadMoreBookings
-    )
-
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        containerColor = Color.Transparent,
-        topBar = {
-            Text(
-                text = "Riwayat Booking WFA",
-                style = headline2,
-                modifier = Modifier.padding(start = 16.dp, top = 32.dp)
-            )
-        }
-    ) { innerPadding ->
-        WfaBookingHistoryContent(
-            uiState = uiState,
-            listState = listState,
-            onStatusSelected = viewModel::onBookingStatusFilterChanged,
-            onRetryClick = viewModel::retryBookingHistoryLoad,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp)
-        )
-    }
+    WfaRequestsScreen(onOpenAttendance = onOpenAttendance)
 }
 
 @Composable

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -1,0 +1,349 @@
+package com.example.infinite_track.presentation.screen.wfa
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.infinite_track.presentation.components.loading.InlineRefreshingIndicator
+import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestCard
+import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestFilterChips
+import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestStatusSummary
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Blue_600
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+@Composable
+fun WfaRequestsScreen(
+    onOpenAttendance: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: WfaRequestsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+    val refreshDragDistance = remember { mutableStateOf(0f) }
+    val pullToRefreshConnection = remember(listState, uiState.isLoading, uiState.isRefreshing) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0 && listState.isAtTop() && !uiState.isLoading && !uiState.isRefreshing) {
+                    refreshDragDistance.value += available.y
+                    if (refreshDragDistance.value >= PullToRefreshThresholdPx) {
+                        refreshDragDistance.value = 0f
+                        viewModel.refresh()
+                    }
+                }
+                if (available.y < 0) {
+                    refreshDragDistance.value = 0f
+                }
+                return Offset.Zero
+            }
+        }
+    }
+
+    WfaRequestsPaginationEffect(
+        uiState = uiState,
+        listState = listState,
+        onLoadMore = viewModel::loadMore
+    )
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = Color.Transparent,
+        bottomBar = {
+            OpenAttendanceAction(
+                onOpenAttendance = onOpenAttendance,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(pullToRefreshConnection)
+                .padding(innerPadding)
+                .padding(horizontal = 20.dp),
+            contentPadding = PaddingValues(top = 24.dp, bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                WfaRequestsHeader()
+            }
+
+            if (uiState.isRefreshing) {
+                item {
+                    InlineRefreshingIndicator(message = "Refreshing WFA requests...")
+                }
+            }
+
+            item {
+                WfaRequestStatusSummary(summary = uiState.summary)
+            }
+
+            item {
+                WfaRequestFilterChips(
+                    selectedFilter = uiState.selectedFilter,
+                    onFilterSelected = viewModel::onFilterSelected
+                )
+            }
+
+            item {
+                Text(
+                    text = "Recent WFA Requests",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Purple_500,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            when {
+                uiState.isLoading -> {
+                    item { LoadingState() }
+                }
+
+                uiState.errorMessage != null && uiState.bookings.isEmpty() -> {
+                    item {
+                        ErrorState(
+                            message = uiState.errorMessage ?: "Unable to load WFA requests.",
+                            onRetry = viewModel::retry
+                        )
+                    }
+                }
+
+                uiState.isEmpty -> {
+                    item { EmptyState() }
+                }
+
+                else -> {
+                    items(
+                        items = uiState.bookings,
+                        key = { booking -> "${booking.bookingId}-${booking.scheduleDateRaw}-${booking.statusKey}" }
+                    ) { booking ->
+                        WfaRequestCard(booking = booking)
+                    }
+
+                    if (uiState.isLoadingMore) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(color = Blue_500)
+                            }
+                        }
+                    }
+
+                    if (uiState.errorMessage != null && uiState.bookings.isNotEmpty()) {
+                        item {
+                            ErrorState(
+                                message = uiState.errorMessage ?: "Unable to load more WFA requests.",
+                                onRetry = viewModel::loadMore
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WfaRequestsHeader() {
+    Column {
+        Text(
+            text = "WFA Requests",
+            style = MaterialTheme.typography.headlineMedium,
+            color = Purple_500,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = "Track your Work From Anywhere submissions",
+            style = MaterialTheme.typography.bodyLarge,
+            color = Blue_600,
+            modifier = Modifier.padding(top = 2.dp)
+        )
+    }
+}
+
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(220.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(color = Blue_500)
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.86f), RoundedCornerShape(18.dp))
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "No WFA requests yet",
+            style = MaterialTheme.typography.titleMedium,
+            color = Purple_500,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Create a WFA request from Attendance when you need to work from another location.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Purple_300,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(
+    message: String,
+    onRetry: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.86f), RoundedCornerShape(18.dp))
+            .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(onClick = onRetry) {
+            Text(text = "Retry")
+        }
+    }
+}
+
+@Composable
+private fun OpenAttendanceAction(
+    onOpenAttendance: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Button(
+        onClick = onOpenAttendance,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(58.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+        contentPadding = PaddingValues()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.horizontalGradient(
+                        listOf(Blue_500, Blue_600)
+                    ),
+                    shape = RoundedCornerShape(18.dp)
+                ),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            androidx.compose.material3.Icon(
+                imageVector = Icons.Default.ArrowForward,
+                contentDescription = null,
+                tint = Color.White
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = "Open Attendance",
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+private const val PullToRefreshThresholdPx = 160f
+
+private fun LazyListState.isAtTop(): Boolean =
+    firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+
+@Composable
+private fun WfaRequestsPaginationEffect(
+    uiState: WfaRequestsUiState,
+    listState: LazyListState,
+    onLoadMore: () -> Unit
+) {
+    val latestUiState by rememberUpdatedState(uiState)
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .distinctUntilChanged()
+            .collect { lastVisibleItemIndex ->
+                val currentState = latestUiState
+                val shouldLoadMore =
+                    lastVisibleItemIndex != null &&
+                        currentState.errorMessage == null &&
+                        currentState.bookings.isNotEmpty() &&
+                        lastVisibleItemIndex >= currentState.bookings.size + 2 &&
+                        currentState.pagination.hasNextPage &&
+                        !currentState.isLoading &&
+                        !currentState.isRefreshing &&
+                        !currentState.isLoadingMore
+
+                if (shouldLoadMore) onLoadMore()
+            }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsUiState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsUiState.kt
@@ -1,0 +1,26 @@
+package com.example.infinite_track.presentation.screen.wfa
+
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.model.booking.BookingHistoryPagination
+import com.example.infinite_track.domain.model.booking.BookingHistorySummary
+
+enum class WfaRequestStatusFilter(val key: String, val label: String) {
+    All("all", "All"),
+    Pending("pending", "Pending"),
+    Approved("approved", "Approved"),
+    Rejected("rejected", "Rejected")
+}
+
+data class WfaRequestsUiState(
+    val selectedFilter: WfaRequestStatusFilter = WfaRequestStatusFilter.All,
+    val summary: BookingHistorySummary = BookingHistorySummary(),
+    val bookings: List<BookingHistoryItem> = emptyList(),
+    val pagination: BookingHistoryPagination = BookingHistoryPagination(),
+    val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val errorMessage: String? = null
+) {
+    val isEmpty: Boolean
+        get() = !isLoading && errorMessage == null && bookings.isEmpty()
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsViewModel.kt
@@ -1,0 +1,122 @@
+package com.example.infinite_track.presentation.screen.wfa
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WfaRequestsViewModel @Inject constructor(
+    private val getBookingHistoryUseCase: GetBookingHistoryUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WfaRequestsUiState())
+    val uiState: StateFlow<WfaRequestsUiState> = _uiState
+
+    init {
+        loadRequests(WfaRequestStatusFilter.All)
+    }
+
+    fun onFilterSelected(filter: WfaRequestStatusFilter) {
+        if (_uiState.value.selectedFilter == filter && !_uiState.value.isEmpty) return
+        loadRequests(filter)
+    }
+
+    fun retry() {
+        loadRequests(_uiState.value.selectedFilter)
+    }
+
+    fun refresh() {
+        val currentState = _uiState.value
+        if (currentState.isLoading || currentState.isRefreshing) return
+        loadRequests(currentState.selectedFilter, isRefresh = true)
+    }
+
+    fun loadMore() {
+        val currentState = _uiState.value
+        if (currentState.isLoading || currentState.isRefreshing || currentState.isLoadingMore || !currentState.pagination.hasNextPage) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingMore = true, errorMessage = null) }
+            val nextPage = currentState.pagination.currentPage + 1
+            getBookingHistoryUseCase(
+                status = currentState.selectedFilter.key,
+                page = nextPage,
+                limit = currentState.pagination.itemsPerPage,
+                sortBy = "created_at",
+                sortOrder = "DESC"
+            ).onSuccess { page ->
+                _uiState.update {
+                    it.copy(
+                        summary = page.summary,
+                        bookings = it.bookings + page.bookings,
+                        pagination = page.pagination,
+                        isLoadingMore = false,
+                        errorMessage = null
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        isLoadingMore = false,
+                        errorMessage = error.message ?: "Unable to load more WFA requests."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun loadRequests(
+        filter: WfaRequestStatusFilter,
+        isRefresh: Boolean = false
+    ) {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    selectedFilter = filter,
+                    bookings = if (isRefresh) it.bookings else emptyList(),
+                    isLoading = !isRefresh,
+                    isRefreshing = isRefresh,
+                    isLoadingMore = false,
+                    errorMessage = null
+                )
+            }
+
+            getBookingHistoryUseCase(
+                status = filter.key,
+                page = 1,
+                limit = 10,
+                sortBy = "created_at",
+                sortOrder = "DESC"
+            ).onSuccess { page ->
+                _uiState.update {
+                    it.copy(
+                        selectedFilter = filter,
+                        summary = page.summary,
+                        bookings = page.bookings,
+                        pagination = page.pagination,
+                        isLoading = false,
+                        isRefreshing = false,
+                        isLoadingMore = false,
+                        errorMessage = null
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        selectedFilter = filter,
+                        isLoading = false,
+                        isRefreshing = false,
+                        isLoadingMore = false,
+                        errorMessage = error.message ?: "Unable to load WFA requests."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
@@ -1,0 +1,240 @@
+package com.example.infinite_track.presentation.screen.wfa.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Violet_100
+import com.example.infinite_track.presentation.theme.requestStatusColor
+
+@Composable
+fun WfaRequestCard(
+    booking: BookingHistoryItem,
+    modifier: Modifier = Modifier
+) {
+    val statusColor = requestStatusColor(booking.statusKey)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .clip(RoundedCornerShape(18.dp))
+            .background(Color.White.copy(alpha = 0.9f))
+    ) {
+        Box(
+            modifier = Modifier
+                .width(5.dp)
+                .fillMaxHeight()
+                .background(statusColor)
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = booking.scheduleDate,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = Purple_500,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 6.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.LocationOn,
+                            contentDescription = null,
+                            tint = Blue_500,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = booking.locationDescription,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Purple_300,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+                StatusPill(
+                    label = booking.statusLabel,
+                    color = statusColor
+                )
+            }
+
+            Divider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = Violet_100
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Suitability Score",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Purple_300,
+                    modifier = Modifier.weight(1f)
+                )
+                ScoreBadge(
+                    score = booking.suitabilityScore,
+                    color = statusColor
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = booking.suitabilityLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = statusColor,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Divider(
+                modifier = Modifier.padding(vertical = 12.dp),
+                color = Violet_100
+            )
+
+            InfoRow(label = "Notes", value = booking.notes)
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                MetadataItem(
+                    iconTint = Blue_500,
+                    icon = Icons.Outlined.CalendarMonth,
+                    text = "Submitted: ${booking.createdAt}"
+                )
+                MetadataItem(
+                    iconTint = Blue_500,
+                    icon = Icons.Outlined.HourglassEmpty,
+                    text = "Processed: ${booking.processedAt}"
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusPill(label: String, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50.dp))
+            .background(color.copy(alpha = 0.13f))
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun ScoreBadge(score: Double?, color: Color) {
+    Box(
+        modifier = Modifier
+            .size(42.dp)
+            .clip(CircleShape)
+            .background(color.copy(alpha = 0.11f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = score?.let { String.format("%.1f", it) } ?: "-",
+            style = MaterialTheme.typography.labelLarge,
+            color = color,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Purple_300,
+            modifier = Modifier.weight(0.8f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Purple_500,
+            modifier = Modifier.weight(1.7f),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun MetadataItem(
+    iconTint: Color,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = Purple_300,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestFilterChips.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestFilterChips.kt
@@ -1,0 +1,54 @@
+package com.example.infinite_track.presentation.screen.wfa.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.screen.wfa.WfaRequestStatusFilter
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Purple_500
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WfaRequestFilterChips(
+    selectedFilter: WfaRequestStatusFilter,
+    onFilterSelected: (WfaRequestStatusFilter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        WfaRequestStatusFilter.values().forEach { filter ->
+            val selected = selectedFilter == filter
+            FilterChip(
+                selected = selected,
+                onClick = { onFilterSelected(filter) },
+                label = {
+                    Text(
+                        text = filter.label,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = Blue_500,
+                    selectedLabelColor = Color.White,
+                    containerColor = Color.White.copy(alpha = 0.86f),
+                    labelColor = Purple_500
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
@@ -1,0 +1,111 @@
+package com.example.infinite_track.presentation.screen.wfa.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.booking.BookingHistorySummary
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Status_Approved
+import com.example.infinite_track.presentation.theme.Status_Pending
+import com.example.infinite_track.presentation.theme.Status_Rejected
+
+@Composable
+fun WfaRequestStatusSummary(
+    summary: BookingHistorySummary,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        SummaryCard(
+            label = "Pending",
+            value = summary.pending,
+            caption = "Waiting review",
+            icon = Icons.Default.Schedule,
+            color = Status_Pending,
+            modifier = Modifier.weight(1f)
+        )
+        SummaryCard(
+            label = "Approved",
+            value = summary.approved,
+            caption = "Ready schedule",
+            icon = Icons.Default.CheckCircle,
+            color = Status_Approved,
+            modifier = Modifier.weight(1f)
+        )
+        SummaryCard(
+            label = "Rejected",
+            value = summary.rejected,
+            caption = "Needs follow-up",
+            icon = Icons.Default.Cancel,
+            color = Status_Rejected,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun SummaryCard(
+    label: String,
+    value: Int,
+    caption: String,
+    icon: ImageVector,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .background(Color.White.copy(alpha = 0.82f), RoundedCornerShape(18.dp))
+            .border(BorderStroke(1.dp, color.copy(alpha = 0.35f)), RoundedCornerShape(18.dp))
+            .padding(horizontal = 8.dp, vertical = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = Purple_500,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Text(
+            text = value.toString(),
+            style = MaterialTheme.typography.headlineSmall,
+            color = Purple_500,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = caption,
+            style = MaterialTheme.typography.labelSmall,
+            color = Purple_300,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/theme/Color.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/theme/Color.kt
@@ -79,3 +79,9 @@ val Green_Success = Color(0xFF56EBA1) // Success state color
 val Blue_Info = Color(0xFF214CE0)     // Information state color
 val Yellow_Warning = Color(0xFFFDE172) // Warning state color
 val Red_Error = Color(0xFFFF5C5C)     // Error state color
+
+// Shared request/status colors. Keep status surfaces aligned across reusable components.
+val Status_Approved = Blue_Accent_700
+val Status_Rejected = Red_Error
+val Status_Pending = Orange_500
+val Status_Default = Blue_500

--- a/app/src/main/java/com/example/infinite_track/presentation/theme/StatusColors.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/theme/StatusColors.kt
@@ -1,0 +1,13 @@
+package com.example.infinite_track.presentation.theme
+
+import androidx.compose.ui.graphics.Color
+import java.util.Locale
+
+fun requestStatusColor(statusKey: String?): Color {
+    return when (statusKey.orEmpty().lowercase(Locale.getDefault())) {
+        "approved" -> Status_Approved
+        "rejected" -> Status_Rejected
+        "pending" -> Status_Pending
+        else -> Status_Default
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-inf-218-wfa-requests-api-ui.md
+++ b/docs/superpowers/plans/2026-07-07-inf-218-wfa-requests-api-ui.md
@@ -1,0 +1,359 @@
+# INF-218 — Android WFA Requests API + UI Implementation Plan
+
+Date: 2026-07-07
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-wfa-requests-api-ui`
+Branch: `fix/android-wfa-requests-api-ui`
+Base: `develop` at `5438044`
+Spec: `docs/superpowers/specs/2026-07-07-inf-218-wfa-requests-api-ui.md`
+
+## Current mapping
+
+1. Main checkout `E:\skrisi\android` is on `develop` at `5438044`, with one unrelated untracked docs plan. Do not edit main checkout.
+2. Isolated worktree is ready and clean:
+   - Path: `C:\Users\Febriyadi\.claude\worktrees\android-wfa-requests-api-ui`
+   - Branch: `fix/android-wfa-requests-api-ui`
+3. Existing relevant code:
+   - `presentation/navigation/Screen.kt` has `Screen.Wfa` and `Screen.Attendance`.
+   - `presentation/navigation/MainContentNavGraph.kt` maps `Screen.Wfa.route` to `WfaHistoryScreen()`.
+   - `data/soucre/network/retrofit/ApiService.kt` already has `GET("api/bookings/history")`.
+   - `data/soucre/network/response/booking/BookingHistoryResponse.kt` lacks INF-225 summary/status-label fields.
+   - `data/repository/booking/BookingRepositoryImpl.kt` maps only bookings + hasNextPage.
+   - `domain/model/booking/BookingHistoryPage.kt` only stores bookings + hasNextPage.
+   - `domain/model/booking/BookingHistoryItem.kt` lacks score/date/processed/status label fields needed by UI.
+   - Existing WFA screen is tied to `HomeViewModel`; plan should introduce a dedicated WFA ViewModel for separation.
+
+## Implementation strategy
+
+Reuse the existing booking API/repository path instead of creating a duplicate service. Extend the existing booking history DTO/domain model to match INF-225, then add a dedicated WFA presentation layer for the bottom tab.
+
+This avoids changing backend, auth/session logic, and attendance business logic.
+
+Additional product decision from 2026-07-07 execution follow-up: remove WFA booking-history preview/cards from Home/dashboard for all roles. The WFA bottom tab becomes the single primary booking-history/status surface.
+
+Additional UI architecture decision: request/status colors must be global presentation/theme tokens instead of hardcoded screen-local `Color(0x...)` mappings. Pull-to-refresh is handled by `WfaRequestsUiState.isRefreshing` in `StateFlow` so refresh loading is separate from first-page loading.
+
+## Step 1 — Extend backend DTOs safely
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/response/booking/BookingHistoryResponse.kt`
+
+Changes:
+
+- Make response nullable-safe:
+  - `message: String?`
+  - `data: BookingData?`
+- Add `BookingSummaryData` with `total`, `pending`, `approved`, `rejected`.
+- Add `status_key` and `status_label` to `BookingItem`.
+- Make nullable backend fields safe:
+  - `scheduleDate: String?`
+  - `status: String?`
+  - `location: BookingLocation?`
+  - `createdAt: String?`
+  - keep `suitabilityScore` nullable; prefer `Double?` or keep `Float?` consistently with mapper.
+- Make `BookingData.bookings` default to empty list.
+- Make `pagination` and `filters` nullable with mapper fallback.
+
+Checkpoint:
+
+- DTO can parse sample INF-225 response including `summary`, `status_key`, `status_label`.
+- DTO can parse missing/null optional fields without throwing before mapper.
+
+## Step 2 — Extend domain models
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt`
+- `app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryPage.kt`
+
+Changes:
+
+- Add `BookingHistorySummary`.
+- Add `BookingHistoryPagination`.
+- Extend `BookingHistoryPage` to include:
+  - `summary`
+  - `pagination`
+  - keep `hasNextPage` compatibility if existing callers rely on it.
+- Extend `BookingHistoryItem` for WFA UI fields:
+  - `statusKey`
+  - `statusLabel`
+  - `suitabilityScore`
+  - `createdAtRaw`
+  - `createdAt`
+  - `processedAtRaw`
+  - `processedAt`
+
+Compatibility rule:
+
+- Preserve existing constructor defaults where possible so existing `HomeViewModel`, `DetailsMyBooking`, and preview code continue compiling.
+
+Checkpoint:
+
+- Existing callers still compile or need minimal updates only.
+
+## Step 3 — Update mapper
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt`
+
+Changes:
+
+- Map `BookingHistoryResponse` / `BookingData` to `BookingHistoryPage` with fallback summary/pagination values.
+- Map `BookingItem` to `BookingHistoryItem` safely:
+  - location null -> `Location not available`
+  - schedule date null -> `-`
+  - status key: prefer `status_key`, fallback `status`, fallback `unknown`
+  - status label: prefer `status_label`, fallback formatted status key
+  - suitability score null remains null
+  - suitability label null -> `Not available`
+  - created date null -> `-`
+  - processed null pending -> `Waiting approval`
+  - processed null non-pending -> `Not processed yet`
+- Add date formatting helpers for:
+  - `yyyy-MM-dd`
+  - `yyyy-MM-dd HH:mm:ss`
+- Keep mapper free of logging raw response or identity fields.
+
+Checkpoint:
+
+- Mapper has no unsafe `!!` or direct non-null access to nullable backend fields.
+
+## Step 4 — Update repository response mapping
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/data/repository/booking/BookingRepositoryImpl.kt`
+- optionally `domain/repository/BookingRepository.kt`
+- optionally `domain/use_case/booking/GetBookingHistoryUseCase.kt`
+
+Changes:
+
+- Continue calling existing `apiService.getBookingHistory`.
+- Pass explicit `status = "all"` from WFA ViewModel when All filter selected. Existing top-card caller may still use null if desired.
+- Convert full response to `BookingHistoryPage`, not only `bookings + hasNextPage`.
+- If `success == false`, return failure using `message` fallback.
+- For API/network failure, preserve existing user-safe failure messages.
+
+Checkpoint:
+
+- Repository returns summary + pagination for WFA ViewModel.
+
+## Step 5 — Create WFA UI state + ViewModel
+
+Files to add:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsUiState.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsViewModel.kt`
+
+Changes:
+
+- Add `WfaRequestStatusFilter` enum with explicit backend keys.
+- Add UI state:
+  - `selectedFilter`
+  - `summary`
+  - `bookings`
+  - `pagination`
+  - `isLoading`
+  - `isLoadingMore` if implementing load more now
+  - `errorMessage`
+- On init, load `All` status.
+- On filter click:
+  - set selected filter
+  - reset page to 1
+  - load with `status = filter.key`
+- Retry reloads current selected filter.
+- Optional: implement future-ready load more using pagination `hasNextPage`, but do not overcomplicate MVP.
+
+Checkpoint:
+
+- WFA screen no longer depends on `HomeViewModel` for bottom tab content.
+- Filter keys are controlled and cannot send arbitrary UI labels.
+
+## Step 6 — Build target UI components
+
+Files to add:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestFilterChips.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt`
+- optional local helpers in same files if compact.
+
+Design requirements:
+
+- Follow reference image style:
+  - purple accent
+  - rounded white cards
+  - compact summary metric cards
+  - horizontal chips
+  - card with status accent strip and status pill
+  - bottom purple CTA
+- Do not add hero illustration card.
+- Do not add long explanatory banner/card.
+- Do not show empty card under populated list.
+
+Checkpoint:
+
+- Cards display required data:
+  - schedule date
+  - status chip
+  - location
+  - suitability score/label safely
+  - notes
+  - submitted date
+  - processed state/date
+
+## Step 7 — Replace WFA bottom tab screen content
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaHistoryScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaBookingHistoryContent.kt` or replace with new `WfaRequestsScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt`
+
+Preferred approach:
+
+- Add `WfaRequestsScreen` with `WfaRequestsViewModel`.
+- Keep `WfaHistoryScreen` as a thin wrapper or rename usage carefully.
+- Update `MainContentNavGraph` to pass `onOpenAttendance = { navController.safeNavigate(Screen.Attendance.route) }`.
+
+Checkpoint:
+
+- `Screen.Wfa.route` still owns WFA bottom tab content.
+- `Open Attendance` only navigates to `Screen.Attendance.route`.
+- No Contact route usage for WFA.
+
+## Step 8 — Add tests where feasible
+
+Preferred tests:
+
+- Mapper unit test for INF-225 sample payload semantics.
+- Mapper unit test for null suitability/processed/location/date fallback.
+
+Candidate test files:
+
+- `app/src/test/java/com/example/infinite_track/data/mapper/booking/BookingMapperWfaRequestsContractTest.kt`
+
+If test setup is too costly, at minimum keep implementation mapper pure and verify compile; mark test coverage as `Needs Verification`.
+
+Checkpoint:
+
+- Tests do not include sensitive raw identity values beyond synthetic placeholders.
+
+## Step 9 — Verification
+
+Run from worktree:
+
+```bash
+cd C:/Users/Febriyadi/.claude/worktrees/android-wfa-requests-api-ui
+./gradlew app:assembleDebug
+```
+
+If time/environment allows:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime/emulator checklist if possible:
+
+1. Login.
+2. Open WFA tab.
+3. Confirm title/subtitle.
+4. Confirm summary cards display backend `summary`.
+5. Confirm All filter calls/loads `status=all`.
+6. Confirm Pending filter calls/loads `status=pending`.
+7. Confirm Approved filter calls/loads `status=approved`.
+8. Confirm Rejected filter calls/loads `status=rejected`.
+9. Confirm empty state appears only for empty selected filter.
+10. Confirm Open Attendance CTA navigates to Attendance screen.
+
+Evidence redaction:
+
+- Do not paste token.
+- Do not paste raw auth-bearing request.
+- Do not paste email/NIP/NIM/full name if logs/screenshots show them.
+
+## Step 10 — Review and final report
+
+Before claiming complete:
+
+- Run git diff/stat.
+- Run verification commands.
+- Request code review if available.
+- Report using Android required categories:
+  - Fact
+  - Assumption
+  - Mismatch
+  - Risk
+  - Needs Verification
+  - Recommendation
+  - Files/areas affected
+  - Verification evidence
+  - Docs/ADR update note
+  - PR/review note
+
+## Risks and mitigations
+
+### Risk: Existing `HomeViewModel` callers regress
+
+Mitigation:
+
+- Preserve domain model defaults.
+- Keep repository method signature unchanged unless required.
+- Do not remove existing booking history path used by Home/DetailsMyBooking.
+
+### Risk: Backend nullable fields crash UI
+
+Mitigation:
+
+- DTO nullable-safe.
+- Mapper fallback values.
+- UI never assumes score/date/location non-null.
+
+### Risk: WFA tab accidentally becomes Attendance owner
+
+Mitigation:
+
+- CTA only navigates to Attendance.
+- No check-in/check-out usecase injection in WFA ViewModel.
+- No attendance history/report data rendered.
+
+### Risk: Runtime/API evidence not available locally
+
+Mitigation:
+
+- Mark runtime as `Needs Verification`.
+- Provide build/test evidence separately.
+
+### Risk: INF-222 component API changes
+
+Mitigation:
+
+- Use stable Material3 primitives and existing theme tokens.
+- Keep screen-specific components compact and easy to migrate.
+
+## Commit/PR note draft
+
+```text
+Implements INF-218 WFA Requests as WFA bottom tab content aligned with INF-224.
+
+- Uses existing GET /api/bookings/history API path with INF-225 summary/bookings/pagination contract.
+- Adds All/Pending/Approved/Rejected filters with explicit backend status keys.
+- Renders backend summary counts separately from filtered request list.
+- Handles nullable suitability score/label and processed timestamp safely.
+- Adds WFA request cards, summary cards, filter chips, loading/error/empty states, pull-to-refresh, and Open Attendance CTA.
+- Adds reusable `InlineRefreshingIndicator` for dashboard/page reuse.
+- Adds global request status color tokens/resolver for reusable status components.
+- Removes WFA booking-history preview/cards from Home/dashboard for all roles.
+- Keeps Attendance screen as owner for WFA creation and check-in/check-out flows.
+- Does not move WFA under Contact.
+- Does not change backend, auth/session business logic, or attendance business logic.
+
+Verification:
+- ./gradlew app:assembleDebug: <result>
+- ./gradlew app:test: <result or Needs Verification>
+- ./gradlew app:lint: <result or Needs Verification>
+- Runtime/emulator WFA tab evidence: <result or Needs Verification>
+```

--- a/docs/superpowers/specs/2026-07-07-inf-218-wfa-requests-api-ui.md
+++ b/docs/superpowers/specs/2026-07-07-inf-218-wfa-requests-api-ui.md
@@ -1,0 +1,322 @@
+# INF-218 — Android WFA Requests API + UI Spec
+
+Date: 2026-07-07
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-wfa-requests-api-ui`
+Branch: `fix/android-wfa-requests-api-ui`
+Base: `develop` at `5438044`
+
+## Scope
+
+Implement the Android WFA bottom tab content for authenticated-user WFA request/history/status tracking using the backend contract from INF-225:
+
+```http
+GET /api/bookings/history
+```
+
+The WFA tab is a read/status surface for WFA booking requests. It must not become an active attendance owner.
+
+## Product boundary
+
+### WFA tab owns
+
+- WFA booking/request list.
+- WFA booking/request history.
+- Pending / Approved / Rejected status tracking.
+- Request detail display if available in the list payload.
+- Navigation CTA to Attendance flow for creating WFA requests.
+- All primary booking-history UI previously previewed from Home/dashboard for any role.
+
+### Attendance screen remains owner of
+
+- Creating WFA requests.
+- Selecting WFA location.
+- `LocationSearch`.
+- `FaceScanner`.
+- Check-in/check-out active attendance flow.
+
+### Explicit non-goals
+
+- Do not implement WFA creation in WFA tab.
+- Do not implement check-in/check-out in WFA tab.
+- Do not show Attendance History data.
+- Do not show My Attendance Report data.
+- Do not keep WFA booking-history cards/preview sections on Home/dashboard for Internship/Admin/Employee/Management roles.
+- Do not show PDF export/reporting metrics.
+- Do not show multi-user/employee booking data.
+- Do not move WFA under Contact.
+- Do not change backend.
+- Do not change auth/session business logic.
+- Do not change attendance check-in/check-out business logic.
+
+## Navigation contract
+
+Bottom navigation final contract follows INF-224:
+
+```text
+Home | History | WFA | Profile
+```
+
+`Screen.Wfa.route` must render the WFA Requests screen. `Open Attendance` CTA navigates to `Screen.Attendance.route` only; it must not trigger any check-in/check-out behavior.
+
+## Backend contract
+
+Endpoint:
+
+```http
+GET /api/bookings/history?page=1&limit=10&status=all&sort_by=created_at&sort_order=DESC
+```
+
+Supported status filter keys:
+
+```text
+all
+pending
+approved
+rejected
+```
+
+Response semantics:
+
+- `data.summary` = all-status counts for authenticated user.
+- `data.bookings` = filtered result by selected status.
+- `data.pagination` = pagination metadata for filtered `bookings` result.
+- `data.filters` = backend echo of applied filters.
+
+## Privacy and security
+
+Backend response may contain identity fields:
+
+- `user_id`
+- `user_full_name`
+- `user_email`
+- `user_nip_nim`
+- `user_position_name`
+- `user_role_name`
+
+MVP UI must not display email, NIP/NIM, or raw identity fields. Runtime/API evidence must not include raw tokens, raw auth-bearing requests, full raw response, email, NIP/NIM, or sensitive identifiers.
+
+UI may use only:
+
+- `booking_id`
+- `schedule_date`
+- `status` / `status_key` / `status_label`
+- `location.description`
+- `notes`
+- `suitability_score`
+- `suitability_label`
+- `created_at`
+- `processed_at`
+- `approved_by` only if needed, but default MVP should not show approver.
+
+## Android data model requirements
+
+### Response DTOs
+
+Existing `BookingHistoryResponse` must be extended or replaced in-place to safely match INF-225:
+
+- Add nullable `summary` object.
+- Add nullable-safe `bookings` list.
+- Add nullable-safe `pagination`.
+- Add `status_key` and `status_label` to booking item DTO.
+- Keep identity fields parsed only if needed for compatibility, but do not map/display sensitive identity fields.
+- Nullable fields must not crash UI.
+
+Recommended DTO shape:
+
+```kotlin
+data class BookingHistoryResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("data") val data: BookingData?,
+    @SerializedName("message") val message: String?
+)
+
+data class BookingData(
+    @SerializedName("summary") val summary: BookingSummaryData?,
+    @SerializedName("bookings") val bookings: List<BookingItem> = emptyList(),
+    @SerializedName("pagination") val pagination: PaginationData?,
+    @SerializedName("filters") val filters: FilterData?
+)
+```
+
+### Domain model
+
+Domain model must support the WFA Requests UI without leaking identity fields:
+
+- `BookingHistoryPage`
+  - `bookings: List<BookingHistoryItem>`
+  - `summary: BookingHistorySummary`
+  - `pagination: BookingHistoryPagination`
+- `BookingHistorySummary`
+  - `total`
+  - `pending`
+  - `approved`
+  - `rejected`
+- `BookingHistoryPagination`
+  - `currentPage`
+  - `totalPages`
+  - `totalItems`
+  - `itemsPerPage`
+  - `hasNextPage`
+  - `hasPreviousPage`
+- `BookingHistoryItem`
+  - `bookingId`
+  - `scheduleDateRaw`
+  - formatted `scheduleDate`
+  - `statusRaw`
+  - `statusKey`
+  - display `statusLabel`
+  - `locationDescription`
+  - `notes`
+  - `suitabilityScore`
+  - `suitabilityLabel`
+  - `createdAtRaw`
+  - display `createdAt`
+  - `processedAtRaw`
+  - display `processedAt`
+
+## UI requirements
+
+WFA Requests screen structure:
+
+```text
+WFA Requests
+├── Top App Bar
+│   ├── Title: WFA Requests
+│   └── Subtitle: Track your Work From Anywhere submissions
+├── Status Summary
+│   ├── Pending
+│   ├── Approved
+│   └── Rejected
+├── Filter Chips
+│   ├── All
+│   ├── Pending
+│   ├── Approved
+│   └── Rejected
+├── Recent WFA Requests
+│   ├── Schedule date
+│   ├── Status chip
+│   ├── Location
+│   ├── Suitability score
+│   ├── Suitability label
+│   ├── Notes
+│   ├── Submitted date
+│   └── Processed date / waiting approval
+└── Open Attendance CTA
+    └── Navigate to Attendance flow
+```
+
+Design target should visually follow the provided reference:
+
+- Purple brand accent.
+- Light rounded cards.
+- Three compact summary metric cards.
+- Horizontal rounded filter chips.
+- Request cards with left status accent, status chip, date, location, score/label, notes, submitted/processed metadata.
+- Bottom purple CTA button.
+
+Do not implement these reference-only elements for MVP:
+
+- Large top hero illustration card.
+- Long explanatory banner/card.
+- Inline “No WFA requests yet” card under populated request cards.
+
+## Empty/loading/error behavior
+
+- Loading: show progress while first page is loading.
+- Error: show user-facing error and retry action.
+- Empty: show only when selected filter has no records.
+- Empty text:
+  - Title: `No WFA requests yet`
+  - Body: `Create a WFA request from Attendance when you need to work from another location.`
+
+## Nullable handling
+
+- `suitability_score == null`: show `-` or `Not scored`.
+- `suitability_label == null`: show `Not available` or omit label safely.
+- `processed_at == null` and status pending: show `Waiting approval`.
+- `processed_at == null` and status not pending: show `Not processed yet`.
+- `approved_by == null`: do not show approver label for MVP.
+- `location == null`: show `Location not available`.
+- date parsing failure: display raw backend date string or `-`, never crash.
+
+## UI state contract
+
+Recommended filter model:
+
+```kotlin
+enum class WfaRequestStatusFilter(val key: String, val label: String) {
+    All("all", "All"),
+    Pending("pending", "Pending"),
+    Approved("approved", "Approved"),
+    Rejected("rejected", "Rejected")
+}
+```
+
+On filter click:
+
+1. Update selected filter.
+2. Reset page to 1.
+3. Call `GET /api/bookings/history` with `status = filter.key`.
+4. Render `summary` from response unchanged.
+5. Render `bookings` from filtered response.
+6. Preserve pagination metadata for future load-more.
+
+## Existing repo mapping
+
+Observed in isolated worktree:
+
+- `Screen.Wfa.route` exists.
+- `MainContentNavGraph` renders `WfaHistoryScreen()` for `Screen.Wfa.route`.
+- `ApiService.getBookingHistory()` already uses `GET("api/bookings/history")`.
+- `BookingRepository`, `BookingRepositoryImpl`, and `GetBookingHistoryUseCase` exist.
+- Existing WFA screen uses `HomeViewModel.bookingHistoryDetailsState`, not a dedicated WFA ViewModel.
+- Existing DTO lacks `summary`, `status_key`, and `status_label`.
+- Existing card/dropdown UI does not match target screen enough for INF-218.
+
+## Acceptance criteria mapping
+
+- Worktree isolated: already satisfied before implementation.
+- WFA tab content: update `Screen.Wfa.route` content only, no Contact route.
+- API call: reuse `ApiService.getBookingHistory` and make `status=all` explicit.
+- Filters: chips call all/pending/approved/rejected.
+- Summary: read from `data.summary`.
+- List: read from `data.bookings`.
+- Pagination: domain model stores pagination; optional load more can use `hasNextPage`.
+- Nullable fields: mapper must guard all nullable backend fields.
+- CTA: navigate to Attendance.
+- Build: `./gradlew app:assembleDebug`.
+
+## Verification requirements
+
+Minimum local verification:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+Recommended if time/environment allows:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime evidence required if possible:
+
+- Login.
+- Open WFA tab.
+- Summary cards visible.
+- Populated request list visible.
+- Switch filters All/Pending/Approved/Rejected.
+- Empty filter state visible when backend returns zero records.
+- Open Attendance CTA navigates to Attendance screen.
+
+If emulator/API runtime cannot be executed, mark as `Needs Verification`.
+
+## Docs/ADR note
+
+This work touches route-visible WFA tab behavior but should align with existing INF-224 contract. If no route ownership changes are made beyond rendering WFA Requests inside `Screen.Wfa.route`, ADR may be unnecessary. PR note must explicitly mention INF-224 alignment:
+
+- Bottom bar remains `Home | History | WFA | Profile`.
+- WFA tab is request/history/status list.
+- Attendance remains creation/check-in/check-out owner.


### PR DESCRIPTION
## Summary

Implements INF-218 WFA Requests as the WFA bottom tab content aligned with INF-224 and INF-225.

- Uses the existing `GET /api/bookings/history` API path with the backend history contract.
- Extends booking history DTO/domain mapping for `summary`, `status_key`, `status_label`, pagination, nullable suitability fields, nullable processed date, and location fallback.
- Adds WFA Requests UI with summary cards, All/Pending/Approved/Rejected filters, request cards, loading/error/empty states, pagination-ready load more, and pull-to-refresh.
- Adds reusable `InlineRefreshingIndicator` for dashboard/page reuse.
- Adds global request status color tokens/resolver for reusable status components.
- Removes WFA booking-history preview/cards from Home/dashboard for all roles so the WFA tab is the primary booking-history/status surface.
- Keeps Attendance screen as owner for WFA creation and check-in/check-out flows.
- Does not move WFA into Contact.
- Does not change backend.
- Does not change auth/session business logic.
- Does not change attendance check-in/check-out business logic.

## Verification

- `git diff --check`: passed locally, only Git CRLF warnings from Windows worktree.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
Caused by: java.net.SocketException: Invalid argument: connect
at sun.nio.ch.UnixDomainSockets.connect0
```

Tried:

- `./gradlew app:assembleDebug`
- `./gradlew --no-daemon app:assembleDebug`
- IPv4 preference Gradle opts
- Windows selector provider Gradle opts
- `./gradlew --stacktrace app:assembleDebug`

All fail before compile in this harness environment.

## Runtime verification needed

- Login.
- Open WFA bottom tab.
- Confirm WFA Requests title/subtitle.
- Confirm summary cards use backend `data.summary`.
- Confirm filters call/load `status=all`, `pending`, `approved`, `rejected`.
- Confirm populated request list.
- Confirm empty state only appears for empty selected filter.
- Pull down refresh and confirm refresh loading indicator/data reload.
- Open Attendance CTA and confirm navigation to Attendance flow.
- Confirm Home/dashboard for Internship/Admin/Employee/Management no longer shows WFA booking-history preview/cards.

## Docs / ADR

- Added focused spec and implementation plan under `docs/superpowers/`.
- ADR not added because this implements the existing INF-224 bottom-tab contract: `Home | History | WFA | Profile`, with WFA as request/history/status list and Attendance as creation/check-in/check-out owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new WFA Requests screen with request cards, status summary, filter chips, pull-to-refresh, and automatic pagination.
  * Added an inline loading indicator component for cleaner in-app refresh states.

* **Bug Fixes**
  * Improved booking history display so missing or partial data shows safe fallback values instead of breaking the UI.
  * Status colors and labels now render more consistently across booking-related screens.

* **Refactor**
  * Simplified Home and WFA navigation to focus on attendance and request browsing.
  * Updated booking history data handling to include summary and pagination details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->