### PR TITLE
fix: Tighten WFA requests title spacing

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -93,7 +93,7 @@ fun WfaRequestsScreen(
                 .nestedScroll(pullToRefreshConnection)
                 .padding(innerPadding)
                 .padding(horizontal = 20.dp),
-            contentPadding = PaddingValues(top = 24.dp, bottom = 16.dp),
+            contentPadding = PaddingValues(top = 0.dp, bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             item {


### PR DESCRIPTION
## Summary

Fixes the WFA Requests top spacing by removing the extra `LazyColumn` top content padding.

- Keeps the title/header style aligned with `Attendance History`.
- Removes the duplicate top gap caused by `contentPadding(top = 24.dp)` plus header vertical padding.
- No backend/auth/session/attendance business logic changes.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open WFA bottom tab.
- Confirm the title is closer to the top and no longer has excessive top spacing.
- Confirm list/filter/refresh still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted spacing at the top of the requests list so the content now aligns properly with the rest of the screen.
  * Preserved the existing bottom spacing for a consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->