### PR TITLE
INF-229: Implement Home today status dashboard

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapper.kt
@@ -18,7 +18,11 @@ import com.example.infinite_track.data.soucre.network.response.CheckinWindow as 
  * Extension function to convert TodayStatusResponse (DTO) to TodayStatus (Domain model)
  */
 fun TodayStatusResponse.toDomain(): TodayStatus {
-    return data.toDomain(cacheTtlSeconds = AuthRuntimePolicy.SHARED_TTL_SECONDS)
+    return data.toDomain(
+        cacheTtlSeconds = meta?.cacheTtlSeconds
+            ?.takeIf { it > 0 }
+            ?: AuthRuntimePolicy.SHARED_TTL_SECONDS
+    )
 }
 
 /**
@@ -32,6 +36,9 @@ fun TodayStatusData.toDomain(
         canCheckOut = this.canCheckOut == true, // Handle null with default false
         checkedInAt = this.checkedInAt,
         checkedOutAt = this.checkedOutAt,
+        checkedInAtIso = this.checkedInAtIso,
+        checkedOutAtIso = this.checkedOutAtIso,
+        workDurationSeconds = this.workDurationSeconds,
         activeMode = this.activeMode,
         activeLocation = this.activeLocation?.toDomain(),
         todayDate = this.todayDate,

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponse.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponse.kt
@@ -66,7 +66,16 @@ data class TodayStatusData(
     val attendanceSessionState: AttendanceSessionStateDto? = null,
 
     @field:SerializedName("active_attendance_id")
-    val activeAttendanceId: Int? = null
+    val activeAttendanceId: Int? = null,
+
+    @field:SerializedName("checked_in_at_iso")
+    val checkedInAtIso: String? = null,
+
+    @field:SerializedName("checked_out_at_iso")
+    val checkedOutAtIso: String? = null,
+
+    @field:SerializedName("work_duration_seconds")
+    val workDurationSeconds: Long? = null
 )
 
 data class AttendanceSessionStateDto(

--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceModel.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceModel.kt
@@ -21,6 +21,9 @@ data class TodayStatus(
     val checkoutAutoTime: String,
     val attendanceSessionState: AttendanceSessionState? = null,
     val activeAttendanceId: Int? = null,
+    val checkedInAtIso: String? = null,
+    val checkedOutAtIso: String? = null,
+    val workDurationSeconds: Long? = null,
     val cacheTtlSeconds: Int = AuthRuntimePolicy.SHARED_TTL_SECONDS
 )
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteServiceItem.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteServiceItem.kt
@@ -1,0 +1,63 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+fun InfiniteServiceItem(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick)
+            .background(InfiniteColors.Surface.copy(alpha = 0.72f))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = InfiniteColors.Primary,
+            modifier = Modifier
+                .clip(RoundedCornerShape(14.dp))
+                .background(InfiniteColors.Primary.copy(alpha = 0.10f))
+                .padding(8.dp)
+                .size(22.dp)
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = title,
+                color = InfiniteColors.Text,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = subtitle,
+                color = InfiniteColors.Text.copy(alpha = 0.60f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.LocationOn
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.Warning
@@ -25,6 +26,7 @@ object InfiniteIcons {
     val Error = Icons.Rounded.Error
     val Location = Icons.Rounded.LocationOn
     val Search = Icons.Rounded.Search
+    val Refresh = Icons.Rounded.Refresh
     val Filter = Icons.Rounded.FilterList
     val Download = Icons.Rounded.FileDownload
     val Share = Icons.Rounded.Share

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -23,6 +23,7 @@ import com.example.infinite_track.presentation.screen.home.HomeScreen
 import com.example.infinite_track.presentation.screen.home.HomeViewModel
 import com.example.infinite_track.presentation.screen.home.details.DetailsMyAttendance
 import com.example.infinite_track.presentation.screen.home.details.DetailsMyBooking
+import com.example.infinite_track.presentation.screen.home.service.CompanyServiceComingSoonScreen
 import com.example.infinite_track.presentation.screen.leave_request.my_leave.MyLeave
 import com.example.infinite_track.presentation.screen.leave_request.timeOff.TimeOffScreen
 import com.example.infinite_track.presentation.screen.profile.ProfileScreen
@@ -47,7 +48,8 @@ fun NavGraphBuilder.mainContentNavGraph(
             viewModel = homeViewModel,
             navigateAttendance = { navController.safeNavigate(Screen.Attendance.route) },
             navigateTimeOffRequest = { navController.safeNavigate(Screen.TimeOffRequest.route) },
-            navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) }
+            navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) },
+            navigateServiceComingSoon = { navController.safeNavigate(Screen.CompanyServiceComingSoon.route) }
         )
     }
 
@@ -94,6 +96,12 @@ fun NavGraphBuilder.mainContentNavGraph(
 
     composable(Screen.Wfa.route) {
         WfaHistoryScreen()
+    }
+
+    composable(Screen.CompanyServiceComingSoon.route) {
+        CompanyServiceComingSoonScreen(
+            onBackClick = { navController.popBackStack() }
+        )
     }
 
     // Profile Feature Flow

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
@@ -30,6 +30,7 @@ sealed class Screen(val route: String) {
     data object DetailListTimeOff : Screen("home/detailsTimeOff")
     data object DetailMyAttendance : Screen("home/listMyAttendance")
     data object DetailsMyBooking : Screen("home/detailsBooking")
+    data object CompanyServiceComingSoon : Screen("home/companyServiceComingSoon")
     data object PaySlip : Screen("profile/PaySlip")
     data object MyDocument : Screen("profile/MyDocument")
     data object About : Screen("profile/about")

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
@@ -33,6 +33,7 @@ fun HomeScreen(
     navigateAttendance: () -> Unit = {},
     navigateTimeOffRequest: () -> Unit = {},
     navigateListMyAttendance: () -> Unit = {},
+    navigateServiceComingSoon: () -> Unit = {},
 ) {
     val userProfile by viewModel.userProfileState.collectAsState()
     val attendanceState by viewModel.topAttendanceHistoryState.collectAsState()
@@ -97,6 +98,7 @@ fun HomeScreen(
                                     navigateAttendance = navigateAttendance,
                                     navigateTimeOffRequest = navigateTimeOffRequest,
                                     navigateListMyAttendance = navigateListMyAttendance,
+                                    navigateServiceComingSoon = navigateServiceComingSoon,
                                     refreshDashboard = { viewModel.refreshDashboard(forceRefresh = true) }
                                 )
                             }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
@@ -9,11 +9,17 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.screen.home.content.EmployeeAndManagerComponent
 import com.example.infinite_track.presentation.screen.home.content.InternshipContent
@@ -30,13 +36,27 @@ fun HomeScreen(
 ) {
     val userProfile by viewModel.userProfileState.collectAsState()
     val attendanceState by viewModel.topAttendanceHistoryState.collectAsState()
-    val annualBalance by viewModel.annualBalance.collectAsState()
-    val annualUsed by viewModel.annualUsed.collectAsState()
     val currentLocation by viewModel.currentAddressState.collectAsState()
-    val internshipSummary by viewModel.internshipSummaryState.collectAsState()
+    val todayStatusState by viewModel.todayStatusState.collectAsState()
 
     val isLoading = attendanceState is UiState.Loading
     val scrollState = rememberScrollState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val hasHandledInitialResume = remember { mutableStateOf(false) }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (hasHandledInitialResume.value) {
+                    viewModel.refreshDashboard(forceRefresh = true)
+                } else {
+                    hasHandledInitialResume.value = true
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -58,10 +78,12 @@ fun HomeScreen(
                             "Internship" -> {
                                 InternshipContent(
                                     user = userProfile,
-                                    summaryData = internshipSummary,
                                     currentLocation = currentLocation,
                                     attendanceState = attendanceState,
-                                    navigateToListMyAttendance = navigateListMyAttendance
+                                    todayStatusState = todayStatusState,
+                                    navigateAttendance = navigateAttendance,
+                                    navigateToListMyAttendance = navigateListMyAttendance,
+                                    refreshDashboard = { viewModel.refreshDashboard(forceRefresh = true) }
                                 )
                             }
 
@@ -69,13 +91,13 @@ fun HomeScreen(
                                 EmployeeAndManagerComponent(
                                     user = userProfile,
                                     attendanceState = attendanceState,
-                                    annualBalance = annualBalance,
-                                    annualUsed = annualUsed,
+                                    todayStatusState = todayStatusState,
                                     currentLocation = currentLocation,
                                     isLoading = isLoading,
                                     navigateAttendance = navigateAttendance,
                                     navigateTimeOffRequest = navigateTimeOffRequest,
-                                    navigateListMyAttendance = navigateListMyAttendance
+                                    navigateListMyAttendance = navigateListMyAttendance,
+                                    refreshDashboard = { viewModel.refreshDashboard(forceRefresh = true) }
                                 )
                             }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
@@ -3,12 +3,12 @@ package com.example.infinite_track.presentation.screen.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.TodayStatus
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.model.booking.BookingHistoryItem
-import com.example.infinite_track.domain.model.dashboard.InternshipSummary
+import com.example.infinite_track.domain.use_case.attendance.GetTodayStatusUseCase
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
 import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
-import com.example.infinite_track.domain.use_case.dashboard.GetInternshipDashboardDataUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentAddressUseCase
 import com.example.infinite_track.utils.UiState
@@ -18,13 +18,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class HomeTodayStatusUiState(
+	val status: UiState<TodayStatus> = UiState.Loading,
+	val warningMessage: String? = null,
+	val isRefreshing: Boolean = false
+)
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
 	private val getLoggedInUserUseCase: GetLoggedInUserUseCase,
 	private val getAttendanceHistoryUseCase: GetAttendanceHistoryUseCase,
 	private val getCurrentAddressUseCase: GetCurrentAddressUseCase,
-	private val getInternshipDashboardDataUseCase: GetInternshipDashboardDataUseCase,
-	private val getBookingHistoryUseCase: GetBookingHistoryUseCase
+	private val getBookingHistoryUseCase: GetBookingHistoryUseCase,
+	private val getTodayStatusUseCase: GetTodayStatusUseCase
 ) : ViewModel() {
 
 	// User profile state
@@ -41,16 +47,8 @@ class HomeViewModel @Inject constructor(
 	private val _currentAddressState = MutableStateFlow("Loading...")
 	val currentAddressState: StateFlow<String> = _currentAddressState
 
-	// Internship Dashboard Summary state - simplified to just hold the data or null
-	private val _internshipSummaryState = MutableStateFlow<InternshipSummary?>(null)
-	val internshipSummaryState: StateFlow<InternshipSummary?> = _internshipSummaryState
-
-	// Dummy leave data for Employee/Manager
-	private val _annualBalance = MutableStateFlow(12)
-	val annualBalance: StateFlow<Int> = _annualBalance
-
-	private val _annualUsed = MutableStateFlow(5)
-	val annualUsed: StateFlow<Int> = _annualUsed
+	private val _todayStatusState = MutableStateFlow(HomeTodayStatusUiState())
+	val todayStatusState: StateFlow<HomeTodayStatusUiState> = _todayStatusState
 
 	// Detailed booking history state for legacy DetailsMyBooking route; WFA tab owns the primary booking history UI.
 	// Detailed booking history state for DetailsMyBooking screen
@@ -73,8 +71,7 @@ class HomeViewModel @Inject constructor(
 		fetchUserProfile()
 		fetchTopAttendanceHistory()
 		fetchCurrentAddress()
-		loadDummyLeaveData()
-		fetchInternshipDashboardData()
+		fetchTodayStatus(forceRefresh = false)
 	}
 
 	private fun fetchUserProfile() {
@@ -112,30 +109,44 @@ class HomeViewModel @Inject constructor(
 		}
 	}
 
-	private fun loadDummyLeaveData() {
-		// These values are already set in the StateFlow initialization
-		// This function is included for clarity and future expansion
-		_annualBalance.value = 12
-		_annualUsed.value = 5
-	}
-
-	private fun fetchInternshipDashboardData() {
+	fun fetchTodayStatus(forceRefresh: Boolean = false) {
 		viewModelScope.launch {
-			getInternshipDashboardDataUseCase().onSuccess { summary ->
-				_internshipSummaryState.value = summary
-			}.onFailure {
-				// On failure, just leave the state as null
-				_internshipSummaryState.value = null
+			val currentState = _todayStatusState.value
+			val hasExistingStatus = currentState.status is UiState.Success
+
+			_todayStatusState.value = when {
+				forceRefresh && hasExistingStatus -> currentState.copy(
+					warningMessage = null,
+					isRefreshing = true
+				)
+
+				else -> HomeTodayStatusUiState(status = UiState.Loading)
 			}
+
+			getTodayStatusUseCase(forceRefresh = forceRefresh)
+				.onSuccess { todayStatus ->
+					_todayStatusState.value = HomeTodayStatusUiState(
+						status = UiState.Success(todayStatus)
+					)
+				}
+				.onFailure { error ->
+					val message = error.message ?: "Unable to refresh today's attendance status"
+					_todayStatusState.value = if (hasExistingStatus) {
+						currentState.copy(
+							warningMessage = message,
+							isRefreshing = false
+						)
+					} else {
+						HomeTodayStatusUiState(status = UiState.Error(message))
+					}
+				}
 		}
 	}
 
-	/**
-	 * Function to refresh the internship dashboard data
-	 * Can be called when user performs a pull-to-refresh or after check-in/check-out
-	 */
-	fun refreshInternshipDashboard() {
-		fetchInternshipDashboardData()
+	fun refreshDashboard(forceRefresh: Boolean = true) {
+		fetchTodayStatus(forceRefresh = forceRefresh)
+		fetchTopAttendanceHistory()
+		fetchCurrentAddress()
 	}
 
 	/**

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
@@ -23,6 +23,7 @@ fun CompanyServicesGrid(
     onAttendanceClick: () -> Unit,
     onTimeOffClick: () -> Unit,
     onAttendanceHistoryClick: () -> Unit,
+    onComingSoonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val services = listOf(
@@ -43,6 +44,12 @@ fun CompanyServicesGrid(
             subtitle = "Lihat riwayat",
             icon = InfiniteIcons.Time,
             onClick = onAttendanceHistoryClick
+        ),
+        CompanyService(
+            title = "More Services",
+            subtitle = "Segera hadir",
+            icon = InfiniteIcons.More,
+            onClick = onComingSoonClick
         )
     )
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
@@ -1,28 +1,17 @@
 package com.example.infinite_track.presentation.screen.home.content
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.components.data.InfiniteServiceItem
 import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
-import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
 import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
@@ -81,8 +70,11 @@ fun CompanyServicesGrid(
                         horizontalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         rowItems.forEach { service ->
-                            CompanyServiceItem(
-                                service = service,
+                            InfiniteServiceItem(
+                                title = service.title,
+                                subtitle = service.subtitle,
+                                icon = service.icon,
+                                onClick = service.onClick,
                                 modifier = Modifier.weight(1f)
                             )
                         }
@@ -92,47 +84,6 @@ fun CompanyServicesGrid(
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun CompanyServiceItem(
-    service: CompanyService,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(20.dp))
-            .clickable(onClick = service.onClick)
-            .background(InfiniteColors.Surface.copy(alpha = 0.72f))
-            .padding(14.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
-    ) {
-        Icon(
-            imageVector = service.icon,
-            contentDescription = null,
-            tint = InfiniteColors.Primary,
-            modifier = Modifier
-                .clip(RoundedCornerShape(14.dp))
-                .background(InfiniteColors.Primary.copy(alpha = 0.10f))
-                .padding(8.dp)
-                .size(22.dp)
-        )
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text(
-                text = service.title,
-                color = InfiniteColors.Text,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = service.subtitle,
-                color = InfiniteColors.Text.copy(alpha = 0.60f),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
@@ -1,0 +1,145 @@
+package com.example.infinite_track.presentation.screen.home.content
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+@Composable
+fun CompanyServicesGrid(
+    onAttendanceClick: () -> Unit,
+    onTimeOffClick: () -> Unit,
+    onAttendanceHistoryClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val services = listOf(
+        CompanyService(
+            title = "Attendance",
+            subtitle = "Check-in / check-out",
+            icon = InfiniteIcons.Success,
+            onClick = onAttendanceClick
+        ),
+        CompanyService(
+            title = "Time Off",
+            subtitle = "Ajukan cuti",
+            icon = InfiniteIcons.Calendar,
+            onClick = onTimeOffClick
+        ),
+        CompanyService(
+            title = "Attendance History",
+            subtitle = "Lihat riwayat",
+            icon = InfiniteIcons.Time,
+            onClick = onAttendanceHistoryClick
+        )
+    )
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        InfiniteSectionHeader(
+            title = "Company Services",
+            subtitle = "Akses layanan utama perusahaan",
+            leadingIcon = InfiniteIcons.More
+        )
+
+        InfiniteCard(
+            modifier = Modifier.fillMaxWidth(),
+            variant = InfiniteSurfaceVariant.Glass,
+            semantic = InfiniteSemantic.Primary,
+            size = InfiniteSize.Medium,
+            density = InfiniteDensity.Comfortable
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                services.chunked(2).forEach { rowItems ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        rowItems.forEach { service ->
+                            CompanyServiceItem(
+                                service = service,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        if (rowItems.size == 1) {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompanyServiceItem(
+    service: CompanyService,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = service.onClick)
+            .background(InfiniteColors.Surface.copy(alpha = 0.72f))
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            imageVector = service.icon,
+            contentDescription = null,
+            tint = InfiniteColors.Primary,
+            modifier = Modifier
+                .clip(RoundedCornerShape(14.dp))
+                .background(InfiniteColors.Primary.copy(alpha = 0.10f))
+                .padding(8.dp)
+                .size(22.dp)
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = service.title,
+                color = InfiniteColors.Text,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = service.subtitle,
+                color = InfiniteColors.Text.copy(alpha = 0.60f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+private data class CompanyService(
+    val title: String,
+    val subtitle: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -42,6 +42,7 @@ fun EmployeeAndManagerComponent(
     navigateAttendance: () -> Unit,
     navigateTimeOffRequest: () -> Unit,
     navigateListMyAttendance: () -> Unit,
+    navigateServiceComingSoon: () -> Unit,
     refreshDashboard: () -> Unit
 ) {
     user?.let { userData ->
@@ -83,7 +84,8 @@ fun EmployeeAndManagerComponent(
                 CompanyServicesGrid(
                     onAttendanceClick = navigateAttendance,
                     onTimeOffClick = navigateTimeOffRequest,
-                    onAttendanceHistoryClick = navigateListMyAttendance
+                    onAttendanceHistoryClick = navigateListMyAttendance,
+                    onComingSoonClick = navigateServiceComingSoon
                 )
 
                 Spacer(modifier.height(14.dp))

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -21,11 +21,12 @@ import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.cards.MenuCard
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.components.tittle.Location
+import com.example.infinite_track.presentation.components.tittle.nameCards
 import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
 import com.example.infinite_track.utils.UiState
 import com.example.infinite_track.utils.getCurrentDate
 
@@ -35,16 +36,14 @@ fun EmployeeAndManagerComponent(
     modifier: Modifier = Modifier,
     user: UserModel?,
     attendanceState: UiState<List<AttendanceRecord>>,
-    annualBalance: Int,
-    annualUsed: Int,
+    todayStatusState: HomeTodayStatusUiState,
     currentLocation: String,
     isLoading: Boolean = false,
     navigateAttendance: () -> Unit,
     navigateTimeOffRequest: () -> Unit,
     navigateListMyAttendance: () -> Unit,
+    refreshDashboard: () -> Unit
 ) {
-    val annualLeft = annualBalance - annualUsed
-
     user?.let { userData ->
         val fullImageUrl = userData.photoUrl?.ifEmpty {
             "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png"
@@ -63,19 +62,31 @@ fun EmployeeAndManagerComponent(
 
                 Spacer(modifier.height(12.dp))
 
-                MenuCard(
-                    annualBalance = annualBalance,
-                    annualUsed = annualUsed,
-                    annualLeft = annualLeft,
-                    userName = userData.fullName,
-                    position = userData.positionName ?: "No Position",
+                nameCards(
                     greeting = "Hello",
-                    onClickLiveAttendance = navigateAttendance,
-                    onClickTimeOff = navigateTimeOffRequest,
+                    userName = userData.fullName,
+                    division = userData.positionName ?: "No Position",
                     profileImage = fullImageUrl
                 )
 
-                Spacer(modifier.height(12.dp))
+                Spacer(modifier.height(14.dp))
+
+                HomeTodayStatusCard(
+                    state = todayStatusState,
+                    currentLocation = currentLocation,
+                    onAttendanceClick = navigateAttendance,
+                    onRefreshClick = refreshDashboard
+                )
+
+                Spacer(modifier.height(14.dp))
+
+                CompanyServicesGrid(
+                    onAttendanceClick = navigateAttendance,
+                    onTimeOffClick = navigateTimeOffRequest,
+                    onAttendanceHistoryClick = navigateListMyAttendance
+                )
+
+                Spacer(modifier.height(14.dp))
 
                 if (isLoading) {
                     Box(
@@ -87,8 +98,6 @@ fun EmployeeAndManagerComponent(
                         LoadingAnimation()
                     }
                 } else {
-                    Spacer(modifier.height(12.dp))
-
                     SeeAllButton(
                         label = stringResource(R.string.attendance_history),
                         onClickButton = navigateListMyAttendance

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
@@ -1,0 +1,400 @@
+package com.example.infinite_track.presentation.screen.home.content
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.attendance.TodayStatus
+import com.example.infinite_track.presentation.components.loading.InlineRefreshingIndicator
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
+import com.example.infinite_track.utils.UiState
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Composable
+fun HomeTodayStatusCard(
+    state: HomeTodayStatusUiState,
+    currentLocation: String,
+    onAttendanceClick: () -> Unit,
+    onRefreshClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        InfiniteSectionHeader(
+            title = "Today Status",
+            subtitle = "Status attendance hari ini dari backend",
+            leadingIcon = InfiniteIcons.Calendar,
+            trailingText = "Refresh",
+            trailingIcon = InfiniteIcons.Refresh,
+            onTrailingClick = if (state.isRefreshing) null else onRefreshClick
+        )
+
+        if (state.isRefreshing) {
+            InlineRefreshingIndicator(message = "Refreshing today status...")
+        }
+
+        state.warningMessage?.let { warning ->
+            InfiniteInlineAlert(
+                title = "Status belum terbaru",
+                message = warning,
+                semantic = InfiniteSemantic.Warning
+            )
+        }
+
+        when (val statusState = state.status) {
+            is UiState.Loading -> TodayStatusLoadingCard()
+            is UiState.Success -> TodayStatusSuccessCard(
+                todayStatus = statusState.data,
+                currentLocation = currentLocation,
+                isRefreshing = state.isRefreshing,
+                onAttendanceClick = onAttendanceClick
+            )
+            is UiState.Error -> TodayStatusErrorCard(
+                message = statusState.errorMessage,
+                onRefreshClick = onRefreshClick
+            )
+            is UiState.Idle -> TodayStatusErrorCard(
+                message = "Status hari ini belum tersedia.",
+                onRefreshClick = onRefreshClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun TodayStatusLoadingCard() {
+    InfiniteCard(
+        modifier = Modifier.fillMaxWidth(),
+        variant = InfiniteSurfaceVariant.SoftGradient,
+        semantic = InfiniteSemantic.Primary,
+        size = InfiniteSize.Large,
+        density = InfiniteDensity.Spacious
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(132.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = InfiniteColors.Primary)
+        }
+    }
+}
+
+@Composable
+private fun TodayStatusErrorCard(
+    message: String,
+    onRefreshClick: () -> Unit
+) {
+    InfiniteCard(
+        modifier = Modifier.fillMaxWidth(),
+        variant = InfiniteSurfaceVariant.StatusTint,
+        semantic = InfiniteSemantic.Warning,
+        size = InfiniteSize.Large,
+        density = InfiniteDensity.Spacious
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = "Status hari ini belum bisa dimuat",
+                color = InfiniteColors.Text,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = message,
+                color = InfiniteColors.Text.copy(alpha = 0.72f)
+            )
+            InfiniteButton(
+                text = "Coba lagi",
+                onClick = onRefreshClick,
+                variant = InfiniteButtonVariant.Outlined,
+                size = InfiniteSize.Small
+            )
+        }
+    }
+}
+
+@Composable
+private fun TodayStatusSuccessCard(
+    todayStatus: TodayStatus,
+    currentLocation: String,
+    isRefreshing: Boolean,
+    onAttendanceClick: () -> Unit
+) {
+    val statusKey = todayStatus.attendanceSessionState?.key.orEmpty().lowercase(Locale.ROOT)
+    val action = todayStatus.actionState(statusKey)
+
+    InfiniteCard(
+        modifier = Modifier.fillMaxWidth(),
+        variant = InfiniteSurfaceVariant.SoftGradient,
+        semantic = todayStatus.semantic(statusKey),
+        size = InfiniteSize.Large,
+        density = InfiniteDensity.Spacious
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Attendance target",
+                        color = InfiniteColors.Text.copy(alpha = 0.62f)
+                    )
+                    Text(
+                        text = todayStatus.activeLocation?.description ?: "Target belum tersedia",
+                        color = InfiniteColors.Text,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                InfiniteStatusPill(
+                    label = todayStatus.displayStatus(statusKey),
+                    variant = todayStatus.statusVariant(statusKey),
+                    size = InfiniteSize.Small
+                )
+            }
+
+            StatusMetricGrid(
+                items = listOf(
+                    TodayStatusMetric("Status", todayStatus.displayStatus(statusKey)),
+                    TodayStatusMetric("Mode", todayStatus.activeMode.ifBlank { "--" }),
+                    TodayStatusMetric("Lokasi Target", todayStatus.activeLocation?.description ?: "--"),
+                    TodayStatusMetric("Check-in", formatTime(todayStatus.checkedInAt, todayStatus.checkedInAtIso)),
+                    TodayStatusMetric("Check-out", formatTime(todayStatus.checkedOutAt, todayStatus.checkedOutAtIso)),
+                    TodayStatusMetric("Durasi Kerja", formatDuration(todayStatus.workDurationSeconds))
+                )
+            )
+
+            GeofenceSummary(
+                targetLocation = todayStatus.activeLocation?.description,
+                currentLocation = currentLocation
+            )
+
+            InfiniteButton(
+                text = action.label,
+                onClick = onAttendanceClick,
+                variant = action.variant,
+                size = InfiniteSize.Medium,
+                state = if (action.enabled && !isRefreshing) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
+                fullWidth = true
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusMetricGrid(items: List<TodayStatusMetric>) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        items.chunked(2).forEach { rowItems ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                rowItems.forEach { item ->
+                    TodayStatusMetricItem(
+                        metric = item,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                if (rowItems.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodayStatusMetricItem(
+    metric: TodayStatusMetric,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(InfiniteColors.Surface.copy(alpha = 0.62f))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = metric.label,
+            color = InfiniteColors.Text.copy(alpha = 0.58f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = metric.value,
+            color = InfiniteColors.Text,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun GeofenceSummary(
+    targetLocation: String?,
+    currentLocation: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(InfiniteColors.Primary.copy(alpha = 0.08f))
+            .padding(12.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Icon(
+            imageVector = InfiniteIcons.Location,
+            contentDescription = null,
+            tint = InfiniteColors.Primary,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = "Geofence / target summary",
+                color = InfiniteColors.Text,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Target: ${targetLocation ?: "belum tersedia"}. Lokasi perangkat: $currentLocation",
+                color = InfiniteColors.Text.copy(alpha = 0.68f)
+            )
+        }
+    }
+}
+
+private data class TodayStatusMetric(
+    val label: String,
+    val value: String
+)
+
+private data class TodayStatusAction(
+    val label: String,
+    val enabled: Boolean,
+    val variant: InfiniteButtonVariant
+)
+
+private fun TodayStatus.actionState(statusKey: String): TodayStatusAction {
+    return when {
+        statusKey == "not_started" && canCheckIn -> TodayStatusAction(
+            label = "Mulai Check-in",
+            enabled = true,
+            variant = InfiniteButtonVariant.Primary
+        )
+        statusKey == "active" && canCheckOut && activeAttendanceId != null -> TodayStatusAction(
+            label = "Lanjut Check-out",
+            enabled = true,
+            variant = InfiniteButtonVariant.Warning
+        )
+        statusKey == "completed" -> TodayStatusAction(
+            label = "Attendance selesai",
+            enabled = false,
+            variant = InfiniteButtonVariant.Success
+        )
+        statusKey == "unavailable" -> TodayStatusAction(
+            label = "Attendance tidak tersedia",
+            enabled = false,
+            variant = InfiniteButtonVariant.Outlined
+        )
+        else -> TodayStatusAction(
+            label = "Buka Attendance",
+            enabled = canCheckIn || canCheckOut,
+            variant = InfiniteButtonVariant.Outlined
+        )
+    }
+}
+
+private fun TodayStatus.displayStatus(statusKey: String): String {
+    attendanceSessionState?.label?.takeIf { it.isNotBlank() }?.let { return it }
+    return when (statusKey) {
+        "not_started" -> "Belum check-in"
+        "active" -> "Sesi aktif"
+        "completed" -> "Selesai"
+        "unavailable" -> "Tidak tersedia"
+        else -> statusKey.takeIf { it.isNotBlank() } ?: "Unknown"
+    }
+}
+
+private fun TodayStatus.statusVariant(statusKey: String): InfiniteStatusVariant {
+    return when (statusKey) {
+        "active" -> InfiniteStatusVariant.Active
+        "completed" -> InfiniteStatusVariant.Completed
+        "not_started" -> InfiniteStatusVariant.NotStarted
+        "unavailable" -> InfiniteStatusVariant.Unavailable
+        else -> InfiniteStatusVariant.Unknown
+    }
+}
+
+private fun TodayStatus.semantic(statusKey: String): InfiniteSemantic {
+    return when (statusKey) {
+        "active", "completed" -> InfiniteSemantic.Success
+        "not_started" -> InfiniteSemantic.Info
+        "unavailable" -> InfiniteSemantic.Warning
+        else -> InfiniteSemantic.Neutral
+    }
+}
+
+private fun formatTime(primary: String?, iso: String?): String {
+    primary?.takeIf { it.isNotBlank() }?.let { return it }
+    return iso
+        ?.takeIf { it.isNotBlank() }
+        ?.let { value ->
+            runCatching {
+                OffsetDateTime.parse(value).format(DateTimeFormatter.ofPattern("HH:mm"))
+            }.getOrElse { value }
+        }
+        ?: "--"
+}
+
+private fun formatDuration(seconds: Long?): String {
+    if (seconds == null || seconds <= 0L) return "--"
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return when {
+        hours > 0 && minutes > 0 -> "${hours}j ${minutes}m"
+        hours > 0 -> "${hours}j"
+        minutes > 0 -> "${minutes}m"
+        else -> "<1m"
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -5,14 +5,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,16 +18,14 @@ import androidx.compose.ui.unit.dp
 import com.example.infinite_track.R
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.domain.model.dashboard.InternshipSummary
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.cards.CardAbsence
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
-import com.example.infinite_track.presentation.components.images.ImageSlider
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.components.tittle.Location
 import com.example.infinite_track.presentation.components.tittle.nameCards
 import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
 import com.example.infinite_track.utils.UiState
 import com.example.infinite_track.utils.getCurrentDate
 
@@ -39,13 +33,15 @@ import com.example.infinite_track.utils.getCurrentDate
 fun InternshipContent(
     modifier: Modifier = Modifier,
     user: UserModel?,
-    summaryData: InternshipSummary?,
     currentLocation: String,
     attendanceState: UiState<List<AttendanceRecord>>,
+    todayStatusState: HomeTodayStatusUiState,
+    navigateAttendance: () -> Unit,
     navigateToListMyAttendance: () -> Unit,
+    refreshDashboard: () -> Unit
 ) {
     Box(
-        modifier = modifier.fillMaxSize()
+        modifier = modifier.fillMaxWidth()
     ) {
         Column(
             modifier = Modifier
@@ -70,53 +66,16 @@ fun InternshipContent(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(14.dp))
 
-            if (summaryData != null) {
-                val cardConfigurations = listOf(
-                    Triple(
-                        "Checked In",
-                        summaryData.checkedInTime ?: "--:--",
-                        R.drawable.ic_checkin
-                    ),
-                    Triple(
-                        "Checked Out",
-                        summaryData.checkedOutTime ?: "--:--",
-                        R.drawable.ic_checkout
-                    ),
-                    Triple("Absence", "${summaryData.totalAbsence} Day", R.drawable.ic_absence),
-                    Triple(
-                        "Total Attended",
-                        "${summaryData.totalAttended} Day",
-                        R.drawable.ic_total_absence
-                    )
-                )
+            HomeTodayStatusCard(
+                state = todayStatusState,
+                currentLocation = currentLocation,
+                onAttendanceClick = navigateAttendance,
+                onRefreshClick = refreshDashboard
+            )
 
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(2),
-                    modifier = Modifier
-                        .height(180.dp)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    userScrollEnabled = false
-                ) {
-                    items(cardConfigurations) { (cardText, cardTitle, cardImage) ->
-                        CardAbsence(
-                            cardTitle = cardTitle,
-                            cardText = cardText,
-                            cardImage = cardImage,
-                            onClick = { }
-                        )
-                    }
-                }
-            } else {
-                Spacer(modifier = Modifier.height(180.dp))
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-            ImageSlider()
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(14.dp))
 
             SeeAllButton(
                 label = stringResource(R.string.attendance_history),

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/service/CompanyServiceComingSoonScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/service/CompanyServiceComingSoonScreen.kt
@@ -1,0 +1,60 @@
+package com.example.infinite_track.presentation.screen.home.service
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.components.button.InfiniteTracButtonBack
+import com.example.infinite_track.presentation.components.empty.ComingSoonAnimation
+import com.example.infinite_track.presentation.core.headline1
+
+@Composable
+fun CompanyServiceComingSoonScreen(
+    onBackClick: () -> Unit
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = Color.Transparent,
+        topBar = {
+            InfiniteTracButtonBack(
+                title = "Company Services",
+                navigationBack = onBackClick,
+                modifier = Modifier.padding(top = 12.dp)
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.offset(y = (-50).dp)
+            ) {
+                ComingSoonAnimation(modifier = Modifier.size(350.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Coming Soon 👾",
+                    style = headline1,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapperTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapperTest.kt
@@ -6,7 +6,6 @@ import com.example.infinite_track.data.soucre.network.response.TodayStatusData
 import com.example.infinite_track.data.soucre.network.response.TodayStatusMeta
 import com.example.infinite_track.data.soucre.network.response.TodayStatusResponse
 import com.example.infinite_track.domain.model.attendance.AttendanceSessionState
-import com.example.infinite_track.domain.model.auth.AuthRuntimePolicy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -42,6 +41,6 @@ class AttendanceMapperTest {
         assertEquals("2026-07-05T18:49:51.000Z", domain.currentTime)
         assertEquals(AttendanceSessionState(4, "unavailable", "Unavailable"), domain.attendanceSessionState)
         assertNull(domain.activeAttendanceId)
-        assertEquals(AuthRuntimePolicy.SHARED_TTL_SECONDS, domain.cacheTtlSeconds)
+        assertEquals(300, domain.cacheTtlSeconds)
     }
 }

--- a/app/src/test/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponseTest.kt
@@ -15,16 +15,19 @@ class TodayStatusResponseTest {
 
         assertEquals(AttendanceSessionState(2, "active", "Active Session"), domain.attendanceSessionState)
         assertEquals(123, domain.activeAttendanceId)
+        assertEquals("2026-07-05T08:00:00.000Z", domain.checkedInAtIso)
+        assertEquals("2026-07-05T17:00:00.000Z", domain.checkedOutAtIso)
+        assertEquals(32_400L, domain.workDurationSeconds)
         assertEquals(AuthRuntimePolicy.SHARED_TTL_SECONDS, domain.cacheTtlSeconds)
     }
 
     @Test
-    fun `always uses shared ttl for status today cache`() {
+    fun `uses backend ttl for status today cache when meta is available`() {
         val response = createResponse(meta = TodayStatusMeta(cacheTtlSeconds = 120))
 
         val domain = response.toDomain()
 
-        assertEquals(AuthRuntimePolicy.SHARED_TTL_SECONDS, domain.cacheTtlSeconds)
+        assertEquals(120, domain.cacheTtlSeconds)
     }
 
     @Test
@@ -53,7 +56,10 @@ class TodayStatusResponseTest {
                 checkinWindow = CheckinWindow("07:00:00", "09:00:00"),
                 checkoutAutoTime = "17:00:00",
                 attendanceSessionState = AttendanceSessionStateDto(id = 2, key = "active", label = "Active Session"),
-                activeAttendanceId = 123
+                activeAttendanceId = 123,
+                checkedInAtIso = "2026-07-05T08:00:00.000Z",
+                checkedOutAtIso = "2026-07-05T17:00:00.000Z",
+                workDurationSeconds = 32_400L
             ),
             message = null,
             meta = meta

--- a/docs/superpowers/plans/2026-07-08-inf-229-android-home-today-status-dashboard.md
+++ b/docs/superpowers/plans/2026-07-08-inf-229-android-home-today-status-dashboard.md
@@ -1,0 +1,458 @@
+# INF-229 — Android Home Today Status Dashboard Implementation Plan
+
+## Status
+
+Draft plan — created after brainstorming approval on 2026-07-08.
+
+## Scope
+
+Implement/refactor Android Home dashboard so it consumes backend `status-today` through the existing clean architecture path and renders a factual Today Status dashboard.
+
+This plan is bounded to Android Home/data model/UI changes. It must not change backend contract, auth/session business logic, attendance action business logic, geofence lifecycle ownership, or bottom navigation.
+
+## Branch / Worktree
+
+Work only in:
+
+```text
+C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard
+```
+
+Branch:
+
+```text
+fix/android-home-today-status-dashboard
+```
+
+Do not edit main checkout:
+
+```text
+E:/skrisi/android
+```
+
+Main checkout was observed dirty on 2026-07-08 and must remain untouched for this task.
+
+## Reference Spec
+
+- `docs/superpowers/specs/2026-07-08-inf-229-android-home-today-status-dashboard.md`
+
+## Current Evidence Summary
+
+Before implementation:
+
+- Isolated worktree exists, branch is correct, working tree is clean.
+- `HomeScreen` is in `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt`.
+- `HomeViewModel` is in `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt`.
+- `GetTodayStatusUseCase(forceRefresh)` exists.
+- `AttendanceRepository.getTodayStatus(forceRefresh)` exists.
+- `ApiService.getTodayStatus()` exists for `GET /api/attendance/status-today`.
+- `HomeViewModel` does not yet consume `GetTodayStatusUseCase`.
+- `TodayStatusResponse`/domain/mapper do not yet fully align with `checked_in_at_iso`, `checked_out_at_iso`, `work_duration_seconds`, and backend TTL meta.
+- Home currently uses `HomeViewModel`, not `AttendanceViewModel`.
+- INF-222 reusable design components are available.
+
+## Phase 0 — Guardrails
+
+1. Confirm worktree and branch before editing:
+
+   ```bash
+   git -C "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" status --short
+   git -C "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" branch --show-current
+   ```
+
+2. Confirm no accidental main checkout edits.
+3. Keep all changes inside isolated worktree.
+4. Do not touch high-risk network/auth/session/geofence files unless required by compile evidence; if unexpectedly required, stop and report risk.
+
+## Phase 1 — Align TodayStatus contract model
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponse.kt`
+- `app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceModel.kt`
+- `app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapper.kt`
+
+Tasks:
+
+1. Add DTO fields to `TodayStatusData`:
+
+   ```kotlin
+   @field:SerializedName("checked_in_at_iso")
+   val checkedInAtIso: String? = null
+
+   @field:SerializedName("checked_out_at_iso")
+   val checkedOutAtIso: String? = null
+
+   @field:SerializedName("work_duration_seconds")
+   val workDurationSeconds: Long? = null
+   ```
+
+2. Add domain fields to `TodayStatus`:
+
+   ```kotlin
+   val checkedInAtIso: String? = null
+   val checkedOutAtIso: String? = null
+   val workDurationSeconds: Long? = null
+   ```
+
+3. Update `TodayStatusResponse.toDomain()`:
+
+   - Prefer `meta?.cacheTtlSeconds`.
+   - Fallback to `AuthRuntimePolicy.SHARED_TTL_SECONDS`.
+
+4. Update `TodayStatusData.toDomain()` to map new fields.
+
+Acceptance:
+
+- Existing repository cache path still compiles.
+- Existing callers that construct `TodayStatus` still compile due to default values, or are updated if needed.
+- TTL behavior follows backend meta when available.
+
+## Phase 2 — Add HomeViewModel dashboard status state
+
+File:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt`
+
+Tasks:
+
+1. Inject `GetTodayStatusUseCase`.
+2. Add `TodayStatus` dashboard state.
+
+Recommended state shape:
+
+```kotlin
+data class HomeTodayStatusUiState(
+    val status: UiState<TodayStatus> = UiState.Loading,
+    val warningMessage: String? = null,
+    val isRefreshing: Boolean = false
+)
+```
+
+Rationale:
+
+- Plain `UiState<TodayStatus>` can represent loading/success/error, but preserving existing data while showing a non-blocking refresh warning is awkward.
+- Wrapper keeps Home factual and avoids blanking the dashboard on refresh failure.
+
+3. Expose:
+
+```kotlin
+val todayStatusState: StateFlow<HomeTodayStatusUiState>
+```
+
+or equivalent if implementation chooses plain `UiState<TodayStatus>` plus warning state.
+
+4. Add:
+
+```kotlin
+fun fetchTodayStatus(forceRefresh: Boolean = false)
+fun refreshDashboard(forceRefresh: Boolean = true)
+```
+
+5. Initial load in `init`:
+
+```kotlin
+fetchTodayStatus(forceRefresh = false)
+```
+
+6. `refreshDashboard(forceRefresh = true)` should refresh:
+
+- today status with force refresh
+- attendance history
+- current address
+- internship dashboard data only if retained for non-primary details or compatibility
+
+7. Failure behavior:
+
+- If previous today status success exists, keep it and set warning.
+- If no previous data exists, set Today Status state to error.
+- Do not blank entire Home.
+
+Acceptance:
+
+- Home consumes `GetTodayStatusUseCase` directly.
+- Home does not consume `AttendanceViewModel`.
+- Force refresh path exists and calls use case with `true`.
+
+## Phase 3 — Build Home Today Status UI components
+
+Potential new files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/RecentAttendancePreview.kt` if useful
+
+Tasks:
+
+1. Create `HomeTodayStatusCard`.
+2. Use INF-222 components where they fit:
+
+   - `InfiniteCard` / `InfiniteSurface`
+   - `InfiniteButton`
+   - `InfiniteStatusPill`
+   - `InfiniteMetricCard`
+   - `InfiniteSectionHeader`
+   - `InfiniteInfoRow`
+   - `InfiniteInlineAlert`
+
+3. Card layout:
+
+   - soft white/lavender surface
+   - rounded corners
+   - subtle border/shadow
+   - compact two-column status grid
+   - status pill/header
+   - CTA or disabled state
+   - optional refresh action
+
+4. Render fields:
+
+   - Status
+   - Mode
+   - Attendance target location
+   - Check-in
+   - Check-out
+   - Work duration
+   - Geofence/target summary
+
+5. Add formatting helpers near component if not reused elsewhere:
+
+   - status key/label mapping
+   - mode formatting
+   - time fallback formatting
+   - ISO time formatting
+   - duration seconds to `h m`
+   - geofence summary text
+
+6. CTA behavior:
+
+   - Navigate to Attendance when allowed by status/capability.
+   - Do not submit check-in/check-out directly.
+
+Acceptance:
+
+- Today Status card can render loading, success, error, and refresh-warning states.
+- Card does not trigger geofence registration.
+- Card makes clear that `active_location` is an attendance target, not current GPS.
+
+## Phase 4 — Add Company Services role-gated grid
+
+File:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt`
+
+Tasks:
+
+1. Create static MVP `CompanyServicesGrid`.
+2. Show only for Employee/Admin/Management.
+3. Hide for Internship.
+4. Recommended MVP items:
+
+   - Attendance
+   - Time Off
+   - Attendance History
+   - WFA only if there is a clear existing route/tab action and it is not a preview list
+
+Implementation note:
+
+- If WFA navigation is not directly available from current Home parameters, omit WFA from MVP rather than adding new route coupling.
+- Do not create a backend Company Services contract.
+
+Acceptance:
+
+- Internship cannot see Company Services.
+- Company Services does not include WFA request/history preview list.
+
+## Phase 5 — Refactor Home role content
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt`
+
+Tasks:
+
+1. Collect today status state in `HomeScreen`.
+2. Pass today status state and refresh/navigation callbacks into role content.
+3. Employee/Admin/Management layout:
+
+   - Today/current location context
+   - Greeting/identity context if retained
+   - Today Status card
+   - Company Services grid
+   - Recent Attendance preview
+
+4. Internship layout:
+
+   - Today/current location context
+   - Greeting/identity context if retained
+   - Today Status card
+   - Recent Attendance preview
+   - No Company Services
+   - Remove old primary Internship summary grid if it conflicts with replacement rule
+
+5. Remove/avoid rendering from Home:
+
+   - Smart Reminder
+   - Personal Insight
+   - Discipline score/advice
+   - WFA booking/request preview list
+   - Large Internship service list
+
+6. Keep detailed booking history state only if still needed by legacy `DetailsMyBooking` route; do not render it on Home.
+
+Acceptance:
+
+- Existing Today/current location/attendance history concepts remain.
+- Old Home component surface is replaced by new dashboard surface.
+- No forbidden sections are rendered.
+
+## Phase 6 — Compile and fix issues
+
+Run from isolated worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+If build fails:
+
+1. Capture the relevant error.
+2. Fix compile issues in scoped files.
+3. Re-run `app:assembleDebug`.
+4. Do not claim passing unless command output confirms success.
+
+Recommended additional checks if feasible:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+If environment blocks Gradle due to known local loopback/env issues, report exact blocker and mark build as `Needs Verification`.
+
+## Phase 7 — Runtime/emulator verification
+
+If emulator/device and accounts are available:
+
+1. Install/open app.
+2. Login as Employee/Admin/Management.
+3. Go to Home.
+4. Capture screenshot/recording:
+
+   - Today Status card visible
+   - Company Services visible
+   - No Smart Reminder
+   - No WFA request/history preview
+
+5. Login/switch as Internship.
+6. Capture screenshot/recording:
+
+   - Today Status card visible
+   - Company Services hidden
+   - No Smart Reminder
+   - No WFA request/history preview
+
+7. Verify API/log evidence:
+
+   - Home calls `GET /api/attendance/status-today` on initial load or forced refresh.
+
+8. Verify duration formatting:
+
+   - `work_duration_seconds` displays as a human-readable duration.
+
+9. Verify refresh:
+
+   - Home refresh action or return from Attendance calls `refreshDashboard(forceRefresh=true)` and reloads status-today.
+
+If runtime cannot be executed, mark all visual/runtime evidence as `Needs Verification`.
+
+## Phase 8 — Review and PR notes
+
+Before claiming completion:
+
+1. Inspect diff:
+
+   ```bash
+   git -C "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" status --short
+   git -C "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" diff --stat
+   git -C "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" diff --name-status
+   ```
+
+2. Review for acceptance criteria.
+3. Prepare final response with required categories:
+
+   - Fact
+   - Assumption
+   - Mismatch
+   - Risk
+   - Needs Verification
+   - Recommendation
+   - Files/areas affected
+   - Verification evidence
+   - Docs/ADR update note
+   - PR/review note
+
+4. PR/review note should mention:
+
+   - Work continued in existing isolated Home/dashboard worktree.
+   - Implemented Home Today Status dashboard from `status-today` contract.
+   - Added/updated TodayStatus DTO/domain fields and mapper.
+   - HomeViewModel now consumes `GetTodayStatusUseCase` directly.
+   - Removed/avoided Smart Reminder and WFA booking/request preview from Home.
+   - Company Services shown only for Employee/Admin/Management.
+   - No backend/auth/session/bottom-nav/geofence lifecycle changes.
+   - Build evidence and runtime `Needs Verification` items.
+
+## Implementation Guardrails
+
+- Do not alter backend endpoints.
+- Do not alter auth/session refresh behavior.
+- Do not alter attendance check-in/check-out mutation semantics.
+- Do not add Home-owned geofence registration.
+- Do not add Smart Reminder, Personal Insight, discipline score, or recommendation content.
+- Do not show WFA request/history preview list on Home.
+- Do not show Company Services for Internship.
+- Do not edit main checkout.
+
+## Expected Files/Areas Affected
+
+Likely changed:
+
+- `app/src/main/java/com/example/infinite_track/data/soucre/network/response/TodayStatusResponse.kt`
+- `app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceModel.kt`
+- `app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceMapper.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt`
+
+Likely new:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt`
+
+Optional new if useful:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/home/content/RecentAttendancePreview.kt`
+
+Docs created:
+
+- `docs/superpowers/specs/2026-07-08-inf-229-android-home-today-status-dashboard.md`
+- `docs/superpowers/plans/2026-07-08-inf-229-android-home-today-status-dashboard.md`
+
+## Definition of Done for This Plan
+
+This work is Done only when:
+
+- Scope remains bounded to INF-229.
+- Affected files/areas are named.
+- DTO/domain/mapper align with required status-today fields.
+- HomeViewModel consumes `GetTodayStatusUseCase` directly.
+- Today Status card and role-gated Company Services are implemented.
+- Forbidden Home sections are not rendered.
+- Build evidence exists, or missing build is explicitly marked `Needs Verification` with blocker.
+- Runtime visual/API evidence exists, or missing runtime verification is explicitly marked `Needs Verification`.
+- Docs/ADR need is handled or explicitly not required.
+- PR/review note is available.

--- a/docs/superpowers/specs/2026-07-08-inf-229-android-home-today-status-dashboard.md
+++ b/docs/superpowers/specs/2026-07-08-inf-229-android-home-today-status-dashboard.md
@@ -1,0 +1,440 @@
+# INF-229 — Android Home Today Status Dashboard from status-today Contract
+
+## Status
+
+Draft — approved for implementation planning on 2026-07-08.
+
+## Owner
+
+Android
+
+## Branch / Worktree
+
+- Branch: `fix/android-home-today-status-dashboard`
+- Worktree: `C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard`
+- Base branch: `develop`
+
+## Problem
+
+The Android Home dashboard currently relies on legacy Home components and does not directly render the backend `status-today` attendance/session contract as the primary personal attendance surface. The existing Home structure also risks keeping duplicate or non-primary sections that are now owned by Attendance, WFA, or History flows.
+
+Home needs to become a factual personal attendance dashboard while preserving only the explicitly adopted concepts:
+
+- Today / current date context
+- Current location context
+- Today Status card
+- Company Services for eligible roles
+- Recent Attendance preview
+
+## Goal
+
+Implement a factual Home dashboard that consumes the existing backend `GET /api/attendance/status-today` contract through Android's existing clean architecture flow and renders today's personal attendance/session state.
+
+Required flow:
+
+```text
+ApiService.getTodayStatus()
+→ AttendanceRepository.getTodayStatus(forceRefresh)
+→ GetTodayStatusUseCase(forceRefresh)
+→ HomeViewModel
+→ Home UI Today Status card
+```
+
+Home remains a read-only dashboard surface except for navigation actions.
+
+## Non-goals
+
+Do not implement or change:
+
+- Backend contract or new backend endpoint
+- Auth/session business logic
+- Attendance check-in/check-out business logic
+- Direct check-in/check-out submit from Home
+- Bottom navigation
+- Active geofence registration or monitoring lifecycle from Home
+- Smart Reminder card
+- Personal Insight
+- Discipline score/trend/advice
+- AI-like recommendation/advice
+- WFA request/history preview list on Home
+- Backend Company Services contract
+
+## Source of Truth Boundary
+
+Backend remains authoritative for:
+
+- Attendance outcome
+- Auth/session validity
+- Booking approval semantics
+- Scheduled-job effects
+- Final reporting state
+
+Android Home is responsible for:
+
+- Displaying backend-provided personal attendance/session state
+- Displaying local current-location/address context
+- Displaying recent attendance preview from existing history flow
+- Navigating users to the correct existing flow when an action is available
+
+Android must not invent final attendance/reporting truth when backend state is unavailable.
+
+## Backend Contract
+
+Endpoint:
+
+```http
+GET /api/attendance/status-today
+```
+
+Expected fields:
+
+- `can_check_in`
+- `can_check_out`
+- `checked_in_at`
+- `checked_out_at`
+- `checked_in_at_iso`
+- `checked_out_at_iso`
+- `work_duration_seconds`
+- `active_mode`
+- `active_location`
+- `today_date`
+- `is_holiday`
+- `holiday_checkin_enabled`
+- `current_time`
+- `checkin_window`
+- `checkout_auto_time`
+- `attendance_session_state`
+- `active_attendance_id`
+- `meta.cache_ttl_seconds`
+
+## Important Semantics
+
+`status-today.active_location` means the primary attendance target for today.
+
+It is not:
+
+- Current GPS location
+- Android current address
+- Full geofence location list
+
+`active_location` may represent:
+
+- Current attendance location if attendance already exists today
+- Approved WFA booking location if there is an approved booking today
+- Default WFO location if there is no attendance/booking
+
+Home may display a geofence/target summary, but it must not register active geofence monitoring only because `active_location` exists.
+
+## Android Model Alignment
+
+If missing, update `TodayStatusResponse.kt` DTO with:
+
+```kotlin
+@SerializedName("checked_in_at_iso")
+val checkedInAtIso: String? = null
+
+@SerializedName("checked_out_at_iso")
+val checkedOutAtIso: String? = null
+
+@SerializedName("work_duration_seconds")
+val workDurationSeconds: Long? = null
+```
+
+Update domain `TodayStatus` with:
+
+```kotlin
+val checkedInAtIso: String? = null
+val checkedOutAtIso: String? = null
+val workDurationSeconds: Long? = null
+```
+
+Update mapper:
+
+- `TodayStatusData.toDomain()` maps `checkedInAtIso`, `checkedOutAtIso`, and `workDurationSeconds`.
+- `TodayStatusResponse.toDomain()` prefers `meta.cache_ttl_seconds` when available.
+- Fallback TTL remains `AuthRuntimePolicy.SHARED_TTL_SECONDS`.
+
+## HomeViewModel Requirements
+
+`HomeViewModel` must consume `GetTodayStatusUseCase` directly.
+
+Add dashboard-oriented status state, either:
+
+```kotlin
+val todayStatusState: StateFlow<UiState<TodayStatus>>
+```
+
+or an equivalent wrapper that can preserve existing data and expose refresh warnings.
+
+Required functions:
+
+```kotlin
+fetchTodayStatus(forceRefresh = false)
+refreshDashboard(forceRefresh = true)
+```
+
+Expected behavior:
+
+- Initial Home open calls `getTodayStatusUseCase(forceRefresh = false)`.
+- Pull-to-refresh, refresh button, or return from Attendance after check-in/check-out calls `getTodayStatusUseCase(forceRefresh = true)`.
+- If refresh fails and existing dashboard data exists, keep the existing data visible and show a factual non-blocking warning.
+- If no existing data exists, show an error/empty factual state for Today Status only, not a blank entire Home.
+
+Home must not reuse `AttendanceViewModel` for dashboard status consumption because that ViewModel owns attendance-flow side effects such as geofence registration, check-in/check-out action state, navigation to attendance flow, and map behavior.
+
+## Home Sections
+
+Adopted Home sections:
+
+1. Today / current date context
+2. Current location context
+3. Today Status card
+4. Company Services for Employee/Admin/Management only
+5. Recent Attendance preview
+
+Not adopted:
+
+1. Smart Reminder card
+2. Personal Insight
+3. Discipline score
+4. AI-like recommendation/advice
+5. WFA request/history preview list
+6. Riwayat Booking WFA section
+7. Large Internship service list
+8. Duplicate sections now owned by WFA tab or History tab
+
+## Role Visibility
+
+Company Services visible for:
+
+- Employee
+- Admin
+- Management
+
+Company Services hidden for:
+
+- Internship
+
+Internship still sees:
+
+- Today/current location context
+- Today Status card
+- Recent Attendance preview
+
+## Today Status Card Mapping
+
+Status:
+
+- Prefer `attendance_session_state.label`.
+- Fallback to `attendance_session_state.key`.
+- Map known keys:
+  - `not_started` → `Belum check-in` / `Not Started`
+  - `active` → `Sesi aktif` / `Active Session`
+  - `completed` → `Selesai` / `Completed`
+  - `unavailable` → `Tidak tersedia` / `Unavailable`
+
+Mode:
+
+- `active_mode`
+
+Location:
+
+- `active_location.description`
+- Label as attendance target, not current GPS location.
+
+Check-in:
+
+- Prefer `checked_in_at`.
+- Fallback to formatted `checked_in_at_iso`.
+- If unavailable, display `--`.
+
+Check-out:
+
+- Prefer `checked_out_at`.
+- Fallback to formatted `checked_out_at_iso`.
+- If unavailable, display `--`.
+
+Work Duration:
+
+- Format `work_duration_seconds` to hours/minutes.
+- If unavailable, display `--`.
+
+Geofence:
+
+- Display summary/status only.
+- If Android local geofence/current location summary is available, show it factually.
+- Otherwise show neutral attendance-target/geofence status.
+- Do not register geofence monitoring from Home.
+
+## CTA Rules
+
+If shown, Today Status CTA follows these rules:
+
+- `not_started` + `can_check_in=true` → navigate to Attendance / check-in flow.
+- `active` + `can_check_out=true` + `active_attendance_id != null` → navigate to Attendance / check-out flow.
+- `completed` → disabled/completed state.
+- `unavailable` → disabled/info state.
+
+Home does not submit check-in/check-out directly.
+
+## Visual Direction
+
+Use the uploaded/communicated Home visual reference only as layout/component reference.
+
+Adopt:
+
+- Today Status card
+- Semi-liquid soft white card surface
+- Compact two-column status grid
+- Status field
+- Mode field
+- Location/attendance target field
+- Check-in field
+- Check-out field
+- Work duration field
+- Geofence badge/summary field
+- Company Services grid for eligible roles
+
+Do not adopt:
+
+- Smart Reminder card
+
+Style:
+
+- Light theme only
+- Semi-liquid, Android-runtime friendly
+- Soft white/lavender surface
+- Rounded cards
+- Subtle borders
+- Subtle shadows
+- No heavy blur
+- No dark mode
+- No neon
+
+Brand tokens:
+
+- Primary purple: `#8A3DFF`
+- Secondary yellow: `#FFCD29`
+- Accent cyan: `#38F9F5`
+- Dark text: `#2F2530`
+- Light background: `#E7E4E9`
+- Soft alert: `#FF6B6B`
+
+## Component Guidance
+
+Prefer reusable INF-222 design-system components when they fit:
+
+- `InfiniteCard` / `InfiniteSurface`
+- `InfiniteButton`
+- `InfiniteStatusPill`
+- `InfiniteMetricCard`
+- `InfiniteTimelineRow`
+- `InfiniteSectionHeader`
+- `InfiniteInfoRow`
+- `InfiniteFilterChips`
+- `InfiniteBottomActionBar`
+- `InfiniteInlineAlert`
+
+Allowed Home-specific components:
+
+- `HomeTodayStatusCard`
+- `TodayStatusMetricItem`
+- `GeofenceStatusBadge`
+- `CompanyServicesGrid`
+- `CompanyServiceItem`
+- `RecentAttendanceCard`
+- `RecentAttendanceRow`
+- `HomeInlineWarning`
+
+## Current Repo Evidence Before Implementation
+
+Observed on 2026-07-08:
+
+- Existing isolated worktree/branch is clean and safe to continue.
+- `HomeScreen` currently routes by role to `InternshipContent` or `EmployeeAndManagerComponent`.
+- `HomeViewModel` does not yet inject `GetTodayStatusUseCase`.
+- `AttendanceRepository.getTodayStatus(forceRefresh)` exists.
+- `GetTodayStatusUseCase(forceRefresh)` exists.
+- `TodayStatusResponse` and domain `TodayStatus` do not yet include ISO/duration fields.
+- `TodayStatusResponse.toDomain()` currently uses shared TTL fallback directly instead of preferring `meta.cache_ttl_seconds`.
+- Home currently uses `HomeViewModel`, not `AttendanceViewModel`.
+- INF-222 design components exist and can be reused.
+
+## Acceptance Criteria
+
+- HomeViewModel consumes `GetTodayStatusUseCase` directly.
+- Home exposes `todayStatusState` or equivalent UI state.
+- Today Status card renders status, mode, location/attendance target, check-in, check-out, work duration, and geofence summary.
+- Android DTO/domain maps `checked_in_at_iso`, `checked_out_at_iso`, and `work_duration_seconds`.
+- Mapper uses backend `meta.cache_ttl_seconds` when available.
+- Home refresh can force `status-today` refresh.
+- Home does not reuse `AttendanceViewModel` for dashboard status consumption.
+- Home does not register active geofence only because `active_location` exists.
+- Smart Reminder card is not rendered.
+- Company Services appears only for Employee/Admin/Management.
+- Company Services is hidden for Internship.
+- WFA booking/request preview list is removed/not rendered from Home.
+- Existing Today/current location/attendance history concepts remain where relevant.
+- `./gradlew app:assembleDebug` passes, or failure is reported with evidence and status remains Needs Verification.
+
+## Verification
+
+Required local build:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+Recommended local checks:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime/emulator smoke when environment is available:
+
+- Open app.
+- Go to Home.
+- Observe Today Status card.
+- Observe Company Services visible for Employee/Admin/Management.
+- Observe Company Services hidden for Internship.
+- Observe no Smart Reminder card.
+- Observe no WFA request/history preview on Home.
+- Trigger refresh from Home if UI exposes refresh.
+- Return from Attendance after check-in/check-out and verify status refresh if feasible.
+
+Evidence needed:
+
+- Screenshot/recording of Home Today Status card.
+- Screenshot/recording showing Company Services for Employee/Admin/Management.
+- Screenshot/recording showing Company Services hidden for Internship.
+- Screenshot/recording showing no Smart Reminder card.
+- Screenshot/recording showing no WFA booking/request list on Home.
+- Log/API evidence that Home calls `GET /api/attendance/status-today`.
+- Evidence `work_duration_seconds` is displayed correctly as duration.
+- Evidence `refreshDashboard(forceRefresh=true)` reloads `status-today`.
+- Build evidence: `./gradlew app:assembleDebug`.
+
+If emulator/runtime cannot run, mark runtime items as `Needs Verification`.
+
+## Docs / ADR
+
+No major ADR is expected if implementation only changes Home screen consumption/rendering and does not change:
+
+- Auth/session contract or token refresh behavior
+- Attendance capture semantics
+- Backend source-of-truth expectations
+- Face verification or liveness behavior
+- Geofence/background location lifecycle
+- Navigation shell or role-visible route behavior
+- Network base URL or environment contract
+- Firebase distribution/signing/release workflow
+
+PR/review notes must mention:
+
+- `status-today` contract consumed directly by Home.
+- Home remains factual and backend/session-driven.
+- No Smart Reminder / Personal Insight.
+- No WFA request/history list on Home.
+- No geofence lifecycle ownership change.


### PR DESCRIPTION
## Summary

- Implemented INF-229 Home Today Status Dashboard from the existing `status-today` contract.
- Added INF-229 spec and implementation plan under `docs/superpowers/`.
- Aligned `TodayStatus` DTO/domain/mapper with `checked_in_at_iso`, `checked_out_at_iso`, and `work_duration_seconds`.
- Updated `TodayStatusResponse.toDomain()` to prefer valid backend `meta.cache_ttl_seconds` and fallback to `AuthRuntimePolicy.SHARED_TTL_SECONDS`.
- Updated `HomeViewModel` to consume `GetTodayStatusUseCase` directly and expose dashboard-oriented `HomeTodayStatusUiState`.
- Added Today Status card rendering factual status, mode, attendance target location, check-in, check-out, work duration, and display-only geofence/target summary.
- Reused `InlineRefreshingIndicator` for Home refresh state and added `InfiniteIcons.Refresh`.
- Added role-gated Company Services for Employee/Admin/Management only.
- Updated Internship Home to keep Today/current location, Today Status, and Recent Attendance while hiding Company Services.
- Removed old primary Home rendering of `MenuCard`, Internship summary grid, `ImageSlider`, and `CardAbsence`.
- Added Home `ON_RESUME` force refresh so returning from Attendance can reload `status-today` without moving attendance mutation or geofence lifecycle ownership into Home.
- No backend/auth/session/attendance mutation/geofence lifecycle/bottom-nav changes.

## Verification

Local verification was run from the isolated worktree:

```bash
JAVA_HOME="D:/Java_Home/java 1.8.2" \
PATH="/d/Java_Home/java 1.8.2/bin:$PATH" \
ANDROID_HOME="C:/Users/Febriyadi/AppData/Local/Android/Sdk" \
ANDROID_SDK_ROOT="C:/Users/Febriyadi/AppData/Local/Android/Sdk" \
"C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard/gradlew" \
-p "C:/Users/Febriyadi/.claude/worktrees/android-home-today-status-dashboard" \
--no-daemon app:assembleDebug
```

- `app:assembleDebug` — passed locally.
- `app:test` — completed successfully locally.
- `app:lint` — passed locally.
- `app:assembleRelease` — passed locally.
- `git diff --check` — no whitespace errors; CRLF warnings only for rewritten/new files.

Notes:

- The default local shell JDK 21 failed Gradle daemon startup on Windows with `java.io.IOException: Unable to establish loopback connection` before compilation.
- Local verification used the available local JDK 18 plus explicit `ANDROID_HOME` / `ANDROID_SDK_ROOT`.
- GitHub branch verification still needs to run on this PR; the workflow uses JDK 17 on `ubuntu-latest`.

## Needs Verification

Runtime/emulator evidence is still needed:

- Screenshot/recording of Home Today Status card.
- Screenshot/recording showing Company Services for Employee/Admin/Management.
- Screenshot/recording showing Company Services hidden for Internship.
- Screenshot/recording showing no Smart Reminder card.
- Screenshot/recording showing no WFA booking/request list on Home.
- Log/API evidence that Home calls `GET /api/attendance/status-today`.
- Evidence `work_duration_seconds` is displayed correctly as duration.
- Evidence returning from Attendance triggers `refreshDashboard(forceRefresh=true)` and reloads `status-today`.

## Docs / ADR

- Added focused INF-229 spec and implementation plan.
- No ADR required because this does not change backend contract, auth/session behavior, attendance mutation behavior, geofence lifecycle ownership, bottom navigation, or release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Home “Today Status” dashboard card showing check-in/out times, work duration, and status details (with inline refreshing and actionable states).
  * Expanded Company Services with a “More Services” tile leading to a new “Coming Soon” screen.
* **Bug Fixes**
  * Improved Today Status cache TTL handling by using backend-provided TTL when available (fallback preserved).
  * Enhanced refresh behavior: Home now reloads Today Status when returning to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->