### PR TITLE
fix: preserve session when refresh payload omits user id

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImpl.kt
@@ -60,8 +60,13 @@ class AuthRepositoryImpl @Inject constructor(
                 RefreshSessionRequest(refreshToken = existingRefreshToken)
             ).data
             val accessToken = refreshData.resolvedAccessToken()
+            val existingUserId = userPreference.getUserId().first()
+            val refreshedUserId = refreshData.id
+                .takeIf { it > 0 }
+                ?.toString()
+                ?: existingUserId.takeIf { it.isNotBlank() }
 
-            if (accessToken.isBlank() || refreshData.id <= 0) {
+            if (accessToken.isBlank() || refreshedUserId.isNullOrBlank()) {
                 val error = IllegalStateException("Invalid refresh session payload")
                 safeLogError("Refresh session returned invalid payload", error)
                 return Result.failure(
@@ -74,7 +79,6 @@ class AuthRepositoryImpl @Inject constructor(
                 )
             }
 
-            val refreshedUserId = refreshData.id.toString()
             val refreshTokenToStore = refreshData.resolvedRefreshToken() ?: existingRefreshToken
 
             userPreference.saveSession(

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -747,6 +747,45 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
+    fun `refresh session keeps stored user id when backend omits id but returns auth tokens`() = runBlocking {
+        val userPreference = createUserPreference()
+        userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
+        val fakeAuthSessionApi = FakeAuthSessionApiService(
+            refreshSessionBlock = {
+                RefreshSessionResponse(
+                    success = true,
+                    message = "ok",
+                    data = RefreshSessionData(
+                        id = 0,
+                        token = null,
+                        refreshToken = null,
+                        auth = AuthPayload(
+                            accessToken = "primary-new-access",
+                            refreshToken = "primary-new-refresh"
+                        )
+                    )
+                )
+            }
+        )
+
+        val repository = AuthRepositoryImpl(
+            userPreference = userPreference,
+            apiService = FakeApiService(
+                refreshBlock = { request -> fakeAuthSessionApi.refreshSession(request) }
+            ),
+            authSessionApiService = fakeAuthSessionApi,
+            userDao = FakeUserDao()
+        )
+
+        val result = repository.refreshSession()
+
+        assertTrue(result.isSuccess)
+        assertEquals("primary-new-access", userPreference.getAuthToken().first())
+        assertEquals("primary-new-refresh", userPreference.getRefreshToken().first())
+        assertEquals("10", userPreference.getUserId().first())
+    }
+
+    @Test
     fun `refresh session success stores latest tokens`() = runBlocking {
         val userPreference = createUserPreference()
         userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
@@ -851,7 +890,7 @@ class AuthRepositoryImplRefreshSessionTest {
     }
 
     @Test
-    fun `refresh session returns temporary failure and does not persist when user id is invalid`() = runBlocking {
+    fun `refresh session falls back to stored user id when payload omits id`() = runBlocking {
         val userPreference = createUserPreference()
         userPreference.saveSession(token = "old-access", userId = "10", refreshToken = "old-refresh")
 
@@ -879,9 +918,9 @@ class AuthRepositoryImplRefreshSessionTest {
 
         val result = repository.refreshSession()
 
-        assertTrue(result.isFailure)
-        assertEquals("old-access", userPreference.getAuthToken().first())
-        assertEquals("old-refresh", userPreference.getRefreshToken().first())
+        assertTrue(result.isSuccess)
+        assertEquals("new-access", userPreference.getAuthToken().first())
+        assertEquals("new-refresh", userPreference.getRefreshToken().first())
         assertEquals("10", userPreference.getUserId().first())
     }
 


### PR DESCRIPTION
- treat refresh session payload as valid when access token is present and a stored user id already exists
- fall back to the locally persisted user id when backend refresh response omits data.id
- add/update tests covering refresh success without response user id

Needs Verification:
- emulator restart continuity should be rechecked after merge
- local Gradle compile/test remain blocked by loopback environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshing a session now preserves the existing user ID when the server response doesn’t include one, while still updating the session tokens.
  * Improved validation so refresh results are only accepted when the returned access token and user ID are usable.

* **Tests**
  * Added coverage for refresh flows where the backend omits the user ID.
  * Updated session refresh tests to verify successful fallback to the stored user ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->