### PR TITLE
INF-227: Implement About Infinite Track detail screen

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/soucre/local/about/AboutDummyContentProvider.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/local/about/AboutDummyContentProvider.kt
@@ -1,0 +1,95 @@
+package com.example.infinite_track.data.soucre.local.about
+
+import com.example.infinite_track.domain.model.about.AboutAchievement
+import com.example.infinite_track.domain.model.about.AboutContent
+import com.example.infinite_track.domain.model.about.AboutCreator
+import com.example.infinite_track.domain.model.about.AboutFeatureChip
+import com.example.infinite_track.domain.model.about.AboutHero
+import com.example.infinite_track.domain.model.about.AboutImpactItem
+import com.example.infinite_track.domain.model.about.AboutImpactSemantic
+import com.example.infinite_track.domain.model.about.AboutOverview
+import com.example.infinite_track.domain.model.about.AboutTimelineItem
+import com.example.infinite_track.domain.model.about.VerificationStatus
+import javax.inject.Inject
+
+class AboutDummyContentProvider @Inject constructor() {
+
+    fun getContent(): AboutContent = AboutContent(
+        hero = AboutHero(
+            appName = "Infinite Track",
+            tagline = "Smart Attendance & Workforce Presence System",
+            description = "Infinite Track is an internal attendance and workforce presence system designed to support employee check-in, check-out, location validation, WFA booking, attendance history, and personal work activity tracking.",
+            badgeLabel = "Internship Project · 2025"
+        ),
+        overview = AboutOverview(
+            title = "Project Overview",
+            description = "Infinite Track was developed as a digital attendance solution for internal company operations. The project combines mobile attendance, location-based validation, face verification, WFA support, attendance reporting, and decision-support concepts using Fuzzy AHP while keeping backend services as the authoritative source of final attendance truth.",
+            featureChips = listOf(
+                AboutFeatureChip("Attendance Tracking"),
+                AboutFeatureChip("Location Validation"),
+                AboutFeatureChip("Fuzzy AHP Support")
+            )
+        ),
+        timeline = listOf(
+            AboutTimelineItem(
+                period = "January 2025",
+                title = "Project Discovery",
+                description = "Requirement gathering, company workflow observation, and attendance problem analysis."
+            ),
+            AboutTimelineItem(
+                period = "February 2025",
+                title = "System Design",
+                description = "Database design, mobile flow planning, dashboard concept, and Fuzzy AHP method mapping."
+            ),
+            AboutTimelineItem(
+                period = "March 2025",
+                title = "Core Development",
+                description = "Attendance module, face verification, location validation, WFA booking, and backend API integration."
+            ),
+            AboutTimelineItem(
+                period = "April 2025",
+                title = "Testing & Refinement",
+                description = "UI refinement, feature testing, report preparation, and partner feedback improvements."
+            )
+        ),
+        creator = AboutCreator(
+            name = "Febri",
+            role = "Mobile & Fullstack Developer Intern",
+            university = "Universitas Tadulako",
+            program = "Informatics Engineering",
+            contribution = "Designed and developed the Infinite Track ecosystem, including Android attendance flow, backend integration, dashboard concept, and Fuzzy AHP-based attendance decision-support analysis.",
+            skillTags = listOf(
+                "Android",
+                "Backend API",
+                "UI/UX Design",
+                "Fuzzy AHP",
+                "Attendance System"
+            )
+        ),
+        achievement = AboutAchievement(
+            title = "Achievement & Appreciation",
+            subtitle = "Best Internship Project Preview",
+            description = "This preview card is prepared to highlight partner appreciation once supporting evidence is available. It must not be treated as a final official award claim yet.",
+            note = "Preview only — recognition, award wording, and partner appreciation details still need verification evidence before being presented as official achievements.",
+            verificationStatus = VerificationStatus.PreviewOnly
+        ),
+        impacts = listOf(
+            AboutImpactItem(
+                title = "Digital Attendance",
+                description = "Supports structured employee presence recording.",
+                semantic = AboutImpactSemantic.Attendance
+            ),
+            AboutImpactItem(
+                title = "Operational Visibility",
+                description = "Helps users and admins understand attendance activities.",
+                semantic = AboutImpactSemantic.Visibility
+            ),
+            AboutImpactItem(
+                title = "Decision Support",
+                description = "Introduces Fuzzy AHP as a method-based analysis layer.",
+                semantic = AboutImpactSemantic.DecisionSupport
+            )
+        ),
+        footerNote = "Built with purpose for internship, research, and real company workflow improvement."
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/domain/model/about/AboutContent.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/about/AboutContent.kt
@@ -1,0 +1,69 @@
+package com.example.infinite_track.domain.model.about
+
+data class AboutContent(
+    val hero: AboutHero,
+    val overview: AboutOverview,
+    val timeline: List<AboutTimelineItem>,
+    val creator: AboutCreator,
+    val achievement: AboutAchievement,
+    val impacts: List<AboutImpactItem>,
+    val footerNote: String
+)
+
+data class AboutHero(
+    val appName: String,
+    val tagline: String,
+    val description: String,
+    val badgeLabel: String
+)
+
+data class AboutOverview(
+    val title: String,
+    val description: String,
+    val featureChips: List<AboutFeatureChip>
+)
+
+data class AboutFeatureChip(
+    val label: String
+)
+
+data class AboutTimelineItem(
+    val period: String,
+    val title: String,
+    val description: String
+)
+
+data class AboutCreator(
+    val name: String,
+    val role: String,
+    val university: String,
+    val program: String,
+    val contribution: String,
+    val skillTags: List<String>
+)
+
+data class AboutAchievement(
+    val title: String,
+    val subtitle: String,
+    val description: String,
+    val note: String,
+    val verificationStatus: VerificationStatus
+)
+
+data class AboutImpactItem(
+    val title: String,
+    val description: String,
+    val semantic: AboutImpactSemantic
+)
+
+enum class VerificationStatus {
+    PreviewOnly,
+    NeedsVerification,
+    Verified
+}
+
+enum class AboutImpactSemantic {
+    Attendance,
+    Visibility,
+    DecisionSupport
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/about/GetAboutContentUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/about/GetAboutContentUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.infinite_track.domain.use_case.about
+
+import com.example.infinite_track.data.soucre.local.about.AboutDummyContentProvider
+import com.example.infinite_track.domain.model.about.AboutContent
+import javax.inject.Inject
+
+class GetAboutContentUseCase @Inject constructor(
+    private val aboutDummyContentProvider: AboutDummyContentProvider
+) {
+    operator fun invoke(): AboutContent = aboutDummyContentProvider.getContent()
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteColors.kt
@@ -36,6 +36,7 @@ object InfiniteColors {
     val Text = Purple_500
     val Background = Violet_100
     val Surface = White
+    val Transparent = Color.Transparent
     val SoftAlert = Color(0xFFFF6B6B)
     val Success = Green_Success
     val Info = Color(0xFF214CE0)
@@ -95,6 +96,27 @@ object InfiniteColors {
     val AccountHubDestructiveContainer = Red_Error.copy(alpha = 0.12f)
     val AccountHubDestructiveArrow = Red_Error.copy(alpha = 0.82f)
     val AccountHubDividerColor = Violet_200.copy(alpha = 0.62f)
+
+    val AboutPurple = Color(0xFF7B4DF3)
+    val AboutPurpleSoft = Color(0xFF8D5CFF)
+    val AboutCyan = Color(0xFF22C7D2)
+    val AboutCyanSoft = Color(0xFF8FEAF0)
+    val AboutLavender = Color(0xFFB9A7FF)
+    val AboutCreatorAvatar = Color(0xFF9D8BDC)
+    val AboutGold = Color(0xFFFFB300)
+    val AboutGoldStrong = Color(0xFFC08A00)
+    val AboutGoldMuted = Color(0xFF9D7000)
+    val AboutGoldSurface = Color(0xFFFFF7D7)
+    val AboutGoldBorder = Color(0xFFFFCF5A)
+    val AboutGoldGlow = Color(0xFFFFD24A)
+    val AboutGoldSoft = Color(0xFFFFE9A7)
+    val AboutGoldLight = Color(0xFFFFE39A)
+    val AboutGoldPale = Color(0xFFFFF9E7)
+    val AboutGlassSurface = White.copy(alpha = 0.58f)
+    val AboutGlassSurfaceStrong = White.copy(alpha = 0.82f)
+    val AboutGlassSurfaceMuted = White.copy(alpha = 0.46f)
+    val AboutGlassBorder = White.copy(alpha = 0.88f)
+    val AboutGlassBorderStrong = White.copy(alpha = 0.92f)
 
     val GlassGradient: Brush
         get() = Brush.verticalGradient(

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -26,6 +26,7 @@ import com.example.infinite_track.presentation.screen.home.details.DetailsMyBook
 import com.example.infinite_track.presentation.screen.leave_request.my_leave.MyLeave
 import com.example.infinite_track.presentation.screen.leave_request.timeOff.TimeOffScreen
 import com.example.infinite_track.presentation.screen.profile.ProfileScreen
+import com.example.infinite_track.presentation.screen.profile.details.about.AboutScreen
 import com.example.infinite_track.presentation.screen.profile.details.contactUs.ContactUsScreen
 import com.example.infinite_track.presentation.screen.profile.details.edit_profile.EditProfile
 import com.example.infinite_track.presentation.screen.profile.details.my_document.MyDocumentScreen
@@ -107,6 +108,7 @@ fun NavGraphBuilder.mainContentNavGraph(
                 navigateToContacts = { navController.navigate(Screen.Contact.route) },
                 navigateToMyDocument = { navController.navigateToProfileDetail(Screen.MyDocument.route) },
                 navigateToPaySlip = { navController.navigateToProfileDetail(Screen.PaySlip.route) },
+                navigateToAbout = { navController.navigateToProfileDetail(Screen.About.route) },
                 navHostController = navController,
                 rootNavController = rootNavController
             )
@@ -132,6 +134,12 @@ fun NavGraphBuilder.mainContentNavGraph(
 
         composable(Screen.MyDocument.route) {
             MyDocumentScreen(
+                onBackClick = { navController.navigateBackToProfile() }
+            )
+        }
+
+        composable(Screen.About.route) {
+            AboutScreen(
                 onBackClick = { navController.navigateBackToProfile() }
             )
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
@@ -32,6 +32,7 @@ sealed class Screen(val route: String) {
     data object DetailsMyBooking : Screen("home/detailsBooking")
     data object PaySlip : Screen("profile/PaySlip")
     data object MyDocument : Screen("profile/MyDocument")
+    data object About : Screen("profile/about")
 
     // WFA Booking
     data object WfaBooking : Screen("wfa_booking/{latitude}/{longitude}") {

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -81,6 +81,7 @@ fun ProfileScreen(
 //    navigateToFAQ: () -> Unit,
     navigateToMyDocument: () -> Unit,
     navigateToPaySlip: () -> Unit,
+    navigateToAbout: () -> Unit,
     navHostController: NavHostController,
     rootNavController: NavHostController,
     profileViewModel: ProfileViewModel = hiltViewModel()
@@ -248,6 +249,7 @@ fun ProfileScreen(
                         onPaySlip = navigateToPaySlip,
                         onContactSupport = navigateToContactUs,
                         onEmployees = navigateToContacts,
+                        onAbout = navigateToAbout,
                         onLogout = { showLogoutConfirmDialog = true }
                     )
                 }
@@ -269,6 +271,7 @@ private fun AccountHubContent(
     onPaySlip: () -> Unit,
     onContactSupport: () -> Unit,
     onEmployees: () -> Unit,
+    onAbout: () -> Unit,
     onLogout: () -> Unit
 ) {
     val unavailable = stringResource(R.string.account_hub_not_available)
@@ -377,7 +380,7 @@ private fun AccountHubContent(
                 title = stringResource(R.string.account_hub_about_title),
                 description = stringResource(R.string.account_hub_about_description),
                 icon = R.drawable.ic_community,
-                onClick = {}
+                onClick = onAbout
             )
         }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
@@ -1,0 +1,108 @@
+package com.example.infinite_track.presentation.screen.profile.details.about
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutAchievementCard
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutCreatorCard
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutFooter
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutHeroCard
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutImpactSection
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutOverviewCard
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutTimelineSection
+import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutTopBar
+
+@Composable
+fun AboutScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AboutViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(InfiniteColors.AccountHubBackgroundGradient)
+    ) {
+        LiquidBackgroundDecor()
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = InfiniteColors.Transparent,
+            topBar = { AboutTopBar(onBackClick = onBackClick) }
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
+                uiState.content?.let { content ->
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 30.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        item { AboutHeroCard(hero = content.hero) }
+                        item { AboutOverviewCard(overview = content.overview) }
+                        item { AboutTimelineSection(timeline = content.timeline) }
+                        item { AboutCreatorCard(creator = content.creator) }
+                        item { AboutAchievementCard(achievement = content.achievement) }
+                        item { AboutImpactSection(impacts = content.impacts) }
+                        item { AboutFooter(note = content.footerNote) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiquidBackgroundDecor() {
+    Box(
+        modifier = Modifier
+            .offset(x = 280.dp, y = (-22).dp)
+            .size(150.dp)
+            .clip(CircleShape)
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(
+                        InfiniteColors.Surface.copy(alpha = 0.82f),
+                        InfiniteColors.AboutLavender.copy(alpha = 0.28f),
+                        InfiniteColors.Transparent
+                    )
+                )
+            )
+    )
+    Box(
+        modifier = Modifier
+            .offset(x = (-42).dp, y = 640.dp)
+            .size(150.dp)
+            .clip(CircleShape)
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(
+                        InfiniteColors.Surface.copy(alpha = 0.72f),
+                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.22f),
+                        InfiniteColors.Transparent
+                    )
+                )
+            )
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutUiState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutUiState.kt
@@ -1,0 +1,7 @@
+package com.example.infinite_track.presentation.screen.profile.details.about
+
+import com.example.infinite_track.domain.model.about.AboutContent
+
+data class AboutUiState(
+    val content: AboutContent? = null
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutViewModel.kt
@@ -1,0 +1,20 @@
+package com.example.infinite_track.presentation.screen.profile.details.about
+
+import androidx.lifecycle.ViewModel
+import com.example.infinite_track.domain.use_case.about.GetAboutContentUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class AboutViewModel @Inject constructor(
+    getAboutContentUseCase: GetAboutContentUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        AboutUiState(content = getAboutContentUseCase())
+    )
+    val uiState: StateFlow<AboutUiState> = _uiState.asStateFlow()
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutAchievementCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutAchievementCard.kt
@@ -1,0 +1,182 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.EmojiEvents
+import androidx.compose.material.icons.rounded.Shield
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutAchievement
+import com.example.infinite_track.domain.model.about.VerificationStatus
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+@Composable
+fun AboutAchievementCard(
+    achievement: AboutAchievement,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        color = InfiniteColors.AboutGoldSurface.copy(alpha = 0.62f),
+        border = BorderStroke(1.dp, InfiniteColors.AboutGoldBorder.copy(alpha = 0.62f)),
+        shadowElevation = 10.dp
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            InfiniteColors.AboutGoldPale.copy(alpha = 0.82f),
+                            InfiniteColors.AboutGoldSoft.copy(alpha = 0.42f),
+                            InfiniteColors.Surface.copy(alpha = 0.30f)
+                        )
+                    )
+                )
+                .padding(22.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Star,
+                contentDescription = null,
+                tint = InfiniteColors.AboutGoldGlow.copy(alpha = 0.72f),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(34.dp)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TrophyBadge()
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text(
+                        text = achievement.title,
+                        style = headline4,
+                        color = InfiniteColors.AboutGoldStrong,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = achievement.subtitle,
+                        style = headline3,
+                        color = InfiniteColors.AboutGoldStrong,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = achievement.description,
+                        style = headline4,
+                        color = InfiniteColors.AccountHubBodyText
+                    )
+                    Surface(
+                        shape = RoundedCornerShape(18.dp),
+                        color = InfiniteColors.Surface.copy(alpha = 0.48f),
+                        border = BorderStroke(1.dp, InfiniteColors.AboutGoldBorder.copy(alpha = 0.32f))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Shield,
+                                contentDescription = null,
+                                tint = InfiniteColors.AboutGoldStrong,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Text(
+                                text = achievement.note,
+                                style = headline4,
+                                color = InfiniteColors.AboutGoldMuted,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
+                    InfiniteStatusPill(
+                        label = achievement.verificationStatus.label,
+                        variant = achievement.verificationStatus.statusVariant,
+                        size = InfiniteSize.Small
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrophyBadge() {
+    Box(
+        modifier = Modifier
+            .size(112.dp)
+            .clip(CircleShape)
+            .background(
+                Brush.sweepGradient(
+                    colors = listOf(
+                        InfiniteColors.AboutGoldGlow.copy(alpha = 0.92f),
+                        InfiniteColors.Surface.copy(alpha = 0.92f),
+                        InfiniteColors.AboutGoldLight.copy(alpha = 0.68f),
+                        InfiniteColors.AboutGoldGlow.copy(alpha = 0.92f)
+                    )
+                )
+            )
+            .padding(10.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier.size(88.dp),
+            shape = CircleShape,
+            color = InfiniteColors.Surface.copy(alpha = 0.70f),
+            border = BorderStroke(1.dp, InfiniteColors.AboutGoldBorder.copy(alpha = 0.50f)),
+            shadowElevation = 8.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Rounded.EmojiEvents,
+                    contentDescription = null,
+                    tint = InfiniteColors.AboutGold,
+                    modifier = Modifier.size(58.dp)
+                )
+            }
+        }
+    }
+}
+
+private val VerificationStatus.label: String
+    get() = when (this) {
+        VerificationStatus.PreviewOnly -> "Preview only"
+        VerificationStatus.NeedsVerification -> "Needs verification"
+        VerificationStatus.Verified -> "Verified"
+    }
+
+private val VerificationStatus.statusVariant: InfiniteStatusVariant
+    get() = when (this) {
+        VerificationStatus.PreviewOnly -> InfiniteStatusVariant.Pending
+        VerificationStatus.NeedsVerification -> InfiniteStatusVariant.NeedsReview
+        VerificationStatus.Verified -> InfiniteStatusVariant.Approved
+    }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutCreatorCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutCreatorCard.kt
@@ -1,0 +1,201 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Code
+import androidx.compose.material.icons.rounded.DesignServices
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.School
+import androidx.compose.material.icons.rounded.Storage
+import androidx.compose.material.icons.rounded.Workspaces
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutCreator
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun AboutCreatorCard(
+    creator: AboutCreator,
+    modifier: Modifier = Modifier
+) {
+    GlassSectionCard(modifier = modifier) {
+        InfiniteSectionHeader(
+            title = "Created By",
+            subtitle = "Creator and contribution",
+            leadingIcon = Icons.Rounded.Person
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CreatorAvatar()
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = creator.name,
+                    style = headline3,
+                    color = InfiniteColors.AccountHubTitle,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = creator.role,
+                    style = headline4,
+                    color = InfiniteColors.AboutPurple,
+                    fontWeight = FontWeight.Bold
+                )
+                CreatorInfo(icon = Icons.Rounded.School, text = creator.university)
+                CreatorInfo(icon = Icons.Rounded.Workspaces, text = creator.program)
+            }
+        }
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(22.dp),
+            color = InfiniteColors.Surface.copy(alpha = 0.46f),
+            border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.78f))
+        ) {
+            Text(
+                modifier = Modifier.padding(18.dp),
+                text = creator.contribution,
+                style = headline4,
+                color = InfiniteColors.AccountHubBodyText
+            )
+        }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            creator.skillTags.forEachIndexed { index, tag ->
+                SkillChip(
+                    text = tag,
+                    icon = when (index % 3) {
+                        0 -> Icons.Rounded.Code
+                        1 -> Icons.Rounded.Storage
+                        else -> Icons.Rounded.DesignServices
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreatorAvatar() {
+    Box(
+        modifier = Modifier
+            .size(112.dp)
+            .background(
+                Brush.sweepGradient(
+                    colors = listOf(
+                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.42f),
+                        InfiniteColors.Surface.copy(alpha = 0.84f),
+                        InfiniteColors.AboutCyan.copy(alpha = 0.28f),
+                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.42f)
+                    )
+                ),
+                CircleShape
+            )
+            .padding(8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier.size(92.dp),
+            shape = CircleShape,
+            color = InfiniteColors.Surface.copy(alpha = 0.78f),
+            border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.92f)),
+            shadowElevation = 8.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Rounded.Person,
+                    contentDescription = null,
+                    tint = InfiniteColors.AboutCreatorAvatar,
+                    modifier = Modifier.size(58.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreatorInfo(
+    icon: ImageVector,
+    text: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = InfiniteColors.AccountHubMutedText,
+            modifier = Modifier.size(18.dp)
+        )
+        Text(
+            text = text,
+            style = headline4,
+            color = InfiniteColors.AccountHubBodyText,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+private fun SkillChip(
+    text: String,
+    icon: ImageVector
+) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.58f),
+        border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.86f)),
+        shadowElevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (text.contains("Fuzzy")) InfiniteColors.AboutCyan else InfiniteColors.AboutPurple,
+                modifier = Modifier.size(20.dp)
+            )
+            Text(
+                text = text,
+                style = headline4,
+                color = InfiniteColors.AccountHubTitle,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutFooter.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutFooter.kt
@@ -1,0 +1,29 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun AboutFooter(
+    note: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = note,
+            style = headline4,
+            color = InfiniteColors.AccountHubMutedText,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutGlassComponents.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutGlassComponents.kt
@@ -1,0 +1,33 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+@Composable
+fun GlassSectionCard(
+    modifier: Modifier = Modifier,
+    semantic: InfiniteSemantic = InfiniteSemantic.Neutral,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    InfiniteCard(
+        modifier = modifier.fillMaxWidth(),
+        variant = InfiniteSurfaceVariant.Glass,
+        semantic = semantic,
+        size = InfiniteSize.Large
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutHeroCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutHeroCard.kt
@@ -1,0 +1,152 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.Key
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutHero
+import com.example.infinite_track.presentation.core.headline2
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+@Composable
+fun AboutHeroCard(
+    hero: AboutHero,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(30.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.60f),
+        border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.88f)),
+        shadowElevation = 10.dp
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(InfiniteColors.GlassGradient)
+                .padding(24.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .size(148.dp)
+                    .clip(RoundedCornerShape(topStart = 90.dp, topEnd = 40.dp, bottomStart = 48.dp, bottomEnd = 30.dp))
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                InfiniteColors.AboutCyanSoft.copy(alpha = 0.56f),
+                                InfiniteColors.AboutCyanSoft.copy(alpha = 0.20f),
+                                InfiniteColors.Surface.copy(alpha = 0.06f)
+                            )
+                        )
+                    )
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(22.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                HeroIconBadge()
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text(
+                        text = hero.appName,
+                        style = headline2,
+                        color = InfiniteColors.AccountHubTitle,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = hero.tagline,
+                        style = headline4,
+                        color = InfiniteColors.AboutPurple,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = hero.description,
+                        style = headline4,
+                        color = InfiniteColors.AccountHubBodyText
+                    )
+                    InfiniteStatusPill(
+                        label = hero.badgeLabel,
+                        variant = InfiniteStatusVariant.Recommended,
+                        size = InfiniteSize.Small,
+                        leadingIcon = Icons.Rounded.AutoAwesome
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroIconBadge() {
+    Box(
+        modifier = Modifier
+            .size(128.dp)
+            .clip(CircleShape)
+            .background(
+                Brush.sweepGradient(
+                    colors = listOf(
+                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.72f),
+                        InfiniteColors.AboutCyan.copy(alpha = 0.62f),
+                        InfiniteColors.Surface.copy(alpha = 0.92f),
+                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.72f)
+                    )
+                )
+            )
+            .padding(10.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            modifier = Modifier.size(104.dp),
+            shape = CircleShape,
+            color = InfiniteColors.Surface.copy(alpha = 0.76f),
+            border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.92f)),
+            shadowElevation = 10.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Surface(
+                    modifier = Modifier.size(74.dp),
+                    shape = RoundedCornerShape(22.dp),
+                    color = InfiniteColors.Surface.copy(alpha = 0.92f),
+                    shadowElevation = 8.dp
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Rounded.Key,
+                            contentDescription = null,
+                            tint = InfiniteColors.AboutPurple,
+                            modifier = Modifier.size(42.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutImpactSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutImpactSection.kt
@@ -1,0 +1,105 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Analytics
+import androidx.compose.material.icons.rounded.Groups
+import androidx.compose.material.icons.rounded.PhoneIphone
+import androidx.compose.material.icons.rounded.TrackChanges
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutImpactItem
+import com.example.infinite_track.domain.model.about.AboutImpactSemantic
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun AboutImpactSection(
+    impacts: List<AboutImpactItem>,
+    modifier: Modifier = Modifier
+) {
+    GlassSectionCard(modifier = modifier) {
+        InfiniteSectionHeader(
+            title = "Project Impact",
+            subtitle = "Expected product value",
+            leadingIcon = Icons.Rounded.Analytics
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            impacts.forEach { impact ->
+                ImpactCard(impact = impact)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImpactCard(
+    impact: AboutImpactItem
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(22.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.58f),
+        border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.84f)),
+        shadowElevation = 5.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = impact.semantic.icon,
+                contentDescription = null,
+                tint = impact.semantic.tint,
+                modifier = Modifier.size(42.dp)
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = impact.title,
+                    style = headline4,
+                    color = impact.semantic.tint,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = impact.description,
+                    style = headline4,
+                    color = InfiniteColors.AccountHubBodyText
+                )
+            }
+        }
+    }
+}
+
+private val AboutImpactSemantic.icon: ImageVector
+    get() = when (this) {
+        AboutImpactSemantic.Attendance -> Icons.Rounded.PhoneIphone
+        AboutImpactSemantic.Visibility -> Icons.Rounded.Groups
+        AboutImpactSemantic.DecisionSupport -> Icons.Rounded.TrackChanges
+    }
+
+private val AboutImpactSemantic.tint: Color
+    get() = when (this) {
+        AboutImpactSemantic.Attendance -> InfiniteColors.AboutPurple
+        AboutImpactSemantic.Visibility -> InfiniteColors.AboutCyan
+        AboutImpactSemantic.DecisionSupport -> InfiniteColors.AboutPurple
+    }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutOverviewCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutOverviewCard.kt
@@ -1,0 +1,100 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Article
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.LocationOn
+import androidx.compose.material.icons.rounded.QueryStats
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutFeatureChip
+import com.example.infinite_track.domain.model.about.AboutOverview
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun AboutOverviewCard(
+    overview: AboutOverview,
+    modifier: Modifier = Modifier
+) {
+    GlassSectionCard(modifier = modifier) {
+        InfiniteSectionHeader(
+            title = overview.title,
+            subtitle = "Project purpose and story",
+            leadingIcon = Icons.Rounded.Article
+        )
+        Text(
+            text = overview.description,
+            style = headline4,
+            color = InfiniteColors.AccountHubBodyText,
+            fontWeight = FontWeight.Normal
+        )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            overview.featureChips.forEachIndexed { index, chip ->
+                OverviewFeatureChip(
+                    chip = chip,
+                    icon = when (index % 3) {
+                        0 -> Icons.Rounded.CalendarMonth
+                        1 -> Icons.Rounded.LocationOn
+                        else -> Icons.Rounded.QueryStats
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverviewFeatureChip(
+    chip: AboutFeatureChip,
+    icon: ImageVector
+) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.64f),
+        border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.90f)),
+        shadowElevation = 5.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (chip.label.contains("Location")) InfiniteColors.AboutCyan else InfiniteColors.AboutPurple,
+                modifier = Modifier.size(22.dp)
+            )
+            Text(
+                text = chip.label,
+                style = headline4,
+                color = InfiniteColors.AccountHubTitle,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutTimelineSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutTimelineSection.kt
@@ -1,0 +1,132 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.about.AboutTimelineItem
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun AboutTimelineSection(
+    timeline: List<AboutTimelineItem>,
+    modifier: Modifier = Modifier
+) {
+    GlassSectionCard(modifier = modifier) {
+        InfiniteSectionHeader(
+            title = "Development Timeline",
+            subtitle = "From discovery to refinement",
+            leadingIcon = Icons.Rounded.Schedule
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
+            timeline.forEachIndexed { index, item ->
+                TimelineEntry(
+                    item = item,
+                    isFirst = index == 0,
+                    isLast = index == timeline.lastIndex
+                )
+                if (index != timeline.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 66.dp),
+                        color = InfiniteColors.AccountHubDividerColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineEntry(
+    item: AboutTimelineItem,
+    isFirst: Boolean,
+    isLast: Boolean
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(18.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        TimelineMarker(isFirst = isFirst, isLast = isLast)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = "${item.period} — ${item.title}",
+                style = headline4,
+                color = InfiniteColors.AccountHubTitle,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = item.description,
+                style = headline4,
+                color = InfiniteColors.AccountHubBodyText
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimelineMarker(
+    isFirst: Boolean,
+    isLast: Boolean
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Canvas(modifier = Modifier.size(width = 4.dp, height = 12.dp)) {
+            if (!isFirst) {
+                drawLine(
+                    color = InfiniteColors.AboutPurpleSoft.copy(alpha = 0.28f),
+                    start = Offset(size.width / 2, 0f),
+                    end = Offset(size.width / 2, size.height),
+                    strokeWidth = size.width
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(InfiniteColors.AboutPurpleSoft.copy(alpha = 0.15f), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(14.dp)
+                    .background(InfiniteColors.AboutPurpleSoft, CircleShape)
+            )
+        }
+        Canvas(modifier = Modifier.size(width = 4.dp, height = if (isLast) 6.dp else 28.dp)) {
+            if (!isLast) {
+                drawLine(
+                    color = InfiniteColors.AboutPurpleSoft.copy(alpha = 0.28f),
+                    start = Offset(size.width / 2, 0f),
+                    end = Offset(size.width / 2, size.height),
+                    strokeWidth = size.width
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutTopBar.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/components/AboutTopBar.kt
@@ -1,0 +1,84 @@
+package com.example.infinite_track.presentation.screen.profile.details.about.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBackIosNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun AboutTopBar(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        shape = RoundedCornerShape(28.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.62f),
+        border = BorderStroke(1.dp, InfiniteColors.Surface.copy(alpha = 0.86f)),
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .background(InfiniteColors.GlassGradient)
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Surface(
+                modifier = Modifier.size(52.dp),
+                shape = CircleShape,
+                color = InfiniteColors.Surface.copy(alpha = 0.82f),
+                border = BorderStroke(1.dp, InfiniteColors.AccountHubStrongOutline),
+                shadowElevation = 6.dp
+            ) {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        imageVector = Icons.Rounded.ArrowBackIosNew,
+                        contentDescription = "Back",
+                        tint = InfiniteColors.AccountHubTitle,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier.weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "About Infinite Track",
+                    style = headline3,
+                    color = InfiniteColors.AccountHubTitle,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(CircleShape)
+                    .background(InfiniteColors.AccountHubDecorativeTint)
+            )
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-inf-227-about-infinite-track-detail-screen.md
+++ b/docs/superpowers/plans/2026-07-07-inf-227-about-infinite-track-detail-screen.md
@@ -1,0 +1,137 @@
+# INF-227 — About Infinite Track Detail Screen Implementation Plan
+
+Date: 2026-07-07
+Branch: `fix/android-about-infinite-track-screen`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-about-infinite-track-screen`
+Spec: `docs/superpowers/specs/2026-07-07-inf-227-about-infinite-track-detail-screen.md`
+
+## Status
+
+Implementation started in isolated worktree. Initial routing, data model, dummy content provider, use case, ViewModel, UI state, and About screen components have been added. Visual refinement remains to align more closely with the uploaded semi-liquid glass reference.
+
+## Worktree mapping
+
+- Main checkout `E:\skrisi\android` is dirty and must not be edited.
+- Existing branch `fix/android-account-hub-main-refresh` is INF-226 scope and should not be reused for INF-227.
+- Existing branch `fix/profile-detail-back-navigation` has dirty navigation changes and should not be reused.
+- INF-227 worktree is isolated and safe for this task.
+
+## Implementation steps
+
+### 1. Preserve architecture separation
+
+- Keep About content in `AboutDummyContentProvider`.
+- Keep page model in `domain/model/about/AboutContent.kt`.
+- Keep ViewModel state in `AboutViewModel` + `AboutUiState`.
+- Do not move static long-form copy into `AboutScreen.kt`.
+
+### 2. Finalize navigation wiring
+
+- Keep `Screen.About : Screen("profile/about")`.
+- Keep `navigateToAbout` callback on `ProfileScreen`.
+- Keep About row wired to `onAbout`.
+- Keep About screen inside `ProfileFlow`.
+- Back action remains `navController.popBackStack()`.
+
+### 3. Refine visual implementation to match uploaded reference
+
+Implementation constraints:
+
+- About color literals must live in `InfiniteColors` tokens, not inside About composables.
+- Existing INF-222 components should be reused where applicable; section titles use `InfiniteSectionHeader`.
+- About-specific components are allowed only for local layout/rendering surfaces and must not introduce new global icon token objects.
+- Shared About glass sections should wrap existing `InfiniteCard` instead of replacing the design-system surface primitive.
+
+Target refinements:
+
+- Wrap page in lavender/white background with decorative soft blobs.
+- Use a floating glass top app bar with rounded rectangle and rounded back button.
+- Update hero card layout to match reference:
+  - left app icon glass tile/ring
+  - right title/tagline/description/badge
+  - cyan liquid blob on lower right
+- Update overview card:
+  - icon + title row
+  - long paragraph
+  - three/four feature glass chips
+- Replace generic `InfiniteTimelineRow` usage with About-specific timeline rows if needed:
+  - vertical line
+  - purple glowing dots
+  - title and description rows
+- Update creator card:
+  - avatar-style glass circle
+  - creator info column
+  - contribution text column
+  - skill chips row
+- Update achievement card:
+  - gold-tinted glass card
+  - trophy/award style visual
+  - visible `Preview only` status
+  - no final verified claim unless evidence exists
+- Update impact section:
+  - three compact cards with icon, title, description
+- Footer note centered below content.
+
+### 4. Keep scope boundaries
+
+Do not change:
+
+- Profile main visual design
+- bottom navigation
+- auth/session
+- logout
+- backend/API
+- unrelated detail screens
+
+### 5. Verification plan
+
+Run from isolated worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If environment permits:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime smoke will be performed by the human/operator on `develop` after this isolated branch is integrated:
+
+```text
+Open Profile tab on develop
+Tap About Infinite Track row
+Verify About Infinite Track screen opens
+Scroll all sections
+Tap back
+Verify Profile screen returns
+Capture screenshot/screen recording
+```
+
+Until that `develop` runtime pass exists, navigation/screenshot evidence remains `Needs Verification` for this branch.
+
+### 6. Known blocker handling
+
+Current Gradle attempts fail before compilation:
+
+```text
+java.io.IOException: Unable to establish loopback connection
+```
+
+If this remains, final report must mark build/runtime as `Needs Verification` and include the exact failure.
+
+### 7. PR note requirements
+
+Mention:
+
+- Isolated branch/worktree.
+- Added About Infinite Track detail screen.
+- Added route and Profile -> About navigation.
+- Content is model/provider/ViewModel driven.
+- UI follows uploaded semi-liquid glass reference.
+- Achievement/appreciation is PreviewOnly / Needs Verification.
+- No backend/auth/session/bottom-nav/Profile redesign changes.
+- Build evidence or Gradle environment blocker.
+- Runtime evidence or `Needs Verification`.

--- a/docs/superpowers/specs/2026-07-07-inf-227-about-infinite-track-detail-screen.md
+++ b/docs/superpowers/specs/2026-07-07-inf-227-about-infinite-track-detail-screen.md
@@ -1,0 +1,164 @@
+# INF-227 — Android About Infinite Track Detail Screen Spec
+
+Date: 2026-07-07
+Branch: `fix/android-about-infinite-track-screen`
+Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-about-infinite-track-screen`
+
+## Problem
+
+Profile already exposes an About Infinite Track row, but the row is not wired to a detail page. Android needs a dedicated About detail screen that explains the Infinite Track project story, purpose, timeline, creator/contribution, appreciation preview, and impact without adding a backend API or changing Profile main-screen visuals.
+
+## Scope
+
+Implement a local/static About Infinite Track detail page reachable from:
+
+```text
+Profile -> About Infinite Track
+```
+
+Final route:
+
+```text
+profile/about
+```
+
+## Non-goals
+
+- Do not redesign Profile main screen.
+- Do not redesign Edit Profile, FAQ, Contact tab, Pay Slip, or My Document.
+- Do not add a backend About API.
+- Do not change auth/session flow.
+- Do not change bottom navigation policy.
+- Do not change logout behavior.
+- Do not create a new global icon token object.
+- Do not claim final awards/appreciation without evidence.
+
+## Architecture
+
+Use a lightweight Clean Architecture path for static MVP content:
+
+```text
+AboutDummyContentProvider
+        ↓
+GetAboutContentUseCase
+        ↓
+AboutViewModel
+        ↓
+AboutUiState
+        ↓
+AboutScreen
+        ↓
+About section components
+```
+
+Packages:
+
+```text
+domain/model/about/
+- AboutContent.kt
+
+data/soucre/local/about/
+- AboutDummyContentProvider.kt
+
+domain/use_case/about/
+- GetAboutContentUseCase.kt
+
+presentation/screen/profile/details/about/
+- AboutScreen.kt
+- AboutViewModel.kt
+- AboutUiState.kt
+- components/*
+```
+
+## Data model
+
+`AboutContent` owns all page content:
+
+- `AboutHero`
+- `AboutOverview`
+- `AboutFeatureChip`
+- `AboutTimelineItem`
+- `AboutCreator`
+- `AboutAchievement`
+- `AboutImpactItem`
+- `VerificationStatus`
+- `AboutImpactSemantic`
+
+Achievement/appreciation claims must use a verification marker. For INF-227 dummy content, the status is:
+
+```kotlin
+VerificationStatus.PreviewOnly
+```
+
+This prevents preview-only appreciation copy from being presented as a final verified award.
+
+## Visual direction
+
+Reference received on 2026-07-07. About UI colors must come from the existing design token layer (`InfiniteColors`). If a needed About color does not exist yet, add a named token there instead of hardcoding literals in About composables. Section headers should reuse existing INF-222 components such as `InfiniteSectionHeader`, and repeated glass section surfaces should wrap `InfiniteCard` instead of replacing the design-system surface primitive.
+
+Required visual language:
+
+- light theme only
+- semi-liquid glass look
+- transparent lavender/white surfaces
+- rounded cards with soft borders
+- purple and cyan accents
+- clean long-form vertical content
+- floating profile-detail top bar with back button
+- hero app identity card with app icon treatment
+- custom vertical timeline
+- gold-tinted appreciation preview card
+- three impact cards
+
+## Required sections
+
+1. Top bar: About Infinite Track
+2. Hero app identity card
+3. Project Overview
+4. Development Timeline
+5. Created By
+6. Achievement & Appreciation
+7. Project Impact
+8. Footer note
+
+## Navigation contract
+
+- Add `Screen.About : Screen("profile/about")`.
+- Add `navigateToAbout` callback to `ProfileScreen`.
+- Wire About row `onClick` to `navigateToAbout`.
+- Add About composable to `ProfileFlow` in `MainContentNavGraph`.
+- Back button calls `navController.popBackStack()`.
+
+## Source-of-truth boundary
+
+Android only renders local About preview content. It does not define backend attendance outcomes, reporting truth, booking approval semantics, auth/session validity, or official award status.
+
+## Acceptance criteria
+
+- About route exists.
+- Profile About row navigates to About screen.
+- About content is model/provider/ViewModel-driven.
+- About screen includes all required sections.
+- Section components are split into small composables.
+- Achievement/appreciation section is visibly preview-only or needs verification.
+- No backend/auth/bottom-nav/Profile redesign changes.
+- `./gradlew app:assembleDebug` passes when Gradle environment can start.
+- Runtime smoke confirms Profile -> About -> Back.
+
+## Verification evidence required
+
+- Build: `./gradlew app:assembleDebug`
+- Optional quality gate: `./gradlew app:test`, `./gradlew app:lint`
+- Runtime screenshot of About screen on `develop` after branch integration
+- Runtime screenshot/recording of Profile -> About navigation on `develop` after branch integration
+- Code evidence for content separation and preview-only achievement status
+
+## Current known verification caveat
+
+In this session, Gradle fails before compilation with:
+
+```text
+java.io.IOException: Unable to establish loopback connection
+```
+
+This is an environment/Gradle bootstrap failure, not a source compile verdict. Build remains `Needs Verification` until rerun in a working Gradle environment.


### PR DESCRIPTION
## Summary

- Added the `profile/about` route and wired the Profile About row to navigate to the new detail screen.
- Added modeled local About content, dummy provider, use case, ViewModel, and UI state.
- Implemented the About Infinite Track detail screen with semi-liquid glass styling aligned with the uploaded visual reference.
- Reused existing design-system primitives where applicable, including `InfiniteCard` and `InfiniteSectionHeader`.
- Moved About visual colors into `InfiniteColors` tokens instead of hardcoding color literals in About composables.
- Added INF-227 spec and implementation plan docs.

## Scope boundaries

- No backend About API added.
- No auth/session flow changed.
- No bottom navigation policy changed.
- No Profile main screen redesign.
- No logout behavior changed.
- Achievement/appreciation content is marked `PreviewOnly` and must not be treated as a final verified award claim without supporting evidence.

## Verification

- `git diff --check` passed locally before commit.
- Static checks confirmed:
  - no `Color(0x...)` literals in About components
  - no custom `SectionTitle` usage
  - `InfiniteCard` usage present
  - `InfiniteSectionHeader` usage present
  - `VerificationStatus.PreviewOnly` present
  - `profile/about` route present

## Needs Verification

- `./gradlew app:assembleDebug` was attempted, but Gradle failed before compilation in this environment with:

```text
java.io.IOException: Unable to establish loopback connection
```

- Re-run `./gradlew app:assembleDebug` in a normal Gradle environment.
- Runtime smoke is intentionally planned on `develop` after integration:

```text
Profile -> About Infinite Track -> Back
```

- Capture screenshot/screen recording evidence on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “About” screen in the profile area with rich sections for app overview, timeline, creator details, achievements, impact, and a footer note.
  * Added navigation from Profile to the new About screen, including a back action.

* **Bug Fixes**
  * Enabled the About menu item to open the new destination instead of doing nothing.

* **Documentation**
  * Added implementation notes and a product spec for the new About experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->