### PR TITLE
fix: Revise WFA requests header and remove CTA

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -92,9 +92,7 @@ fun NavGraphBuilder.mainContentNavGraph(
     }
 
     composable(Screen.Wfa.route) {
-        WfaHistoryScreen(
-            onOpenAttendance = { navController.safeNavigate(Screen.Attendance.route) }
-        )
+        WfaHistoryScreen()
     }
 
     // Profile Feature Flow

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaHistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaHistoryScreen.kt
@@ -10,10 +10,8 @@ import com.example.infinite_track.presentation.screen.home.HomeViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
-fun WfaHistoryScreen(
-    onOpenAttendance: () -> Unit
-) {
-    WfaRequestsScreen(onOpenAttendance = onOpenAttendance)
+fun WfaHistoryScreen() {
+    WfaRequestsScreen()
 }
 
 @Composable

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -11,16 +11,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -35,7 +31,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -46,18 +41,17 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.infinite_track.presentation.components.loading.InlineRefreshingIndicator
+import com.example.infinite_track.presentation.core.headline3
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestCard
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestFilterChips
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestStatusSummary
 import com.example.infinite_track.presentation.theme.Blue_500
-import com.example.infinite_track.presentation.theme.Blue_600
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 fun WfaRequestsScreen(
-    onOpenAttendance: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: WfaRequestsViewModel = hiltViewModel()
 ) {
@@ -90,13 +84,7 @@ fun WfaRequestsScreen(
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        containerColor = Color.Transparent,
-        bottomBar = {
-            OpenAttendanceAction(
-                onOpenAttendance = onOpenAttendance,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
-            )
-        }
+        containerColor = Color.Transparent
     ) { innerPadding ->
         LazyColumn(
             state = listState,
@@ -193,18 +181,15 @@ fun WfaRequestsScreen(
 
 @Composable
 private fun WfaRequestsHeader() {
-    Column {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
         Text(
             text = "WFA Requests",
-            style = MaterialTheme.typography.headlineMedium,
-            color = Purple_500,
-            fontWeight = FontWeight.Bold
-        )
-        Text(
-            text = "Track your Work From Anywhere submissions",
-            style = MaterialTheme.typography.bodyLarge,
-            color = Blue_600,
-            modifier = Modifier.padding(top = 2.dp)
+            style = headline3
         )
     }
 }
@@ -273,47 +258,6 @@ private fun ErrorState(
     }
 }
 
-@Composable
-private fun OpenAttendanceAction(
-    onOpenAttendance: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Button(
-        onClick = onOpenAttendance,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(58.dp),
-        shape = RoundedCornerShape(18.dp),
-        colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-        contentPadding = PaddingValues()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    brush = Brush.horizontalGradient(
-                        listOf(Blue_500, Blue_600)
-                    ),
-                    shape = RoundedCornerShape(18.dp)
-                ),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            androidx.compose.material3.Icon(
-                imageVector = Icons.Default.ArrowForward,
-                contentDescription = null,
-                tint = Color.White
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Text(
-                text = "Open Attendance",
-                color = Color.White,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-        }
-    }
-}
 
 private const val PullToRefreshThresholdPx = 160f
 


### PR DESCRIPTION
## Summary

Applies requested WFA Requests UI revisions after INF-218 merge.

- Updates the WFA Requests title/header style to match the existing `Attendance History` title style (`headline3`, centered top row).
- Removes the subtitle text `Track your Work From Anywhere submissions`.
- Removes the `Open Attendance` bottom CTA button from the WFA Requests page.
- Simplifies WFA route wiring now that the WFA page no longer needs an Attendance navigation callback.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open WFA bottom tab.
- Confirm title style visually matches `Attendance History`.
- Confirm subtitle is removed.
- Confirm `Open Attendance` CTA is removed.
- Confirm WFA list/filter/refresh still render normally.

## Docs / ADR

No ADR update required; this is a focused UI revision that does not change backend contract, auth/session behavior, attendance business logic, or bottom-tab ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
