### PR TITLE
fix: remove Profile hub title and local background

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -197,7 +197,6 @@ fun ProfileScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(InfiniteColors.AccountHubBackgroundGradient)
                 .padding(horizontal = 16.dp, vertical = 18.dp)
         ) {
             when (profileState) {
@@ -289,13 +288,6 @@ private fun AccountHubContent(
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
-        Text(
-            text = stringResource(R.string.account_hub_title),
-            style = headline2,
-            color = InfiniteColors.AccountHubTitle,
-            fontWeight = FontWeight.Bold
-        )
-
         IdentityHeroCard(
             user = user,
             role = role,


### PR DESCRIPTION
## Summary

Small Profile UI cleanup:

- removes the `My Profile` title text from the Profile / Account Hub main screen
- removes the screen-local background gradient from `ProfileScreen.kt`
- keeps the page using the existing global transparent/background layering, matching Home behavior

## Scope

- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`

## Guardrails

- No backend changes
- No auth/session changes
- No navigation changes
- No Edit Profile changes
- No About/MyDocument/PaySlip changes
- No bottom navigation changes

## Verification

Static checks completed:

- `git diff --check` passed
- grep confirmed `account_hub_title` is no longer rendered in `ProfileScreen.kt`
- grep confirmed the root `.background(InfiniteColors.AccountHubBackgroundGradient)` was removed from `ProfileScreen.kt`

Attempted build:

```bash
./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
```

Local build is still blocked before Kotlin compile by the known environment-level Gradle bootstrap issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

- `./gradlew app:assembleDebug` in CI/Android Studio or another environment without the loopback issue
- Runtime visual check:
  - Profile screen no longer shows `My Profile`
  - Profile screen uses the global transparent/background treatment like Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)
