### PR TITLE
INF-226: Refresh Android account hub main screen

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
@@ -5,13 +5,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import com.example.infinite_track.presentation.theme.Blue_50
+import com.example.infinite_track.presentation.theme.Blue_100
 import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Blue_600
 import com.example.infinite_track.presentation.theme.Blue_Accent_500
 import com.example.infinite_track.presentation.theme.Green_Success
 import com.example.infinite_track.presentation.theme.Orange_500
 import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Purple_900
 import com.example.infinite_track.presentation.theme.Red_Error
+import com.example.infinite_track.presentation.theme.Violet_50
 import com.example.infinite_track.presentation.theme.Violet_100
+import com.example.infinite_track.presentation.theme.Violet_200
 import com.example.infinite_track.presentation.theme.White
 import com.example.infinite_track.presentation.theme.Yellow_Warning
 
@@ -36,6 +42,59 @@ object InfiniteColors {
     val Warning = Yellow_Warning
     val Error = Red_Error
     val Neutral = Color(0xFF746D74)
+
+    val AccountHubTitle = Purple_900
+    val AccountHubPrimary = Blue_500
+    val AccountHubPrimaryStrong = Blue_600
+    val AccountHubAccent = Blue_Accent_500
+    val AccountHubSurface = White
+    val AccountHubDivider = Purple_500
+    val AccountHubDestructive = Red_Error
+
+    val AccountHubBackgroundGradient: Brush
+        get() = Brush.verticalGradient(
+            colors = listOf(
+                Blue_50,
+                Violet_100,
+                Violet_50
+            )
+        )
+
+    val AccountHubHeroGradient: Brush
+        get() = Brush.linearGradient(
+            colors = listOf(
+                White.copy(alpha = 0.78f),
+                Blue_100.copy(alpha = 0.68f),
+                Blue_Accent_500.copy(alpha = 0.18f)
+            )
+        )
+
+    val AccountHubAvatarRingGradient: Brush
+        get() = Brush.linearGradient(
+            colors = listOf(
+                Blue_500.copy(alpha = 0.70f),
+                Blue_Accent_500.copy(alpha = 0.70f)
+            )
+        )
+
+    val AccountHubDecorativeTint = Blue_Accent_500.copy(alpha = 0.12f)
+    val AccountHubSectionAccent = Blue_600
+    val AccountHubMutedText = Purple_500.copy(alpha = 0.62f)
+    val AccountHubBodyText = Purple_500.copy(alpha = 0.82f)
+    val AccountHubIconText = Purple_500.copy(alpha = 0.76f)
+    val AccountHubOutline = White.copy(alpha = 0.88f)
+    val AccountHubStrongOutline = White.copy(alpha = 0.94f)
+    val AccountHubHeroOutline = White.copy(alpha = 0.92f)
+    val AccountHubHeroSurface = White.copy(alpha = 0.78f)
+    val AccountHubSummarySurface = White.copy(alpha = 0.76f)
+    val AccountHubIconSurface = White.copy(alpha = 0.86f)
+    val AccountHubFloatingSurface = White.copy(alpha = 0.82f)
+    val AccountHubPillContainer = Blue_500.copy(alpha = 0.10f)
+    val AccountHubPillBorder = Blue_500.copy(alpha = 0.22f)
+    val AccountHubIconBorder = Blue_500.copy(alpha = 0.14f)
+    val AccountHubDestructiveContainer = Red_Error.copy(alpha = 0.12f)
+    val AccountHubDestructiveArrow = Red_Error.copy(alpha = 0.82f)
+    val AccountHubDividerColor = Violet_200.copy(alpha = 0.62f)
 
     val GlassGradient: Brush
         get() = Brush.verticalGradient(

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -1,10 +1,15 @@
 package com.example.infinite_track.presentation.screen.profile
 
 import android.annotation.SuppressLint
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,13 +18,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,7 +41,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -53,12 +61,16 @@ import com.example.infinite_track.presentation.components.status.StatusStates
 import com.example.infinite_track.presentation.core.headline2
 import com.example.infinite_track.presentation.core.headline3
 import com.example.infinite_track.presentation.core.headline4
-import com.example.infinite_track.presentation.theme.Purple_300
-import com.example.infinite_track.presentation.theme.Purple_500
-import com.example.infinite_track.presentation.theme.White
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.utils.UiState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+
+private const val DefaultAvatarUrl =
+    "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png"
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -73,7 +85,6 @@ fun ProfileScreen(
     rootNavController: NavHostController,
     profileViewModel: ProfileViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var showLogoutConfirmDialog by remember { mutableStateOf(false) }
     var showLogoutLoadingDialog by remember { mutableStateOf(false) }
@@ -94,7 +105,7 @@ fun ProfileScreen(
             // We do not persist here; persistence happens on confirm
             profileViewModel.onUpdateLanguage(newLanguage)
         },
-        onConfirm = { confirmedLanguage ->
+        onConfirm = { _ ->
             // Persist already done in onUpdateLanguage; ensure dialog closed
             // LanguagePopUp will call updateAppLanguage to apply runtime locale
             profileViewModel.onLanguageDialogDismiss()
@@ -185,7 +196,8 @@ fun ProfileScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
+                .background(InfiniteColors.AccountHubBackgroundGradient)
+                .padding(horizontal = 16.dp, vertical = 18.dp)
         ) {
             when (profileState) {
                 is UiState.Loading -> {
@@ -198,7 +210,7 @@ fun ProfileScreen(
                             verticalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
                             CircularProgressIndicator(
-                                color = Purple_500,
+                                color = InfiniteColors.AccountHubPrimary,
                                 modifier = Modifier.size(48.dp)
                             )
                             EmployeesAccessShortcut(onClick = navigateToContacts)
@@ -218,7 +230,7 @@ fun ProfileScreen(
                             Text(
                                 text = (profileState as UiState.Error).errorMessage,
                                 style = headline3,
-                                color = Color.Red
+                                color = InfiniteColors.AccountHubDestructive
                             )
                             EmployeesAccessShortcut(onClick = navigateToContacts)
                         }
@@ -226,142 +238,18 @@ fun ProfileScreen(
                 }
 
                 is UiState.Success -> {
-                    // Show profile content
                     val user = (profileState as UiState.Success<UserModel>).data
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.Top,
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Column(
-                                modifier = Modifier.width(280.dp)
-                            ) {
-                                Text(
-                                    text = user.fullName ?: "N/A",
-                                    style = headline2,
-                                    color = Purple_500,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Text(
-                                    text = user.positionName ?: "N/A",
-                                    style = headline4,
-                                    color = Purple_300,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                            AsyncImage(
-                                model = user.photoUrl
-                                    ?: "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png",
-                                contentDescription = "",
-                                modifier = Modifier
-                                    .padding(horizontal = 8.dp)
-                                    .height(60.dp)
-                                    .width(60.dp)
-                                    .clip(CircleShape),
-                                contentScale = ContentScale.Crop
-                            )
-                        }
-
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.account_information),
-                                style = headline3,
-                                fontWeight = FontWeight.Medium
-                            )
-                            ProfileBar(
-                                label = stringResource(R.string.edit_profile),
-                                onClick = navigateToEditProfile,
-                                icon = R.drawable.ic_pencil
-                            )
-                            ProfileBar(
-                                label = stringResource(R.string.pay_slip),
-                                onClick = navigateToPaySlip,
-                                icon = R.drawable.ic_payslip
-                            )
-                            ProfileBar(
-                                label = stringResource(R.string.my_document),
-                                onClick = navigateToMyDocument,
-                                icon = R.drawable.ic_mydocument
-                            )
-                            EmployeesAccessShortcut(onClick = navigateToContacts)
-                        }
-
-                        Spacer(modifier = Modifier.height(24.dp))
-
-                        // Settings Section
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.setting),
-                                style = headline3,
-                                fontWeight = FontWeight.Medium
-                            )
-
-                            // Language Selector Row
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(50.dp)
-                                    .clickable { profileViewModel.onLanguageSettingsClicked() },
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.ic_global),
-                                    contentDescription = stringResource(R.string.language),
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(modifier = Modifier.width(16.dp))
-                                Text(
-                                    text = stringResource(R.string.language),
-                                    style = headline4,
-                                )
-                                Spacer(modifier = Modifier.weight(1f))
-                                Text(
-                                    text = if (language == "en") "English" else "Indonesia",
-                                    style = headline4,
-                                )
-                                Spacer(modifier = Modifier.width(16.dp))
-                                Icon(
-                                    painter = painterResource(R.drawable.right_arrow),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp)
-                                )
-                            }
-
-                            // Other Settings Options
-                            ProfileBar(
-                                label = stringResource(R.string.contact_us),
-                                onClick = navigateToContactUs,
-                                icon = R.drawable.ic_contactus
-                            )
-//                            ProfileBar(
-//                                label = stringResource(R.string.faq),
-//                                onClick = navigateToFAQ,
-//                                icon = R.drawable.ic_faq
-//                            )
-                            ProfileBar(
-                                label = stringResource(R.string.about_us),
-                                onClick = {},
-                                icon = R.drawable.ic_community
-                            )
-                            ProfileBar(
-                                label = stringResource(R.string.logOut),
-                                icon = R.drawable.ic_logout,
-                                onClick = {
-                                    showLogoutConfirmDialog = true
-                                }
-                            )
-                        }
-                    }
+                    AccountHubContent(
+                        user = user,
+                        language = language,
+                        onEditProfile = navigateToEditProfile,
+                        onLanguageClick = { profileViewModel.onLanguageSettingsClicked() },
+                        onMyDocument = navigateToMyDocument,
+                        onPaySlip = navigateToPaySlip,
+                        onContactSupport = navigateToContactUs,
+                        onEmployees = navigateToContacts,
+                        onLogout = { showLogoutConfirmDialog = true }
+                    )
                 }
 
                 else -> { /* Idle state - do nothing */
@@ -372,9 +260,484 @@ fun ProfileScreen(
 }
 
 @Composable
+private fun AccountHubContent(
+    user: UserModel,
+    language: String,
+    onEditProfile: () -> Unit,
+    onLanguageClick: () -> Unit,
+    onMyDocument: () -> Unit,
+    onPaySlip: () -> Unit,
+    onContactSupport: () -> Unit,
+    onEmployees: () -> Unit,
+    onLogout: () -> Unit
+) {
+    val unavailable = stringResource(R.string.account_hub_not_available)
+    val role = user.roleName.ifBlank { unavailable }
+    val position = user.positionName.orEmpty().ifBlank { unavailable }
+    val division = user.divisionName.orEmpty().ifBlank {
+        user.programName.orEmpty().ifBlank { unavailable }
+    }
+    val contact = user.phone.orEmpty().ifBlank { unavailable }
+    val shouldShowPaySlip = remember(user.roleName) { user.roleName.shouldShowPayrollAccess() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.account_hub_title),
+            style = headline2,
+            color = InfiniteColors.AccountHubTitle,
+            fontWeight = FontWeight.Bold
+        )
+
+        IdentityHeroCard(
+            user = user,
+            role = role,
+            position = position,
+            division = division,
+            onEditProfile = onEditProfile
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            AccountSummaryCard(
+                label = stringResource(R.string.account_hub_role),
+                value = role,
+                icon = R.drawable.ic_profile,
+                modifier = Modifier.weight(1f)
+            )
+            AccountSummaryCard(
+                label = stringResource(R.string.account_hub_division),
+                value = division,
+                icon = R.drawable.ic_division,
+                modifier = Modifier.weight(1f)
+            )
+            AccountSummaryCard(
+                label = stringResource(R.string.account_hub_contact),
+                value = contact,
+                icon = R.drawable.ic_phone,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        AccountHubSection(title = stringResource(R.string.account_hub_account_identity)) {
+            AccountHubMenuRow(
+                title = stringResource(R.string.edit_profile),
+                description = stringResource(R.string.account_hub_edit_profile_description),
+                icon = R.drawable.ic_pencil,
+                onClick = onEditProfile
+            )
+            AccountHubDivider()
+            AccountHubMenuRow(
+                title = stringResource(R.string.language),
+                description = currentLanguageLabel(language),
+                icon = R.drawable.ic_global,
+                onClick = onLanguageClick
+            )
+        }
+
+        AccountHubSection(title = stringResource(R.string.account_hub_company_access)) {
+            AccountHubMenuRow(
+                title = stringResource(R.string.my_document),
+                description = stringResource(R.string.account_hub_my_document_description),
+                icon = R.drawable.ic_mydocument,
+                onClick = onMyDocument
+            )
+            if (shouldShowPaySlip) {
+                AccountHubDivider()
+                AccountHubMenuRow(
+                    title = stringResource(R.string.pay_slip),
+                    description = stringResource(R.string.account_hub_pay_slip_description),
+                    icon = R.drawable.ic_payslip,
+                    onClick = onPaySlip
+                )
+            }
+            AccountHubDivider()
+            AccountHubMenuRow(
+                title = stringResource(R.string.employees),
+                description = stringResource(R.string.account_hub_contact_support_description),
+                icon = R.drawable.ic_contactus,
+                onClick = onEmployees
+            )
+        }
+
+        AccountHubSection(title = stringResource(R.string.account_hub_help_information)) {
+            AccountHubMenuRow(
+                title = stringResource(R.string.account_hub_contact_support),
+                description = stringResource(R.string.account_hub_contact_support_description),
+                icon = R.drawable.ic_contactus,
+                onClick = onContactSupport
+            )
+            AccountHubDivider()
+            AccountHubMenuRow(
+                title = stringResource(R.string.account_hub_about_title),
+                description = stringResource(R.string.account_hub_about_description),
+                icon = R.drawable.ic_community,
+                onClick = {}
+            )
+        }
+
+        AccountHubSection(title = stringResource(R.string.account_hub_security)) {
+            AccountHubMenuRow(
+                title = stringResource(R.string.logOut),
+                description = stringResource(R.string.account_hub_logout_description),
+                icon = R.drawable.ic_logout,
+                onClick = onLogout,
+                destructive = true
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+    }
+}
+
+@Composable
+private fun IdentityHeroCard(
+    user: UserModel,
+    role: String,
+    position: String,
+    division: String,
+    onEditProfile: () -> Unit
+) {
+    val unavailable = stringResource(R.string.account_hub_not_available)
+    val fullName = user.fullName.ifBlank { unavailable }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(InfiniteColors.AccountHubHeroGradient)
+                .padding(20.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .size(124.dp)
+                    .clip(CircleShape)
+                    .background(InfiniteColors.AccountHubDecorativeTint)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(18.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Box(
+                        modifier = Modifier
+                            .size(118.dp)
+                            .clip(CircleShape)
+                            .background(InfiniteColors.AccountHubAvatarRingGradient)
+                            .padding(4.dp)
+                    ) {
+                        AsyncImage(
+                            model = user.photoUrl ?: DefaultAvatarUrl,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(CircleShape)
+                                .border(3.dp, InfiniteColors.AccountHubOutline, CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(14.dp))
+                    InfiniteStatusPill(
+                        label = stringResource(R.string.account_hub_active_status, role),
+                        variant = InfiniteStatusVariant.Active,
+                        size = InfiniteSize.Small
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(9.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = fullName,
+                                style = headline2,
+                                color = InfiniteColors.AccountHubTitle,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = position,
+                                style = headline4,
+                                color = InfiniteColors.AccountHubSectionAccent,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        SoftIconButton(
+                            icon = R.drawable.ic_pencil,
+                            contentDescription = stringResource(R.string.edit_profile),
+                            onClick = onEditProfile
+                        )
+                    }
+
+                    SoftPill(text = role, icon = R.drawable.ic_profile)
+                    IdentityInfoRow(icon = R.drawable.ic_division, text = division)
+                    IdentityInfoRow(
+                        icon = R.drawable.ic_description,
+                        text = stringResource(R.string.account_hub_identifier, user.nipNim)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountSummaryCard(
+    label: String,
+    value: String,
+    @DrawableRes icon: Int,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.height(92.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubSummarySurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = InfiniteColors.AccountHubPrimary,
+                modifier = Modifier.size(26.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label,
+                    style = headline4,
+                    color = InfiniteColors.AccountHubMutedText,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = value,
+                    style = headline4,
+                    color = InfiniteColors.AccountHubTitle,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountHubSection(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(
+                text = title,
+                style = headline4,
+                color = InfiniteColors.AccountHubSectionAccent,
+                fontWeight = FontWeight.Bold
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun AccountHubMenuRow(
+    title: String,
+    description: String,
+    @DrawableRes icon: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    destructive: Boolean = false
+) {
+    val accent = if (destructive) InfiniteColors.AccountHubDestructive else InfiniteColors.AccountHubPrimary
+    val rowBackground = if (destructive) InfiniteColors.AccountHubDestructiveContainer else Color.Transparent
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(rowBackground)
+            .clickable { onClick() }
+            .padding(horizontal = 10.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        Surface(
+            shape = RoundedCornerShape(14.dp),
+            color = InfiniteColors.AccountHubIconSurface,
+            border = BorderStroke(1.dp, InfiniteColors.AccountHubIconBorder),
+            shadowElevation = 3.dp
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier
+                    .padding(12.dp)
+                    .size(24.dp)
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = headline3,
+                color = if (destructive) InfiniteColors.AccountHubDestructive else InfiniteColors.AccountHubTitle,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = description,
+                style = headline4,
+                color = InfiniteColors.AccountHubMutedText,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Icon(
+            painter = painterResource(R.drawable.right_arrow),
+            contentDescription = null,
+            tint = if (destructive) InfiniteColors.AccountHubDestructiveArrow else InfiniteColors.AccountHubTitle,
+            modifier = Modifier.size(18.dp)
+        )
+    }
+}
+
+@Composable
+private fun AccountHubDivider() {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = 72.dp),
+        color = InfiniteColors.AccountHubDividerColor
+    )
+}
+
+@Composable
+private fun SoftIconButton(
+    @DrawableRes icon: Int,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .size(52.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(18.dp),
+        color = InfiniteColors.AccountHubFloatingSurface,
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubStrongOutline),
+        shadowElevation = 5.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = contentDescription,
+                tint = InfiniteColors.AccountHubPrimary,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SoftPill(
+    text: String,
+    @DrawableRes icon: Int
+) {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = InfiniteColors.AccountHubPillContainer,
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubPillBorder)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = InfiniteColors.AccountHubPrimary,
+                modifier = Modifier.size(16.dp)
+            )
+            Text(
+                text = text,
+                style = headline4,
+                color = InfiniteColors.AccountHubSectionAccent,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun IdentityInfoRow(
+    @DrawableRes icon: Int,
+    text: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null,
+            tint = InfiniteColors.AccountHubIconText,
+            modifier = Modifier.size(20.dp)
+        )
+        Text(
+            text = text,
+            style = headline4,
+            color = InfiniteColors.AccountHubBodyText,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
 private fun EmployeesAccessShortcut(onClick: () -> Unit) {
-    ProfileBar(
-        label = stringResource(R.string.employees),
+    AccountHubMenuRow(
+        title = stringResource(R.string.employees),
+        description = stringResource(R.string.account_hub_contact_support_description),
         onClick = onClick,
         icon = R.drawable.ic_contactus
     )
@@ -387,30 +750,29 @@ fun ProfileBar(
     onClick: () -> Unit,
     icon: Int,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(50.dp)
-            .clickable { onClick() },
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            painter = painterResource(icon),
-            contentDescription = null,
-            modifier = Modifier.size(16.dp)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Text(
-            text = label,
-            style = headline4,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Icon(
-            painter = painterResource(R.drawable.right_arrow),
-            contentDescription = null,
-            modifier = Modifier.size(16.dp)
-        )
+    AccountHubMenuRow(
+        title = label,
+        description = "",
+        onClick = onClick,
+        icon = icon,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun currentLanguageLabel(language: String): String {
+    return if (language == "en") {
+        stringResource(R.string.language_english)
+    } else {
+        stringResource(R.string.language_indonesia)
     }
+}
+
+private fun String.shouldShowPayrollAccess(): Boolean {
+    val normalized = lowercase()
+    return !normalized.contains("intern") &&
+        !normalized.contains("internship") &&
+        !normalized.contains("magang")
 }
 
 @Composable
@@ -420,7 +782,7 @@ private fun ProfileLoadingDialog(showDialog: Boolean) {
     Dialog(onDismissRequest = { }) {
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = White)
+            colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubSurface)
         ) {
             Column(
                 modifier = Modifier.padding(24.dp),

--- a/app/src/main/res/values-in/string.xml
+++ b/app/src/main/res/values-in/string.xml
@@ -142,6 +142,26 @@
     <string name="faq">FAQ</string>
     <string name="about_us">Tentang Kami</string>
     <string name="logOut">Keluar</string>
+    <string name="account_hub_title">Profil Saya</string>
+    <string name="account_hub_active_status">%1$s Aktif</string>
+    <string name="account_hub_role">Peran</string>
+    <string name="account_hub_division">Divisi</string>
+    <string name="account_hub_contact">Kontak</string>
+    <string name="account_hub_account_identity">Akun &amp; Identitas</string>
+    <string name="account_hub_company_access">Akses Perusahaan</string>
+    <string name="account_hub_help_information">Bantuan &amp; Informasi</string>
+    <string name="account_hub_security">Keamanan</string>
+    <string name="account_hub_edit_profile_description">Perbarui informasi pribadi Anda</string>
+    <string name="account_hub_language_description">Inggris / Indonesia</string>
+    <string name="account_hub_my_document_description">Lihat dokumen kerja dan perusahaan</string>
+    <string name="account_hub_pay_slip_description">Akses informasi penggajian</string>
+    <string name="account_hub_contact_support">Hubungi Dukungan</string>
+    <string name="account_hub_contact_support_description">Dapatkan bantuan dari admin atau HR</string>
+    <string name="account_hub_about_title">Tentang Infinite Track</string>
+    <string name="account_hub_about_description">Informasi aplikasi dan perusahaan</string>
+    <string name="account_hub_logout_description">Keluar dengan aman dari akun ini</string>
+    <string name="account_hub_not_available">Tidak tersedia</string>
+    <string name="account_hub_identifier">NIP/NIM %1$s</string>
 
     <!--  TimeOff Screen  -->
     //TimeOff Screen

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,6 +144,26 @@
     <string name="faq">FAQ</string>
     <string name="about_us">About Us</string>
     <string name="logOut">Log Out</string>
+    <string name="account_hub_title">My Profile</string>
+    <string name="account_hub_active_status">Active %1$s</string>
+    <string name="account_hub_role">Role</string>
+    <string name="account_hub_division">Division</string>
+    <string name="account_hub_contact">Contact</string>
+    <string name="account_hub_account_identity">Account &amp; Identity</string>
+    <string name="account_hub_company_access">Company Access</string>
+    <string name="account_hub_help_information">Help &amp; Information</string>
+    <string name="account_hub_security">Security</string>
+    <string name="account_hub_edit_profile_description">Update your personal information</string>
+    <string name="account_hub_language_description">English / Indonesia</string>
+    <string name="account_hub_my_document_description">View employment and company documents</string>
+    <string name="account_hub_pay_slip_description">Access payroll information</string>
+    <string name="account_hub_contact_support">Contact Support</string>
+    <string name="account_hub_contact_support_description">Get help from admin or HR</string>
+    <string name="account_hub_about_title">About Infinite Track</string>
+    <string name="account_hub_about_description">App and company information</string>
+    <string name="account_hub_logout_description">Securely sign out from this account</string>
+    <string name="account_hub_not_available">Not available</string>
+    <string name="account_hub_identifier">NIP/NIM %1$s</string>
 
 
     <!--  TimeOff Screen  -->

--- a/docs/superpowers/plans/2026-07-07-inf-226-account-hub-main-screen-refresh.md
+++ b/docs/superpowers/plans/2026-07-07-inf-226-account-hub-main-screen-refresh.md
@@ -1,0 +1,218 @@
+# INF-226 — Account Hub Main Screen Refresh Plan
+
+Date: 2026-07-07
+Branch: `fix/android-account-hub-main-refresh`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh`
+Spec: `docs/superpowers/specs/2026-07-07-inf-226-account-hub-main-screen-refresh.md`
+
+## Guardrails
+
+- Work only in the INF-226 isolated worktree and branch.
+- Do not edit the main `develop` checkout.
+- Keep scope limited to Profile / Account Hub main screen.
+- Do not redesign detail screens.
+- Do not change backend/API contracts.
+- Do not change auth/session/logout business logic.
+- Do not change navigation graph or route contracts.
+- Do not change bottom navigation.
+- Do not add a global icon token object.
+- Do not implement full INF-165.
+- Use existing state and callbacks from `ProfileScreen.kt` / `ProfileViewModel.kt`.
+- Follow the uploaded UI reference once available; exclude out-of-scope elements.
+
+## Baseline evidence
+
+- Main checkout: `E:\skrisi\android`, `develop`, `5438044`, dirty with unrelated untracked plan file.
+- INF-226 worktree: `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh`, branch `fix/android-account-hub-main-refresh`, `5438044`.
+- No existing relevant branch/worktree found for `profile|account|hub|inf-226|inf-165`.
+- `.claude/rules/*.md` files requested by user are absent in current repo; root `CLAUDE.md` is the available repo contract.
+
+## Task 1 — Finish visual-reference mapping before implementation
+
+Completed from the uploaded reference image on 2026-07-07:
+
+| Reference visual element | Android implementation |
+| --- | --- |
+| `My Profile` large title | Top account hub header |
+| Large soft-glass identity card | Screen-local identity hero in `ProfileScreen.kt` |
+| Avatar glow ring | Circular `AsyncImage` with soft purple/cyan border |
+| Pencil edit button | Rounded icon action wired to `navigateToEditProfile` |
+| Role/status pills | Soft pills using current `roleName` and visual active display |
+| Division/NIP rows | Existing `divisionName`/`programName` and `nipNim` |
+| Three mini cards | Role, division, contact summary cards |
+| Rounded grouped menu cards | Account, Company Access, Help, Security sections |
+| Red logout row | Security section row wired to existing logout confirm dialog |
+
+Out-of-scope from the reference:
+
+- FAQ navigation/feature activation because current Profile route/callback is not wired.
+- About detail screen creation; preserve existing no-op behavior only if displayed.
+- Dashboard/WFA/attendance/report/bottom-nav/detail-screen redesign.
+- Backend-driven active status semantics not available in `UserModel`.
+
+## Task 2 — Re-read affected files immediately before editing
+
+Read current versions in the INF-226 worktree:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileViewModel.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt`
+- `app/src/main/java/com/example/infinite_track/domain/model/auth/UserModel.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/surface/InfiniteCard.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteSectionHeader.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt`
+- `app/src/main/res/values/strings.xml`
+- `app/src/main/res/values-in/string.xml`
+
+## Task 3 — Refactor ProfileScreen main success content only
+
+1. Keep existing top-level state collection, language popup, logout confirm/loading/status dialogs, and navigation callbacks intact.
+2. Replace the success-state content layout with a scrollable Account Hub layout:
+   - page title/header if visually aligned with reference
+   - Identity hero section
+   - Account section
+   - Company Access section
+   - Help section
+   - Security section
+3. Use existing `UserModel` fields:
+   - full name
+   - role name
+   - position
+   - division or program as secondary org detail
+   - NIP/NIM
+   - photo URL
+4. Use local helper composables inside `ProfileScreen.kt` if they are screen-specific:
+   - identity hero card
+   - section card
+   - menu action row
+   - info chips/rows
+5. Prefer existing reusable Material 3 design components where they fit:
+   - `InfiniteCard`
+   - `InfiniteStatusPill`
+   - `InfiniteSectionHeader`
+   - `InfiniteColors`
+6. Do not create a global icon token object.
+7. Keep Account Hub colors out of `ProfileScreen.kt`; add/reuse theme/design tokens in `InfiniteColors.kt` backed by existing `presentation/theme/Color.kt` palette.
+8. Do not modify `ProfileViewModel.kt` unless compile requires a no-behavior-change cleanup.
+
+## Task 4 — Preserve existing actions and role behavior safely
+
+1. Wire row clicks to the existing callbacks:
+   - Edit Profile -> `navigateToEditProfile`
+   - Language -> `profileViewModel.onLanguageSettingsClicked()`
+   - My Document -> `navigateToMyDocument`
+   - Pay Slip -> `navigateToPaySlip`
+   - Employees / contacts -> `navigateToContacts` if retained
+   - Contact Us -> `navigateToContactUs`
+   - About -> no-op as current behavior, unless removed from visible UI because it is unwired; do not create route/screen
+   - Logout -> `showLogoutConfirmDialog = true`
+2. Role-gate Pay Slip only with a conservative local helper if supported by current `roleName` evidence:
+   - hide for role strings containing `intern`, `internship`, or `magang`
+   - show for other roles to preserve current behavior
+3. Mark role visibility as `Needs Verification` unless runtime data confirms role variants.
+4. Do not change `MainContentNavGraph.kt`.
+
+## Task 5 — Strings and labels
+
+1. Reuse existing string resources where possible.
+2. Add only small section label strings if needed:
+   - Identity
+   - Account
+   - Company Access
+   - Help
+   - Security
+   - Active
+   - NIP/NIM
+3. Add matching Indonesian translations in `values-in/string.xml` if new strings are introduced.
+4. Avoid changing existing labels used by detail screens unless required for the main screen only.
+
+## Task 6 — Build and local verification
+
+Run from `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh`:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If feasible:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+If Gradle fails with a known local loopback/daemon issue, preserve the exact output and mark build as `Needs Verification` rather than claiming success.
+
+### Current local verification status
+
+Attempts in this worktree failed before Kotlin compile with the same environment-level Gradle bootstrap error:
+
+```text
+java.io.IOException: Unable to establish loopback connection
+```
+
+Commands attempted:
+
+```bash
+./gradlew app:assembleDebug
+./gradlew --no-daemon app:assembleDebug
+./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
+```
+
+Static checks completed:
+
+- `git diff --check` returned no whitespace errors, only Windows line-ending warning for `ProfileScreen.kt`.
+- `ProfileScreen.kt` grep found no Account Hub hardcoded hex/theme colors after moving colors to `InfiniteColors.kt`.
+- Account Hub string parity check found 20 `account_hub_*` strings in both `values/strings.xml` and `values-in/string.xml`, with no missing counterpart.
+
+## Task 7 — Runtime / visual verification
+
+If emulator/device is available:
+
+1. Open Profile tab.
+2. Capture refreshed Account Hub screenshot.
+3. Confirm visual grouping:
+   - Identity
+   - Account
+   - Company Access
+   - Help
+   - Security
+4. Tap and return:
+   - Edit Profile
+   - My Document
+   - Pay Slip if visible
+   - Contact/Support
+5. Tap Logout and verify existing confirmation dialog appears.
+6. Cancel logout. Do not perform destructive logout unless explicitly safe.
+
+If emulator/runtime cannot be run, mark these as `Needs Verification`.
+
+## Expected affected files
+
+Likely:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`
+- `app/src/main/res/values/strings.xml` if section labels need resources
+- `app/src/main/res/values-in/string.xml` if section labels need translations
+
+Possibly not touched:
+
+- `ProfileViewModel.kt`
+- `MainContentNavGraph.kt`
+- detail screens
+
+## PR / review note draft
+
+- Work done in isolated branch/worktree: `fix/android-account-hub-main-refresh` / `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh`.
+- Main Account Hub/Profile screen refreshed.
+- Visual direction follows uploaded reference image within INF-226 scope.
+- Content grouped into identity/account/company access/help/security.
+- Existing navigation behavior preserved.
+- Role-based visibility respected or marked `Needs Verification`.
+- No detail screens redesigned.
+- No backend changes.
+- No auth/session changes.
+- No global icon token object.
+- Build evidence included.
+- Runtime screenshot/navigation evidence included or marked `Needs Verification`.

--- a/docs/superpowers/specs/2026-07-07-inf-226-account-hub-main-screen-refresh.md
+++ b/docs/superpowers/specs/2026-07-07-inf-226-account-hub-main-screen-refresh.md
@@ -1,0 +1,197 @@
+# INF-226 — Account Hub Main Screen Refresh Spec
+
+Date: 2026-07-07
+Branch: `fix/android-account-hub-main-refresh`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh`
+Base: `develop` at `5438044`
+
+## Goal
+
+Refresh the Android Profile / Account Hub **main screen only** so it presents account identity, account preferences, company access, help, and security actions in a clearer Material 3 friendly account hub.
+
+Android remains a trusted data-capture client, not the source of truth for backend-owned state. This issue must not change backend contracts, auth/session behavior, logout business logic, or navigation route contracts.
+
+## Worktree and branch mapping
+
+- Main checkout: `E:\skrisi\android`, branch `develop`, head `5438044`.
+- Main checkout had one unrelated untracked plan file and must not be edited for INF-226.
+- Existing branch/worktree search for `profile|account|hub|inf-226|inf-165` found no safe/relevant candidate.
+- INF-226 work happens only in `C:\Users\Febriyadi\.claude\worktrees\android-account-hub-main-refresh` on `fix/android-account-hub-main-refresh`.
+
+## Current source mapping
+
+### Profile main screen
+
+- File: `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`
+- Current profile success content shows:
+  - name
+  - position
+  - circular photo
+  - account information rows: Edit Profile, Pay Slip, My Document, Employees shortcut
+  - settings rows: Language, Contact Us, About Us, Log Out
+- Current loading/error states still expose `EmployeesAccessShortcut`, which is pre-existing behavior and not part of this visual refresh unless layout requires safe containment.
+
+### Profile state and user fields
+
+- File: `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileViewModel.kt`
+- Data source: `GetLoggedInUserUseCase()` into `profileState: UiState<UserModel>`.
+- User model fields available from `app/src/main/java/com/example/infinite_track/domain/model/auth/UserModel.kt`:
+  - `fullName`
+  - `email`
+  - `roleName`
+  - `positionName`
+  - `programName`
+  - `divisionName`
+  - `nipNim`
+  - `phone`
+  - `photoUrl`
+- Active account status is not a current user-model field. The Account Hub may show a visual `Active` status pill as a client-side display label only, not as backend truth.
+
+### Existing navigation actions
+
+- File: `app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt`
+- Existing callbacks must be preserved:
+  - `navigateToEditProfile` -> `Screen.EditProfile.route`
+  - `navigateToContactUs` -> `Screen.ContactUs.route`
+  - `navigateToContacts` -> `Screen.Contact.route`
+  - `navigateToMyDocument` -> `Screen.MyDocument.route`
+  - `navigateToPaySlip` -> `Screen.PaySlip.route`
+  - Logout entry -> existing `InfiniteTrackConfirmDialog`, `ProfileViewModel.onConfirmLogout()`, and root auth graph navigation after status dialog.
+
+### Existing reusable UI foundation
+
+INF-222 components are present and safe to use additively:
+
+- `presentation/design/components/surface/InfiniteCard.kt`
+- `presentation/design/components/surface/InfiniteSurface.kt`
+- `presentation/design/components/status/InfiniteStatusPill.kt`
+- `presentation/design/components/data/InfiniteSectionHeader.kt`
+- `presentation/design/components/data/InfiniteInfoRow.kt`
+- `presentation/design/tokens/InfiniteColors.kt`
+- `presentation/design/tokens/InfiniteSpacing.kt`
+- `presentation/design/tokens/InfiniteRadius.kt`
+
+No new global icon token object should be added. Existing drawable icons and local Material Icons imports are acceptable if compile-safe.
+
+## Target content grouping
+
+Implement the Profile main screen sections as:
+
+1. Identity
+   - avatar/photo
+   - full name
+   - role badge
+   - position
+   - division
+   - NIP/NIM or employee ID
+   - active status pill
+2. Account
+   - Edit Profile
+   - Language / account preference row (existing behavior)
+3. Company Access
+   - My Document
+   - Pay Slip only when current role check safely identifies employee/admin/management and excludes internship
+   - Employees / contacts access only if current existing behavior remains intentionally visible; if role contract is unclear, preserve current visibility rather than inventing backend role semantics
+4. Help
+   - Contact Us / Support
+   - About if already available as an entry, but do not create a new About screen or route
+   - FAQ remains out-of-scope because it is not currently wired in `ProfileScreen.kt`
+5. Security
+   - Logout visual entry only; existing logout confirmation and business logic preserved
+
+## Role-based visibility policy
+
+The current `ProfileScreen.kt` has no role-gated Pay Slip / My Document visibility. `UserModel.roleName` is available, and other screens distinguish user roles by strings such as home content role branching.
+
+Safe INF-226 policy:
+
+- Do not introduce or change backend role contracts.
+- Use only existing `roleName` strings if the current app already exposes enough evidence.
+- Pay Slip may be hidden for role names containing `intern` / `magang` / `internship`, because acceptance explicitly says Internship must not see employee-only payroll/service access when supported.
+- If runtime role variants cannot be verified, mark role visibility as `Needs Verification`.
+- Do not remove existing contact/company shortcuts unless the user approves broader behavior change.
+
+## Visual reference mapping
+
+User uploaded a Profile / Account Hub reference image on 2026-07-07. The image shows a light, soft-glass profile hub with a large identity hero, quick summary cards, grouped menu surfaces, and a red-tinted logout row.
+
+| Reference visual element | Android implementation |
+| --- | --- |
+| Large `My Profile` title | Header text at the top of the Profile main screen |
+| Large soft-glass identity hero card | Screen-local identity hero composable in `ProfileScreen.kt` using rounded Material 3 surfaces, soft border, subtle shadow, and light purple/cyan visual tone |
+| Circular avatar with glow ring | Existing `AsyncImage` clipped as circle with soft purple/cyan ring treatment |
+| Floating pencil edit button | Small rounded edit action in identity hero, wired to existing `navigateToEditProfile` callback |
+| Name + position hierarchy | `fullName` as primary text and `positionName` as purple-accent subtitle |
+| Role pill | Existing `roleName` rendered as a soft pill |
+| Division and NIP rows | Existing `divisionName`/`programName` and `nipNim` rendered as compact identity rows |
+| Active Employee pill | Visual active status pill only; not treated as backend truth |
+| Three quick summary cards | Role, division/program, and contact/phone summary cards below hero |
+| Account & Identity menu card | Account section with Edit Profile and Language rows |
+| Company Access card | My Document and Pay Slip rows, with conservative internship payroll hiding if role text supports it |
+| Help & Information card | Contact Support plus existing About entry; FAQ remains out-of-scope because current Profile route/callback is not wired |
+| Security card | Red-tinted Logout row that opens the existing logout confirmation dialog |
+| Liquid/glass background blobs | Subtle gradients and soft cards only; no heavy blur dependency, no dark mode, no neon |
+
+Out-of-scope from the reference for INF-226:
+
+- FAQ navigation/feature activation because the current Profile callback is commented/not wired.
+- About detail screen creation; existing About row may remain no-op, but no new route/screen is added.
+- Dashboard, WFA, attendance, report, bottom navigation, or detail screen redesign.
+- Backend-driven account status beyond fields currently available in `UserModel`.
+
+## Non-goals
+
+- No redesign of `EditProfile.kt`, `PaySlipScreen.kt`, `MyDocumentScreen.kt`, `ContactUsScreen.kt`, FAQ detail, About detail, Login, Attendance, Home, or WFA screens.
+- No backend/API contract change.
+- No auth/session/logout business-logic change.
+- No navigation graph or route contract change.
+- No bottom navigation change.
+- No global icon token object.
+- No full INF-165 implementation.
+- No new Pay Slip / My Document feature logic.
+
+## Risks
+
+- Logout is a session boundary surface. Only the visual row may change; confirm dialog and `ProfileViewModel.onConfirmLogout()` behavior must remain unchanged.
+- Role names may vary by backend data. Any role-based visibility beyond existing model evidence must be treated as `Needs Verification`.
+- UI reference image may contain out-of-scope screens/elements; those must be excluded unless separately approved.
+- UI/navigation runtime verification requires emulator/device; build alone is not enough to mark Account Hub as Done.
+
+## Verification plan
+
+Run from the isolated worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If time/environment permits:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime smoke, if emulator/device is available:
+
+1. Open Profile tab.
+2. Verify Account Hub main screen renders and sections are visible.
+3. Tap Edit Profile, then back.
+4. Tap My Document, then back.
+5. Tap Pay Slip if visible, then back.
+6. Tap Contact/Support, then back.
+7. Tap Logout entry, verify existing confirmation appears, cancel logout.
+8. Capture screenshot/screen recording as visual evidence.
+
+If runtime cannot be executed, mark runtime and screenshot evidence as `Needs Verification`.
+
+## Docs / ADR note
+
+No ADR expected if implementation remains a main-screen visual refresh only. PR note must explicitly say:
+
+- INF-226 only refreshes Profile / Account Hub main screen.
+- No backend contract changed.
+- No auth/session logic changed.
+- No detail screens redesigned.
+- No global icon token object created.
+- Uploaded UI reference followed within INF-226 scope.


### PR DESCRIPTION
## Summary

- Refreshes the Android Profile / Account Hub main screen only for INF-226.
- Follows the uploaded UI reference within scope: identity hero, quick summary cards, grouped menu cards, and red-tinted security/logout row.
- Groups content into Identity, Account & Identity, Company Access, Help & Information, and Security.
- Adds Account Hub design color tokens to `InfiniteColors.kt`, backed by the existing theme palette instead of hardcoded screen colors.
- Adds localized Account Hub strings in `values` and `values-in`.
- Adds INF-226 spec and plan docs with visual mapping, guardrails, verification plan, and known Needs Verification items.

## Guardrails / non-goals

- No backend contract changes.
- No auth/session/logout business logic changes.
- No navigation graph or route contract changes.
- No bottom navigation changes.
- No detail screen redesigns.
- No global icon token object created.
- FAQ from the reference remains out-of-scope because the current Profile callback/route is not wired.
- About remains an existing entry/no-op; no About screen or route is created.

## Role visibility

- Uses existing `UserModel.roleName` only.
- Pay Slip is conservatively hidden for role names containing `intern`, `internship`, or `magang`.
- Runtime role variants still need validation with real profile data.

## Verification

Static checks completed locally:

- `git diff --check` returned no whitespace errors, only Windows line-ending warnings for modified text files.
- `ProfileScreen.kt` grep found no Account Hub hardcoded hex/theme colors after moving colors to `InfiniteColors.kt`.
- Account Hub string parity check found 20 `account_hub_*` strings in both `values/strings.xml` and `values-in/string.xml`, with no missing counterpart.

Attempted build commands:

```bash
./gradlew app:assembleDebug
./gradlew --no-daemon app:assembleDebug
./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
```

All local Gradle attempts failed before Kotlin compile with the environment-level bootstrap error:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

- `./gradlew app:assembleDebug` in CI/Android Studio or another environment without the local loopback issue.
- Optional quality gate when environment allows: `./gradlew app:test` and `./gradlew app:lint`.
- Runtime/emulator smoke:
  - Open Profile tab.
  - Verify refreshed Account Hub visual against uploaded reference.
  - Tap Edit Profile and back.
  - Tap My Document and back.
  - Tap Pay Slip if visible and back.
  - Tap Contact Support and back.
  - Tap Logout and verify existing confirmation appears, then cancel.
- Screenshot/screen recording evidence of refreshed Account Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
