### PR TITLE
INF-228: Refresh Android edit profile detail screen

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
@@ -27,10 +27,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -78,18 +78,9 @@ fun EditProfile(
     val phone by viewModel.phone.collectAsStateWithLifecycle()
     val nipNim by viewModel.nipNim.collectAsStateWithLifecycle()
     val updateProfileState by viewModel.updateProfileState.collectAsStateWithLifecycle()
+    val canSave by viewModel.canSave.collectAsStateWithLifecycle()
 
     val isSaving = updateProfileState is UiState.Loading
-    val hasChanges = userProfile?.let { user ->
-        fullName != user.fullName ||
-            nipNim != user.nipNim ||
-            phone != user.phone.orEmpty()
-    } ?: false
-    val canSave = userProfile != null &&
-        fullName.isNotBlank() &&
-        nipNim.isNotBlank() &&
-        hasChanges &&
-        !isSaving
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -397,8 +388,10 @@ private fun EditProfileField(
                 }
             },
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-            colors = TextFieldDefaults.outlinedTextFieldColors(
-                containerColor = InfiniteColors.AccountHubIconSurface,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = InfiniteColors.AccountHubIconSurface,
+                unfocusedContainerColor = InfiniteColors.AccountHubIconSurface,
+                disabledContainerColor = InfiniteColors.AccountHubIconSurface,
                 focusedBorderColor = borderColor,
                 unfocusedBorderColor = borderColor,
                 disabledBorderColor = borderColor,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
@@ -1,207 +1,520 @@
 package com.example.infinite_track.presentation.screen.profile.details.edit_profile
 
-import android.widget.Toast
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.infinite_track.presentation.components.avatar.ProfileCard
-import com.example.infinite_track.presentation.components.button.CancelButton
-import com.example.infinite_track.presentation.components.button.InfiniteTracButtonBack
-import com.example.infinite_track.presentation.components.button.InfiniteTrackButton
-import com.example.infinite_track.presentation.components.profile_textfield.PhoneNumberTextFieldComponent
-import com.example.infinite_track.presentation.components.profile_textfield.ProfileTextFieldComponent
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.example.infinite_track.R
+import com.example.infinite_track.domain.model.auth.UserModel
+import com.example.infinite_track.presentation.components.status.InfiniteTrackInlineAlert
+import com.example.infinite_track.presentation.components.status.StatusStateSpec
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.headline2
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.utils.UiState
 
-/**
- * Edit Profile Screen component
- * Purely reactive UI that only displays state from ViewModel
- * and forwards user actions to ViewModel
- */
+private const val DefaultAvatarUrl =
+    "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png"
+
 @Composable
 fun EditProfile(
     onBackClick: () -> Unit,
     viewModel: EditProfileViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
+    val userProfile by viewModel.userProfileState.collectAsStateWithLifecycle()
+    val fullName by viewModel.fullName.collectAsStateWithLifecycle()
+    val phone by viewModel.phone.collectAsStateWithLifecycle()
+    val nipNim by viewModel.nipNim.collectAsStateWithLifecycle()
+    val updateProfileState by viewModel.updateProfileState.collectAsStateWithLifecycle()
 
-    // Collect states from ViewModel
-    val userProfile by viewModel.userProfileState.collectAsState()
-    val fullName by viewModel.fullName.collectAsState()
-    val phone by viewModel.phone.collectAsState()
-    val nipNim by viewModel.nipNim.collectAsState()
-    val isEditing by viewModel.isEditing.collectAsState()
-    val updateProfileState by viewModel.updateProfileState.collectAsState()
+    val isSaving = updateProfileState is UiState.Loading
+    val hasChanges = userProfile?.let { user ->
+        fullName != user.fullName ||
+            nipNim != user.nipNim ||
+            phone != user.phone.orEmpty()
+    } ?: false
+    val canSave = userProfile != null &&
+        fullName.isNotBlank() &&
+        nipNim.isNotBlank() &&
+        hasChanges &&
+        !isSaving
 
-    // Process update profile state
-    LaunchedEffect(updateProfileState) {
-        when (updateProfileState) {
-            is UiState.Success -> {
-                Toast.makeText(
-                    context,
-                    "Profile updated successfully!",
-                    Toast.LENGTH_SHORT
-                ).show()
-                onBackClick() // Navigate back on successful update
-                viewModel.resetUpdateState() // Reset state after handling
-            }
-
-            is UiState.Error -> {
-                Toast.makeText(
-                    context,
-                    (updateProfileState as UiState.Error).errorMessage,
-                    Toast.LENGTH_SHORT
-                ).show()
-                viewModel.resetUpdateState() // Reset state after handling error
-            }
-
-            else -> { /* Do nothing for other states */
-            }
-        }
-    }
-
-    // UI Layout
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = Color.Transparent,
         topBar = {
-            InfiniteTracButtonBack(
-                title = "Edit Profile",
-                navigationBack = onBackClick,
-                modifier = Modifier.padding(top = 12.dp)
+            EditProfileTopBar(onBackClick = onBackClick)
+        },
+        bottomBar = {
+            EditProfileBottomActionBar(
+                canSave = canSave,
+                isSaving = isSaving,
+                onSave = { viewModel.onSaveChangesClick() },
+                onCancel = {
+                    viewModel.onCancelClick()
+                    onBackClick()
+                }
             )
         }
     ) { innerPadding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
+                .background(InfiniteColors.AccountHubBackgroundGradient)
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            // Loading indicator when update is in progress
-            if (updateProfileState is UiState.Loading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center)
-                )
+            EditProfileHeroCard(user = userProfile)
+            EditProfileFormCard(
+                user = userProfile,
+                fullName = fullName,
+                nipNim = nipNim,
+                phone = phone,
+                onFullNameChange = viewModel::onFullNameChange,
+                onNipNimChange = viewModel::onNipNimChange,
+                onPhoneChange = viewModel::onPhoneChange
+            )
+            EditProfileFeedback(
+                updateProfileState = updateProfileState,
+                onDismiss = { viewModel.resetUpdateState() }
+            )
+            Spacer(modifier = Modifier.height(88.dp))
+        }
+    }
+}
+
+@Composable
+private fun EditProfileTopBar(onBackClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(78.dp)
+                .background(InfiniteColors.AccountHubHeroGradient)
+                .padding(horizontal = 18.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .size(52.dp)
+                    .clickable { onBackClick() },
+                shape = CircleShape,
+                color = InfiniteColors.AccountHubFloatingSurface,
+                border = BorderStroke(1.dp, InfiniteColors.AccountHubStrongOutline),
+                shadowElevation = 4.dp
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_backks),
+                        contentDescription = stringResource(R.string.cancel),
+                        tint = InfiniteColors.AccountHubTitle,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+            Text(
+                text = stringResource(R.string.edit_profile_title),
+                style = headline2,
+                color = InfiniteColors.AccountHubTitle,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditProfileHeroCard(user: UserModel?) {
+    val unavailable = stringResource(R.string.account_hub_not_available)
+    val fullName = user?.fullName?.ifBlank { unavailable } ?: unavailable
+    val position = user?.positionName?.ifBlank { null } ?: stringResource(R.string.edit_profile_no_position)
+    val role = user?.roleName?.ifBlank { unavailable } ?: unavailable
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(InfiniteColors.AccountHubHeroGradient)
+                .padding(22.dp),
+            horizontalArrangement = Arrangement.spacedBy(22.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(contentAlignment = Alignment.BottomEnd) {
+                Box(
+                    modifier = Modifier
+                        .size(118.dp)
+                        .clip(CircleShape)
+                        .background(InfiniteColors.AccountHubAvatarRingGradient)
+                        .padding(4.dp)
+                ) {
+                    AsyncImage(
+                        model = user?.photoUrl ?: DefaultAvatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(CircleShape)
+                            .border(3.dp, InfiniteColors.AccountHubOutline, CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+                Surface(
+                    modifier = Modifier.size(44.dp),
+                    shape = CircleShape,
+                    color = InfiniteColors.AccountHubFloatingSurface,
+                    border = BorderStroke(1.dp, InfiniteColors.AccountHubStrongOutline),
+                    shadowElevation = 5.dp
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_cameras),
+                            contentDescription = stringResource(R.string.edit_profile_photo_action_disabled),
+                            tint = InfiniteColors.AccountHubPrimary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
             }
 
             Column(
-                modifier = Modifier
-                    .padding(innerPadding)
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                // Only show profile card if user profile is available
-                userProfile?.let { user ->
-                    ProfileCard(
-                        imageResId = com.example.infinite_track.R.drawable.logo,
-                        name = user.fullName,
-                        jobTitle = user.positionName ?: "No Position"
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Editable fields
-                ProfileTextFieldComponent(
-                    label = "Full Name",
-                    value = fullName,
-                    onValueChange = { viewModel.onFullNameChange(it) },
-                    enabled = isEditing
+                Text(
+                    text = fullName,
+                    style = headline2,
+                    color = InfiniteColors.AccountHubTitle,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                ProfileTextFieldComponent(
-                    label = "NIP / NIM",
-                    value = nipNim,
-                    onValueChange = { viewModel.onNipNimChange(it) },
-                    enabled = isEditing
+                Text(
+                    text = position,
+                    style = headline3,
+                    color = InfiniteColors.AccountHubMutedText,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Read-only fields
-                userProfile?.let { user ->
-                    ProfileTextFieldComponent(
-                        label = "Division",
-                        value = user.divisionName ?: "No Division",
-                        enabled = false
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    ProfileTextFieldComponent(
-                        label = "Position",
-                        value = user.positionName ?: "No Position",
-                        enabled = false
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    ProfileTextFieldComponent(
-                        label = "Email",
-                        value = user.email,
-                        enabled = false
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                PhoneNumberTextFieldComponent(
-                    label = "Phone Number",
-                    value = phone,
-                    onValueChange = { viewModel.onPhoneChange(it) },
-                    enabled = isEditing
+                InfiniteStatusPill(
+                    label = role,
+                    variant = InfiniteStatusVariant.Recommended,
+                    size = InfiniteSize.Small,
+                    leadingIcon = null
                 )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (isEditing) {
-                        InfiniteTrackButton(
-                            label = "Save",
-                            onClick = { viewModel.onSaveChangesClick() },
-                            enabled = true,
-                            isOutline = false
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        CancelButton(
-                            onClick = { viewModel.onCancelClick() },
-                            label = "Cancel"
-                        )
-                    }
-
-                    if (!isEditing) {
-                        InfiniteTrackButton(
-                            label = "Edit",
-                            onClick = { viewModel.onToggleEditMode() },
-                            enabled = true,
-                            isOutline = false
-                        )
-                    }
-                }
             }
+        }
+    }
+}
+
+@Composable
+private fun EditProfileFormCard(
+    user: UserModel?,
+    fullName: String,
+    nipNim: String,
+    phone: String,
+    onFullNameChange: (String) -> Unit,
+    onNipNimChange: (String) -> Unit,
+    onPhoneChange: (String) -> Unit
+) {
+    val noDivision = stringResource(R.string.edit_profile_no_division)
+    val noPosition = stringResource(R.string.edit_profile_no_position)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_full_name),
+                value = fullName,
+                onValueChange = onFullNameChange,
+                editable = true,
+                icon = R.drawable.ic_pencil
+            )
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_nip_nim),
+                value = nipNim,
+                onValueChange = onNipNimChange,
+                editable = true,
+                icon = R.drawable.ic_pencil
+            )
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_phone_number),
+                value = phone,
+                onValueChange = onPhoneChange,
+                editable = true,
+                icon = R.drawable.ic_pencil,
+                keyboardType = KeyboardType.Phone
+            )
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_division),
+                value = user?.divisionName?.ifBlank { null } ?: noDivision,
+                onValueChange = {},
+                editable = false
+            )
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_position),
+                value = user?.positionName?.ifBlank { null } ?: noPosition,
+                onValueChange = {},
+                editable = false
+            )
+            EditProfileField(
+                label = stringResource(R.string.edit_profile_email),
+                value = user?.email.orEmpty(),
+                onValueChange = {},
+                editable = false
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditProfileField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    editable: Boolean,
+    @DrawableRes icon: Int? = null,
+    keyboardType: KeyboardType = KeyboardType.Text
+) {
+    var focused by remember { mutableStateOf(false) }
+    val borderColor = when {
+        focused && editable -> InfiniteColors.AccountHubPrimary
+        editable -> InfiniteColors.AccountHubOutline
+        else -> InfiniteColors.AccountHubDividerColor
+    }
+    val fieldValue = value.ifBlank {
+        if (editable) "" else stringResource(R.string.account_hub_not_available)
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = label,
+            style = headline4,
+            color = InfiniteColors.AccountHubMutedText,
+            fontWeight = FontWeight.Medium
+        )
+        OutlinedTextField(
+            value = fieldValue,
+            onValueChange = onValueChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged { focused = it.isFocused },
+            enabled = editable,
+            readOnly = !editable,
+            singleLine = true,
+            textStyle = body1.copy(color = InfiniteColors.AccountHubTitle),
+            shape = RoundedCornerShape(18.dp),
+            trailingIcon = {
+                if (editable && icon != null) {
+                    Icon(
+                        painter = painterResource(icon),
+                        contentDescription = label,
+                        tint = InfiniteColors.AccountHubPrimary,
+                        modifier = Modifier.size(22.dp)
+                    )
+                } else if (!editable) {
+                    ReadOnlyBadge()
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                containerColor = InfiniteColors.AccountHubIconSurface,
+                focusedBorderColor = borderColor,
+                unfocusedBorderColor = borderColor,
+                disabledBorderColor = borderColor,
+                cursorColor = InfiniteColors.AccountHubPrimary,
+                focusedTextColor = InfiniteColors.AccountHubTitle,
+                unfocusedTextColor = InfiniteColors.AccountHubTitle,
+                disabledTextColor = InfiniteColors.AccountHubBodyText,
+                disabledTrailingIconColor = InfiniteColors.AccountHubMutedText
+            )
+        )
+    }
+}
+
+@Composable
+private fun ReadOnlyBadge() {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = InfiniteColors.AccountHubFloatingSurface,
+        border = BorderStroke(1.dp, InfiniteColors.AccountHubDividerColor)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Lock,
+                contentDescription = null,
+                tint = InfiniteColors.AccountHubMutedText,
+                modifier = Modifier.size(16.dp)
+            )
+            Text(
+                text = stringResource(R.string.edit_profile_read_only),
+                style = headline4,
+                color = InfiniteColors.AccountHubMutedText,
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditProfileFeedback(
+    updateProfileState: UiState<UserModel>,
+    onDismiss: () -> Unit
+) {
+    when (updateProfileState) {
+        is UiState.Success -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStateSpec("success", "Success"),
+                title = stringResource(R.string.edit_profile_success_title),
+                message = stringResource(R.string.edit_profile_success_message),
+                onDismiss = onDismiss
+            )
+        }
+
+        is UiState.Error -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStateSpec("error", "Error"),
+                title = stringResource(R.string.edit_profile_error_title),
+                message = updateProfileState.errorMessage.ifBlank {
+                    stringResource(R.string.edit_profile_error_message)
+                },
+                onDismiss = onDismiss
+            )
+        }
+
+        else -> Unit
+    }
+}
+
+@Composable
+private fun EditProfileBottomActionBar(
+    canSave: Boolean,
+    isSaving: Boolean,
+    onSave: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val primaryState = when {
+        isSaving -> InfiniteButtonState.Loading
+        canSave -> InfiniteButtonState.Enabled
+        else -> InfiniteButtonState.Disabled
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = InfiniteColors.AccountHubHeroSurface,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            InfiniteButton(
+                text = if (isSaving) {
+                    stringResource(R.string.edit_profile_saving)
+                } else {
+                    stringResource(R.string.edit_profile_save_changes)
+                },
+                onClick = onSave,
+                modifier = Modifier.weight(1f),
+                variant = InfiniteButtonVariant.Primary,
+                state = primaryState,
+                fullWidth = true
+            )
+            InfiniteButton(
+                text = stringResource(R.string.edit_profile_cancel),
+                onClick = onCancel,
+                modifier = Modifier.weight(1f),
+                variant = InfiniteButtonVariant.Outlined,
+                state = if (isSaving) InfiniteButtonState.Disabled else InfiniteButtonState.Enabled,
+                fullWidth = true
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
@@ -68,9 +68,6 @@ import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.utils.UiState
 
-private const val DefaultAvatarUrl =
-    "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png"
-
 @Composable
 fun EditProfile(
     onBackClick: () -> Unit,
@@ -221,8 +218,11 @@ private fun EditProfileHeroCard(user: UserModel?) {
                         .padding(4.dp)
                 ) {
                     AsyncImage(
-                        model = user?.photoUrl ?: DefaultAvatarUrl,
+                        model = user?.photoUrl?.takeIf { it.isNotBlank() },
                         contentDescription = null,
+                        placeholder = painterResource(R.drawable.ic_profile),
+                        error = painterResource(R.drawable.ic_profile),
+                        fallback = painterResource(R.drawable.ic_profile),
                         modifier = Modifier
                             .fillMaxSize()
                             .clip(CircleShape)

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt
@@ -9,9 +9,12 @@ import com.example.infinite_track.domain.use_case.profile.UpdateProfileUseCase
 import com.example.infinite_track.utils.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -46,6 +49,29 @@ class EditProfileViewModel @Inject constructor(
     // Update profile state
     private val _updateProfileState = MutableStateFlow<UiState<UserModel>>(UiState.Idle)
     val updateProfileState: StateFlow<UiState<UserModel>> = _updateProfileState.asStateFlow()
+
+    val hasChanges: StateFlow<Boolean> = combine(
+        _userProfileState,
+        _fullName,
+        _nipNim,
+        _phone
+    ) { currentUser, fullName, nipNim, phone ->
+        currentUser?.let { isFormChanged(it, fullName, nipNim, phone) } ?: false
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val canSave: StateFlow<Boolean> = combine(
+        _userProfileState,
+        _fullName,
+        _nipNim,
+        hasChanges,
+        _updateProfileState
+    ) { currentUser, fullName, nipNim, hasChanges, updateState ->
+        currentUser != null &&
+                fullName.isNotBlank() &&
+                nipNim.isNotBlank() &&
+                hasChanges &&
+                updateState !is UiState.Loading
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     init {
         fetchUserProfile()
@@ -117,7 +143,7 @@ class EditProfileViewModel @Inject constructor(
             )
 
             // Only update if there are changes
-            if (isFormChanged(currentUser)) {
+            if (isFormChanged(currentUser, _fullName.value, _nipNim.value, _phone.value)) {
                 updateProfileUseCase(currentUser.id, request)
                     .onSuccess { updatedUser ->
                         _userProfileState.value = updatedUser
@@ -155,10 +181,15 @@ class EditProfileViewModel @Inject constructor(
     /**
      * Check if the form has changed compared to the current user data
      */
-    private fun isFormChanged(currentUser: UserModel): Boolean {
-        return _fullName.value != currentUser.fullName ||
-                _nipNim.value != currentUser.nipNim ||
-                _phone.value != currentUser.phone.orEmpty()
+    private fun isFormChanged(
+        currentUser: UserModel,
+        fullName: String,
+        nipNim: String,
+        phone: String
+    ): Boolean {
+        return fullName != currentUser.fullName ||
+                nipNim != currentUser.nipNim ||
+                phone != currentUser.phone.orEmpty()
     }
 
     /**

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt
@@ -113,13 +113,17 @@ class EditProfileViewModel @Inject constructor(
             val request = ProfileUpdateRequest(
                 fullName = _fullName.value.takeIf { it != currentUser.fullName },
                 nipNim = _nipNim.value.takeIf { it != currentUser.nipNim },
-                phone = _phone.value.takeIf { it != currentUser.phone }
+                phone = _phone.value.takeIf { it != currentUser.phone.orEmpty() }
             )
 
             // Only update if there are changes
             if (isFormChanged(currentUser)) {
                 updateProfileUseCase(currentUser.id, request)
                     .onSuccess { updatedUser ->
+                        _userProfileState.value = updatedUser
+                        _fullName.value = updatedUser.fullName
+                        _nipNim.value = updatedUser.nipNim
+                        _phone.value = updatedUser.phone ?: ""
                         _updateProfileState.value = UiState.Success(updatedUser)
                         _isEditing.value = false
                     }
@@ -154,7 +158,7 @@ class EditProfileViewModel @Inject constructor(
     private fun isFormChanged(currentUser: UserModel): Boolean {
         return _fullName.value != currentUser.fullName ||
                 _nipNim.value != currentUser.nipNim ||
-                _phone.value != currentUser.phone
+                _phone.value != currentUser.phone.orEmpty()
     }
 
     /**

--- a/app/src/main/res/values-in/string.xml
+++ b/app/src/main/res/values-in/string.xml
@@ -162,6 +162,25 @@
     <string name="account_hub_logout_description">Keluar dengan aman dari akun ini</string>
     <string name="account_hub_not_available">Tidak tersedia</string>
     <string name="account_hub_identifier">NIP/NIM %1$s</string>
+    <string name="edit_profile_title">Ubah Profil</string>
+    <string name="edit_profile_full_name">Nama Lengkap</string>
+    <string name="edit_profile_nip_nim">NIP / NIM</string>
+    <string name="edit_profile_phone_number">Nomor Telepon</string>
+    <string name="edit_profile_division">Divisi</string>
+    <string name="edit_profile_position">Posisi</string>
+    <string name="edit_profile_email">Email</string>
+    <string name="edit_profile_read_only">Hanya baca</string>
+    <string name="edit_profile_save_changes">Simpan Perubahan</string>
+    <string name="edit_profile_saving">Menyimpan...</string>
+    <string name="edit_profile_cancel">Batal</string>
+    <string name="edit_profile_success_title">Profil berhasil diperbarui.</string>
+    <string name="edit_profile_success_message">Perubahan profil Anda sudah disimpan.</string>
+    <string name="edit_profile_error_title">Tidak dapat memperbarui profil.</string>
+    <string name="edit_profile_error_message">Silakan coba lagi.</string>
+    <string name="edit_profile_no_position">Tidak ada posisi</string>
+    <string name="edit_profile_no_division">Tidak ada divisi</string>
+    <string name="edit_profile_no_phone">Nomor telepon belum tersedia</string>
+    <string name="edit_profile_photo_action_disabled">Ubah foto profil belum tersedia</string>
 
     <!--  TimeOff Screen  -->
     //TimeOff Screen

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,25 @@
     <string name="account_hub_logout_description">Securely sign out from this account</string>
     <string name="account_hub_not_available">Not available</string>
     <string name="account_hub_identifier">NIP/NIM %1$s</string>
+    <string name="edit_profile_title">Edit Profile</string>
+    <string name="edit_profile_full_name">Full Name</string>
+    <string name="edit_profile_nip_nim">NIP / NIM</string>
+    <string name="edit_profile_phone_number">Phone Number</string>
+    <string name="edit_profile_division">Division</string>
+    <string name="edit_profile_position">Position</string>
+    <string name="edit_profile_email">Email</string>
+    <string name="edit_profile_read_only">Read only</string>
+    <string name="edit_profile_save_changes">Save Changes</string>
+    <string name="edit_profile_saving">Saving...</string>
+    <string name="edit_profile_cancel">Cancel</string>
+    <string name="edit_profile_success_title">Profile updated successfully.</string>
+    <string name="edit_profile_success_message">Your profile changes have been saved.</string>
+    <string name="edit_profile_error_title">Unable to update profile.</string>
+    <string name="edit_profile_error_message">Please try again.</string>
+    <string name="edit_profile_no_position">No Position</string>
+    <string name="edit_profile_no_division">No Division</string>
+    <string name="edit_profile_no_phone">No phone number</string>
+    <string name="edit_profile_photo_action_disabled">Profile photo editing is not available yet</string>
 
 
     <!--  TimeOff Screen  -->

--- a/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -28,7 +28,7 @@ Completed from uploaded Edit Profile reference image on 2026-07-07.
 Reference mapping:
 
 - Glass top app bar -> local rounded glass top bar with back button and centered title.
-- Profile hero -> avatar/photo, disabled/no-op camera badge, full name, position, role pill.
+- Profile hero -> avatar/photo from `UserModel.photoUrl` mapped from `/api/auth/me` `photo`, disabled/no-op camera badge, full name, position, role pill.
 - Editable form card -> Full Name, NIP/NIM, Phone rows with pencil affordance.
 - Phone active state -> focus-aware purple accent border/shadow using tokens.
 - Read-only rows -> Division, Position, Email rows with lock/read-only badge.

--- a/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -1,0 +1,260 @@
+# INF-228 — Android Edit Profile Detail Screen Refresh Plan
+
+Date: 2026-07-07
+Branch: `fix/android-profile-edit-detail-refresh`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`
+Spec: `docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md`
+
+## Guardrails
+
+- Work only in the INF-228 isolated worktree and branch.
+- Do not edit the main `develop` checkout.
+- Do not touch local main-checkout network changes.
+- Scope is only `Profile > Edit Profile` detail screen.
+- Do not redesign Profile main screen.
+- Do not implement About/FAQ/MyDocument/PaySlip redesigns.
+- Do not change backend profile update contract.
+- Do not add profile photo upload/change logic.
+- Do not change auth/session behavior.
+- Do not change bottom navigation.
+- Do not introduce a global `InfiniteIcons` object.
+- Do not delete old profile field components unless usage search proves safe; prefer replacing screen usage first.
+- Use existing reusable components where practical; create screen-local wrappers only when reusable components are too limited.
+
+## Task 1 — Visual reference mapping gate
+
+Completed from uploaded Edit Profile reference image on 2026-07-07.
+
+Reference mapping:
+
+- Glass top app bar -> local rounded glass top bar with back button and centered title.
+- Profile hero -> avatar/photo, disabled/no-op camera badge, full name, position, role pill.
+- Editable form card -> Full Name, NIP/NIM, Phone rows with pencil affordance.
+- Phone active state -> focus-aware purple accent border/shadow using tokens.
+- Read-only rows -> Division, Position, Email rows with lock/read-only badge.
+- Inline feedback -> success and error banners with dismiss action.
+- Sticky bottom action bar -> Save/Saving + Cancel buttons in glass surface.
+
+Out-of-scope:
+
+- Photo upload implementation.
+- Backend update contract changes.
+- Other Profile detail screen redesigns.
+
+## Task 2 — Re-read source before editing
+
+Read immediately before implementation:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt`
+- `app/src/main/java/com/example/infinite_track/domain/model/auth/UserModel.kt`
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/request/ProfileUpdateRequest.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/components/profile_textfield/ProfileTextField.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/components/profile_textfield/ProfilePhoneNumber.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/button/InfiniteButton.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/input/InfiniteTextField.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteBottomActionBar.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/navigation/InfiniteTopBar.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt`
+- `app/src/main/res/values/strings.xml`
+- `app/src/main/res/values-in/string.xml`
+
+## Task 3 — ViewModel behavior preservation / small state additions
+
+Preserve backend update request exactly:
+
+```kotlin
+ProfileUpdateRequest(
+    fullName = ...,
+    nipNim = ...,
+    phone = ...
+)
+```
+
+Allowed ViewModel changes if needed:
+
+1. Start screen in editing mode by default, or remove dependency on `isEditing` from redesigned UI.
+2. Add public helpers/state for:
+   - `hasChanges`
+   - `canSave`
+   - `isSaving`
+3. Add/reset feedback state if screen needs dismissible inline alerts.
+4. Keep `onCancelClick()` resetting local fields. Route can call `onBackClick()` after reset.
+5. Do not add division/position/email/photo update fields.
+
+## Task 4 — Replace EditProfile UI structure
+
+In `EditProfile.kt`:
+
+1. Remove Toast-based success/error flow from redesigned UI.
+2. Remove centered loading overlay for save request.
+3. Add top-level layout:
+   - `Scaffold` with transparent/light background.
+   - Glass top app bar with back button and title.
+   - Scrollable content for hero/form/feedback.
+   - Bottom action bar for Save/Cancel.
+4. Add screen-local wrappers if needed:
+   - `EditProfileTopBar`
+   - `EditProfileHeroCard`
+   - `EditProfileFormCard`
+   - `EditProfileField`
+   - `EditProfileFeedbackBanner`
+   - `EditProfileBottomActionBar`
+5. Prefer reusable design components:
+   - `InfiniteButton`
+   - `InfiniteBottomActionBar`
+   - `InfiniteStatusPill`
+   - `InfiniteInlineAlert`
+   - `InfiniteCard` / `InfiniteSurface`
+6. Render camera/photo edit visual button disabled/no-op.
+7. Handle missing data gracefully with localized fallback copy.
+
+## Task 5 — Form fields
+
+Editable fields:
+
+- Full Name
+- NIP / NIM
+- Phone Number (`KeyboardType.Phone`)
+
+Read-only fields:
+
+- Division
+- Position
+- Email
+
+Implementation requirements:
+
+1. Editable fields show edit/pencil affordance.
+2. Read-only fields show lock icon and/or `Read only` badge.
+3. Read-only fields remain readable, not visually broken.
+4. Required editable fields (`fullName`, `nipNim`) must not save blank values.
+5. Phone field can be optional if current backend/model treats it optional, but should use phone keyboard.
+
+## Task 6 — Feedback and actions
+
+1. Success feedback:
+   - inline alert/banner
+   - copy: `Profile updated successfully.`
+2. Error feedback:
+   - inline alert/banner
+   - default copy: `Unable to update profile. Please try again.`
+   - can include API error message when available and safe.
+3. Save button:
+   - disabled when no changes or invalid input
+   - enabled when changed and valid
+   - loading state with `Saving...` while saving
+4. Cancel button:
+   - secondary/outline action
+   - resets unsaved changes through ViewModel
+   - returns back as MVP behavior
+
+## Task 7 — Strings / localization
+
+Add only needed Edit Profile strings to:
+
+- `app/src/main/res/values/strings.xml`
+- `app/src/main/res/values-in/string.xml`
+
+Likely strings:
+
+- `edit_profile_title`
+- `edit_profile_save_changes`
+- `edit_profile_saving`
+- `edit_profile_cancel`
+- `edit_profile_read_only`
+- `edit_profile_success_title/message`
+- `edit_profile_error_title/message`
+- field labels and helper text if not already present
+
+Do not paste real user email/NIP/phone into docs or logs.
+
+## Task 8 — Verification
+
+Run from INF-228 worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If feasible:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Static checks:
+
+- grep no `Toast` usage remains in redesigned `EditProfile.kt` success/error flow.
+- grep `ProfileUpdateRequest` still only includes `fullName`, `nipNim`, `phone` in ViewModel.
+- grep old `ProfileTextFieldComponent` / `PhoneNumberTextFieldComponent` usage removed from `EditProfile.kt` if replaced.
+
+### Current local verification status
+
+Build attempt:
+
+```bash
+./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
+```
+
+Result: blocked before Kotlin compile by local Gradle environment error:
+
+```text
+java.io.IOException: Unable to establish loopback connection
+```
+
+Static checks completed:
+
+- `git diff --check` returned no whitespace errors, only Windows line-ending warning for `EditProfile.kt`.
+- `EditProfile.kt` grep found no `Toast`, `CircularProgressIndicator`, old `ProfileTextFieldComponent`, old `PhoneNumberTextFieldComponent`, `InfiniteTrackButton`, `CancelButton`, `onToggleEditMode`, or `isEditing` usage.
+- `EditProfile.kt` grep found no hardcoded visible field labels/copy or hardcoded `Color(0x...)` palette.
+- `EditProfileViewModel.kt` grep confirmed `ProfileUpdateRequest` still only uses `fullName`, `nipNim`, and `phone`.
+- Resource parity check found 19 `edit_profile_*` strings in both `values/strings.xml` and `values-in/string.xml`, with no missing counterpart.
+
+Runtime smoke if available:
+
+1. Open Profile.
+2. Open Edit Profile.
+3. Screenshot default state.
+4. Focus Full Name/NIP/Phone.
+5. Verify read-only Division/Position/Email indicators.
+6. Verify Save disabled when unchanged.
+7. Change editable field and verify Save enabled.
+8. Tap Save and verify Saving state.
+9. Verify success/error inline alert.
+10. Tap Cancel and verify reset/back behavior.
+
+If runtime cannot be executed, mark screenshots/runtime as `Needs Verification`.
+
+## Expected affected files
+
+Likely:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt`
+- `app/src/main/res/values/strings.xml`
+- `app/src/main/res/values-in/string.xml`
+- this spec/plan docs
+
+Possibly:
+
+- `app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt` only if required tokens are missing.
+- `presentation/components/profile_textfield/*` only if refactoring generic reusable wrapper is safe and usage search supports it.
+
+## PR / review note draft
+
+- Work done in isolated branch/worktree: `fix/android-profile-edit-detail-refresh` / `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`.
+- Redesigns Edit Profile detail screen only.
+- Editable fields remain Full Name, NIP/NIM, and Phone.
+- Read-only fields remain Division, Position, and Email with read-only indicators.
+- Replaces Toast success/error with inline feedback.
+- Moves save loading into Save button state.
+- Cancel resets unsaved changes and returns back.
+- No backend contract changes.
+- No auth/session changes.
+- No Profile main screen redesign.
+- No About/MyDocument/PaySlip/FAQ redesign.
+- No profile photo upload implemented.
+- Build evidence and Needs Verification items included.

--- a/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/plans/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -2,7 +2,6 @@
 
 Date: 2026-07-07
 Branch: `fix/android-profile-edit-detail-refresh`
-Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`
 Spec: `docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md`
 
 ## Guardrails
@@ -245,7 +244,7 @@ Possibly:
 
 ## PR / review note draft
 
-- Work done in isolated branch/worktree: `fix/android-profile-edit-detail-refresh` / `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`.
+- Work done in isolated branch/worktree: `fix/android-profile-edit-detail-refresh`.
 - Redesigns Edit Profile detail screen only.
 - Editable fields remain Full Name, NIP/NIM, and Phone.
 - Read-only fields remain Division, Position, and Email with read-only indicators.

--- a/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -1,9 +1,6 @@
 # INF-228 — Android Edit Profile Detail Screen Refresh Spec
 
 Date: 2026-07-07
-Branch: `fix/android-profile-edit-detail-refresh`
-Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`
-Base: `develop` at `dec6435`
 
 ## Goal
 
@@ -11,25 +8,9 @@ Redesign only the Android `Profile > Edit Profile` detail screen with reusable M
 
 Android remains a trusted data-capture client. Backend remains authoritative for profile update behavior. INF-228 must not change backend contracts, auth/session behavior, Profile main screen scope, About screen scope, bottom navigation, or route graph semantics.
 
-## Worktree and branch mapping
+## Scope boundary
 
-Main checkout:
-
-- Path: `E:\skrisi\android`
-- Branch: `develop`
-- Head during mapping: `dec6435`
-- Dirty local files in main checkout are unrelated network/environment changes and must not be edited for INF-228:
-  - `app/src/main/java/com/example/infinite_track/di/NetworkModule.kt`
-  - `app/src/main/res/xml/network_security_config.xml`
-  - untracked `docs/superpowers/plans/2026-06-21-inf-164-inf-161-inf-162-layer3-truthful-consumption.md`
-
-Existing Profile worktrees found:
-
-- `android-account-hub-main-refresh` / `fix/android-account-hub-main-refresh`: stale INF-226 branch already merged.
-- `android-profile-detail-back-navigation` / `fix/profile-detail-back-navigation`: stale navigation fix branch already merged.
-- `android-about-infinite-track-screen` / `fix/android-about-infinite-track-screen`: relevant Profile/INF-227 workspace, but dirty with uncommitted About changes; unsafe to mix with INF-228.
-
-Decision: create fresh isolated INF-228 worktree from `develop`.
+INF-228 is intentionally limited to the Edit Profile detail screen. Existing Profile main screen work from INF-226, Profile navigation fixes, and About screen work are separate scopes and must not be mixed into this spec.
 
 ## Current repo facts verified
 

--- a/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -1,0 +1,181 @@
+# INF-228 — Android Edit Profile Detail Screen Refresh Spec
+
+Date: 2026-07-07
+Branch: `fix/android-profile-edit-detail-refresh`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-profile-edit-detail-refresh`
+Base: `develop` at `dec6435`
+
+## Goal
+
+Redesign only the Android `Profile > Edit Profile` detail screen with reusable Material 3 friendly components, premium semi-liquid visual direction, inline feedback, and a sticky bottom action bar while preserving existing profile update business logic.
+
+Android remains a trusted data-capture client. Backend remains authoritative for profile update behavior. INF-228 must not change backend contracts, auth/session behavior, Profile main screen scope, About screen scope, bottom navigation, or route graph semantics.
+
+## Worktree and branch mapping
+
+Main checkout:
+
+- Path: `E:\skrisi\android`
+- Branch: `develop`
+- Head during mapping: `dec6435`
+- Dirty local files in main checkout are unrelated network/environment changes and must not be edited for INF-228:
+  - `app/src/main/java/com/example/infinite_track/di/NetworkModule.kt`
+  - `app/src/main/res/xml/network_security_config.xml`
+  - untracked `docs/superpowers/plans/2026-06-21-inf-164-inf-161-inf-162-layer3-truthful-consumption.md`
+
+Existing Profile worktrees found:
+
+- `android-account-hub-main-refresh` / `fix/android-account-hub-main-refresh`: stale INF-226 branch already merged.
+- `android-profile-detail-back-navigation` / `fix/profile-detail-back-navigation`: stale navigation fix branch already merged.
+- `android-about-infinite-track-screen` / `fix/android-about-infinite-track-screen`: relevant Profile/INF-227 workspace, but dirty with uncommitted About changes; unsafe to mix with INF-228.
+
+Decision: create fresh isolated INF-228 worktree from `develop`.
+
+## Current repo facts verified
+
+### Edit Profile screen
+
+File: `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt`
+
+Current screen:
+
+- Collects `userProfile`, `fullName`, `phone`, `nipNim`, `isEditing`, and `updateProfileState` from `EditProfileViewModel`.
+- Uses `Toast` for success and error.
+- Calls `onBackClick()` immediately after success.
+- Shows centered `CircularProgressIndicator` overlay while saving.
+- Uses `ProfileCard`, `ProfileTextFieldComponent`, `PhoneNumberTextFieldComponent`, `InfiniteTrackButton`, and `CancelButton`.
+- Has internal edit/view toggle via `isEditing`, but INF-228 should treat Edit Profile as editing mode by default.
+
+### EditProfileViewModel
+
+File: `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfileViewModel.kt`
+
+Current ViewModel:
+
+- Loads current user from `GetLoggedInUserUseCase`.
+- Editable field state:
+  - `fullName`
+  - `nipNim`
+  - `phone`
+- Read-only field source from `UserModel`:
+  - `divisionName`
+  - `positionName`
+  - `email`
+  - also `roleName`, `photoUrl` available for hero.
+- Update request uses only:
+  - `ProfileUpdateRequest(fullName = ..., nipNim = ..., phone = ...)`
+- Does not update division, position, email, role, or photo.
+
+### Current field components
+
+Files:
+
+- `presentation/components/profile_textfield/ProfileTextField.kt`
+- `presentation/components/profile_textfield/ProfilePhoneNumber.kt`
+
+Current limitations:
+
+- Hardcoded radius/color/elevation.
+- Duplicate phone/text field implementation.
+- No explicit read-only badge/lock indicator.
+- No support/error text.
+- No focus/active state beyond default TextField behavior.
+
+### Reusable component availability
+
+INF-222 components are present:
+
+- `InfiniteCard` / `InfiniteSurface`
+- `InfiniteButton`
+- `InfiniteIconButton`
+- `InfiniteTextField`
+- `InfiniteStatusPill`
+- `InfiniteBottomActionBar`
+- `InfiniteTopBar`
+
+INF-219/status components are present:
+
+- `InfiniteTrackInlineAlert`
+- `InfiniteInlineAlert`
+- `InfiniteTrackStatusDialog`
+- `InfiniteTrackConfirmDialog`
+
+## Visual reference mapping
+
+User uploaded the Edit Profile detail reference image on 2026-07-07. The image shows a light semi-liquid glass profile edit screen with a large rounded top bar, profile hero, grouped form card, inline success/error banners, and a sticky bottom action bar.
+
+| Reference visual element | Android implementation plan |
+| --- | --- |
+| Glass top app bar with large rounded surface | Screen-local `EditProfileTopBar` with back button and centered title |
+| Back button in soft circular glass | Rounded Material surface with existing back icon behavior via `onBackClick` |
+| Profile hero card | `EditProfileHeroCard` using soft surface, avatar/photo, name, position, role pill |
+| Camera/edit photo button on avatar | Render visual camera button as disabled/no-op; no photo upload implementation |
+| Editable form card | `EditProfileFormCard` with local `EditProfileField` wrappers |
+| Editable fields with pencil icon | Full Name, NIP/NIM, and Phone use editable field rows with `ic_pencil` |
+| Phone focused purple glow | Focus-aware field border/elevation using tokenized purple accent; phone keyboard uses `KeyboardType.Phone` |
+| Read-only fields | Division, Position, Email render readable text plus lock/read-only badge |
+| Inline success banner | Local feedback banner / `InfiniteInlineAlert` style with success semantic |
+| Inline error banner | Local feedback banner / `InfiniteInlineAlert` style with error semantic |
+| Sticky bottom action bar | Bottom glass surface with Save/Saving and Cancel buttons |
+| Purple/cyan liquid accents | Use existing `InfiniteColors` AccountHub/theme tokens and no screen-local hardcoded color palette |
+
+Out-of-scope from the reference:
+
+- Profile photo upload/change logic.
+- Backend profile contract changes.
+- Profile main screen redesign.
+- About/FAQ/MyDocument/PaySlip redesign.
+- Auth/session changes.
+- Bottom navigation changes.
+- New global icon token object.
+
+## Behavior requirements
+
+- Screen starts in editing mode by default.
+- Save disabled when no changes or required editable field is blank.
+- Save enabled when editable fields are valid and changed.
+- Save shows loading state while `updateProfileState is UiState.Loading`.
+- Success shows inline success banner, not Toast.
+- Error shows inline error banner, not Toast.
+- Cancel resets unsaved changes through ViewModel and returns back.
+- Existing update logic remains limited to `fullName`, `nipNim`, `phone`.
+
+## Risks
+
+- Changing success behavior from immediate back+Toast to inline success can alter user flow. This is requested by INF-228 but must be called out in PR notes.
+- ViewModel currently toggles `isEditing`; setting edit mode by default may require small ViewModel adjustment or route-level mapper.
+- Build/runtime verification is required because this is UI/form behavior.
+- Runtime screenshots must redact sensitive email/NIP/phone if shared.
+
+## Verification plan
+
+Run from INF-228 worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If feasible:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime smoke if emulator/device available:
+
+1. Open Profile.
+2. Open Edit Profile.
+3. Verify glass top app bar, hero, form card, read-only indicators, and bottom action bar.
+4. Verify Save disabled initially.
+5. Focus Full Name/NIP/Phone fields.
+6. Edit one field and verify Save enabled.
+7. Tap Save and verify Saving state.
+8. Verify inline success or error feedback.
+9. Tap Cancel and verify reset/back behavior.
+
+If runtime cannot be executed, mark screenshot/runtime evidence as `Needs Verification`.
+
+## Docs / ADR note
+
+No ADR expected if implementation remains a visual/detail-screen refresh with no backend/auth/session/navigation contract change.

--- a/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
+++ b/docs/superpowers/specs/2026-07-07-inf-228-edit-profile-detail-refresh.md
@@ -108,7 +108,7 @@ User uploaded the Edit Profile detail reference image on 2026-07-07. The image s
 | --- | --- |
 | Glass top app bar with large rounded surface | Screen-local `EditProfileTopBar` with back button and centered title |
 | Back button in soft circular glass | Rounded Material surface with existing back icon behavior via `onBackClick` |
-| Profile hero card | `EditProfileHeroCard` using soft surface, avatar/photo, name, position, role pill |
+| Profile hero card | `EditProfileHeroCard` using soft surface, avatar/photo from `UserModel.photoUrl` mapped from `/api/auth/me` `photo`, name, position, role pill |
 | Camera/edit photo button on avatar | Render visual camera button as disabled/no-op; no photo upload implementation |
 | Editable form card | `EditProfileFormCard` with local `EditProfileField` wrappers |
 | Editable fields with pencil icon | Full Name, NIP/NIM, and Phone use editable field rows with `ic_pencil` |


### PR DESCRIPTION
## Summary

Implements INF-228 by redesigning the Android `Profile > Edit Profile` detail screen following the uploaded visual reference.

Changes include:

- Glass top app bar with back button and centered title.
- Profile hero card with avatar/photo, camera affordance, name, position, and role pill.
- Editable form card with:
  - Full Name editable field + pencil affordance
  - NIP / NIM editable field + pencil affordance
  - Phone Number editable field + pencil affordance + phone keyboard
  - Division read-only field + lock/read-only badge
  - Position read-only field + lock/read-only badge
  - Email read-only field + lock/read-only badge
- Inline success/error feedback replacing Toast in the redesigned flow.
- Sticky bottom action bar with Save Changes / Saving... and Cancel.
- Local Edit Profile wrappers that use existing Material 3/design primitives and can be migrated later.
- INF-228 spec/plan docs with worktree mapping, visual mapping, guardrails, and verification notes.

## Behavior / contract

- Existing backend update contract is preserved.
- `ProfileUpdateRequest` still only submits changed editable fields:
  - `fullName`
  - `nipNim`
  - `phone`
- Division, position, email, role, and photo are not submitted.
- No profile photo upload is implemented; camera button is visual/no-op only.
- Cancel resets unsaved changes and returns back.
- Success is now shown inline instead of immediate Toast + auto-back, per INF-228 requirement.

## Guardrails

- No backend contract changes.
- No auth/session changes.
- No Profile main screen redesign.
- No About/FAQ/MyDocument/PaySlip redesign.
- No bottom navigation changes.
- No route graph changes.
- No global icon token object introduced.

## Static verification

Completed locally:

- `git diff --check` passed with only Windows line-ending warnings.
- `EditProfile.kt` grep found no `Toast`, `CircularProgressIndicator`, old `ProfileTextFieldComponent`, old `PhoneNumberTextFieldComponent`, old `InfiniteTrackButton`, old `CancelButton`, `onToggleEditMode`, or `isEditing` usage.
- `EditProfile.kt` grep found no hardcoded visible field labels/copy and no `Color(0x...)` local palette.
- `EditProfileViewModel.kt` grep confirmed `ProfileUpdateRequest` still only uses `fullName`, `nipNim`, and `phone`.
- Resource parity check found 19 `edit_profile_*` strings in both `values/strings.xml` and `values-in/string.xml`, with no missing counterpart.

## Build verification

Attempted locally:

```bash
./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
```

Local Gradle is still blocked before Kotlin compile by the known environment-level bootstrap error:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

- `./gradlew app:assembleDebug` in CI/Android Studio or another environment without the local loopback issue.
- Optional quality checks when environment allows:
  - `./gradlew app:test`
  - `./gradlew app:lint`
- Runtime/emulator smoke:
  - Open Profile.
  - Open Edit Profile.
  - Verify default form state and visual match to uploaded reference.
  - Focus Full Name / NIP / Phone field.
  - Verify read-only Division / Position / Email indicators.
  - Verify Save disabled when unchanged.
  - Change editable field and verify Save enabled.
  - Tap Save and verify Saving... state.
  - Verify inline success/error feedback.
  - Tap Cancel and verify reset/back behavior.
- Screenshot evidence should redact sensitive email/NIP/phone if shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the Edit Profile screen with a cleaner layout, improved form sections, and a sticky action bar.
  * Added inline success and error messages for profile updates.
  * Added localized labels and messages for editable and read-only profile details.

* **Bug Fixes**
  * Improved change detection and save behavior, including better handling when phone numbers are empty.
  * Updated the screen to show saving/loading states and disable saving until required fields change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->