### PR TITLE
INF-162: polish My Attendance Report UI

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceReportMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/attendance/AttendanceReportMapper.kt
@@ -1,33 +1,29 @@
-package com.example.infinite_track.presentation.mapper.attendance
+package com.example.infinite_track.data.mapper.attendance
 
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
-import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusInfo
+import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusKind
 import java.util.Locale
 import kotlin.math.roundToInt
 
-data class AttendanceReportStatus(
-    val label: String,
-    val variant: InfiniteStatusVariant
-)
-
-fun AttendanceRecord.reportStatus(): AttendanceReportStatus {
+fun AttendanceRecord.toReportStatus(): AttendanceReportStatusInfo {
     val statusValue = status.orEmpty().lowercase(Locale.ROOT)
     val categoryValue = category.orEmpty().lowercase(Locale.ROOT)
     return when {
         categoryValue.contains("alpha") || categoryValue.contains("absent") || statusValue.contains("alpha") || statusValue.contains("absent") -> {
-            AttendanceReportStatus("Alpha", InfiniteStatusVariant.Alpha)
+            AttendanceReportStatusInfo("Alpha", AttendanceReportStatusKind.Alpha)
         }
-        timeOut.isNullOrBlank() -> AttendanceReportStatus("Active Session", InfiniteStatusVariant.Active)
-        statusValue.contains("late") -> AttendanceReportStatus("Late", InfiniteStatusVariant.Late)
+        timeOut.isNullOrBlank() -> AttendanceReportStatusInfo("Active Session", AttendanceReportStatusKind.ActiveSession)
+        statusValue.contains("late") -> AttendanceReportStatusInfo("Late", AttendanceReportStatusKind.Late)
         statusValue.contains("on_time") || statusValue.contains("ontime") || statusValue.contains("on time") -> {
-            AttendanceReportStatus("On Time", InfiniteStatusVariant.OnTime)
+            AttendanceReportStatusInfo("On Time", AttendanceReportStatusKind.OnTime)
         }
-        statusValue.isNotBlank() -> AttendanceReportStatus(statusValue.toDisplayLabel(), InfiniteStatusVariant.Neutral)
-        else -> AttendanceReportStatus("Unknown", InfiniteStatusVariant.Unknown)
+        statusValue.isNotBlank() -> AttendanceReportStatusInfo(statusValue.toDisplayLabel(), AttendanceReportStatusKind.Neutral)
+        else -> AttendanceReportStatusInfo("Unknown", AttendanceReportStatusKind.Unknown)
     }
 }
 
-fun AttendanceRecord.fullDateLabel(): String {
+fun AttendanceRecord.toReportDateLabel(): String {
     return when {
         attendanceDate?.isNotBlank() == true -> attendanceDate.orEmpty()
         monthYear.isNotBlank() -> "$date $monthYear"
@@ -35,23 +31,23 @@ fun AttendanceRecord.fullDateLabel(): String {
     }
 }
 
-fun AttendanceRecord.workModeLabel(): String {
+fun AttendanceRecord.toReportWorkModeLabel(): String {
     val raw = category.orEmpty().trim()
     return if (raw.isBlank()) "Work mode unavailable" else raw.toDisplayLabel()
 }
 
-fun AttendanceRecord.timeRangeLabel(): String {
+fun AttendanceRecord.toReportTimeRangeLabel(): String {
     if (isAlphaRecord()) return "No check-in recorded"
     val checkOut = timeOut?.takeIf { it.isNotBlank() } ?: "Active"
     return "Check-in $timeIn · Check-out $checkOut"
 }
 
-fun AttendanceRecord.workHourLabel(): String? {
+fun AttendanceRecord.toReportWorkHourLabel(): String? {
     if (isAlphaRecord() || timeOut.isNullOrBlank()) return null
     return workHour?.takeIf { it.isNotBlank() }?.let { "Work hours $it" }
 }
 
-fun List<AttendanceRecord>.totalWorkHoursLabel(): String {
+fun List<AttendanceRecord>.toReportTotalWorkHoursLabel(): String {
     val minutes = mapNotNull { record ->
         if (record.isAlphaRecord() || record.timeOut.isNullOrBlank()) null else record.workHour?.toMinutesOrNull()
     }.sum()

--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceReportStatusInfo.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceReportStatusInfo.kt
@@ -1,0 +1,15 @@
+package com.example.infinite_track.domain.model.attendance
+
+enum class AttendanceReportStatusKind {
+    ActiveSession,
+    OnTime,
+    Late,
+    Alpha,
+    Unknown,
+    Neutral
+}
+
+data class AttendanceReportStatusInfo(
+    val label: String,
+    val kind: AttendanceReportStatusKind
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -26,7 +26,7 @@ fun InfiniteAttendanceModeDistributionCard(
     modifier: Modifier = Modifier,
     wfhCount: Int? = null,
     title: String = "Attendance Mode",
-    subtitle: String = "WFO and WFA distribution from backend summary",
+    subtitle: String? = "WFO and WFA distribution from backend summary",
     unavailableModeMessage: String? = "WFH is not shown because total_wfh is not available in the current Android model."
 ) {
     val totalKnown = wfoCount + wfaCount + (wfhCount ?: 0)

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
@@ -20,7 +20,7 @@ fun InfiniteAttendancePeriodFilterCard(
     onPeriodSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
     title: String = "Period Filter",
-    subtitle: String = "Choose the reporting period",
+    subtitle: String? = "Choose the reporting period",
     options: List<InfiniteFilterOption> = attendanceReportPeriodOptions
 ) {
     InfiniteGlassReportCard(modifier = modifier) {

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
@@ -24,7 +24,7 @@ fun InfiniteAttendanceReportActionsCard(
     onExportClick: () -> Unit = {},
     onShareClick: () -> Unit = {},
     title: String = "Export / Share Report",
-    subtitle: String = "PDF contract is shown honestly until runtime wiring is verified",
+    subtitle: String? = "PDF contract is shown honestly until runtime wiring is verified",
     supportMessage: String = "Expected export endpoint: ${AttendanceReportExportContract.exportPdfPath(selectedPeriod)}. Preview endpoint: ${AttendanceReportExportContract.PERSONAL_PDF_PREVIEW_PATH}. Wiring and backend runtime readiness need verification before enabling these actions."
 ) {
     InfiniteGlassReportCard(modifier = modifier) {

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummarySection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummarySection.kt
@@ -3,6 +3,7 @@ package com.example.infinite_track.presentation.design.components.data
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -18,49 +19,54 @@ fun InfiniteAttendanceReportSummarySection(
     attendanceRateSubtitle: String = "Backend denominator unavailable",
     workHoursSubtitle: String = "From returned work_hour",
     title: String = "Report Summary",
-    subtitle: String = "Backend summary with deterministic Android display"
+    subtitle: String? = null
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        InfiniteSectionHeader(
-            title = title,
-            subtitle = subtitle
-        )
+    InfiniteGlassReportCard(modifier = modifier) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            InfiniteSectionHeader(
+                title = title,
+                subtitle = subtitle
+            )
 
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteMetricCard(
-                title = "Attendance Rate",
-                value = attendanceRateValue,
-                subtitle = attendanceRateSubtitle,
-                semantic = InfiniteSemantic.Primary,
-                modifier = Modifier.weight(1f)
-            )
-            InfiniteMetricCard(
-                title = "Work Hours",
-                value = workHoursValue,
-                subtitle = workHoursSubtitle,
-                semantic = InfiniteSemantic.Info,
-                modifier = Modifier.weight(1f)
-            )
-        }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                InfiniteMetricCard(
+                    title = "Attendance Rate",
+                    value = attendanceRateValue,
+                    subtitle = attendanceRateSubtitle,
+                    semantic = InfiniteSemantic.Primary,
+                    modifier = Modifier.weight(1f)
+                )
+                InfiniteMetricCard(
+                    title = "Work Hours",
+                    value = workHoursValue,
+                    subtitle = workHoursSubtitle,
+                    semantic = InfiniteSemantic.Info,
+                    modifier = Modifier.weight(1f)
+                )
+            }
 
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteMetricCard(
-                title = "Late",
-                value = lateCount.toString(),
-                subtitle = "Backend summary",
-                semantic = InfiniteSemantic.Warning,
-                modifier = Modifier.weight(1f)
-            )
-            InfiniteMetricCard(
-                title = "Alpha",
-                value = alphaCount.toString(),
-                subtitle = "Backend summary",
-                semantic = InfiniteSemantic.Error,
-                modifier = Modifier.weight(1f)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                InfiniteMetricCard(
+                    title = "Late",
+                    value = lateCount.toString(),
+                    subtitle = "Backend summary",
+                    semantic = InfiniteSemantic.Warning,
+                    modifier = Modifier.weight(1f)
+                )
+                InfiniteMetricCard(
+                    title = "Alpha",
+                    value = alphaCount.toString(),
+                    subtitle = "Backend summary",
+                    semantic = InfiniteSemantic.Error,
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -3,6 +3,7 @@ package com.example.infinite_track.presentation.screen.history
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -92,6 +93,7 @@ fun HistoryScreen(
             state = lazyListState,
             modifier = Modifier
                 .fillMaxSize()
+                .padding(innerPadding)
                 .nestedScroll(pullToRefreshConnection),
             contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -23,14 +23,15 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.infinite_track.data.mapper.attendance.toReportDateLabel
+import com.example.infinite_track.data.mapper.attendance.toReportStatus
+import com.example.infinite_track.data.mapper.attendance.toReportTimeRangeLabel
+import com.example.infinite_track.data.mapper.attendance.toReportTotalWorkHoursLabel
+import com.example.infinite_track.data.mapper.attendance.toReportWorkHourLabel
+import com.example.infinite_track.data.mapper.attendance.toReportWorkModeLabel
 import com.example.infinite_track.domain.model.attendance.AttendancePeriod
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
-import com.example.infinite_track.presentation.mapper.attendance.fullDateLabel
-import com.example.infinite_track.presentation.mapper.attendance.reportStatus
-import com.example.infinite_track.presentation.mapper.attendance.timeRangeLabel
-import com.example.infinite_track.presentation.mapper.attendance.totalWorkHoursLabel
-import com.example.infinite_track.presentation.mapper.attendance.workHourLabel
-import com.example.infinite_track.presentation.mapper.attendance.workModeLabel
+import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusKind
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceModeDistributionCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendancePeriodFilterCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportActionsCard
@@ -43,6 +44,7 @@ import com.example.infinite_track.presentation.design.components.data.TimelineCo
 import com.example.infinite_track.presentation.design.components.state.InfiniteEmptyState
 import com.example.infinite_track.presentation.design.components.state.InfiniteErrorState
 import com.example.infinite_track.presentation.design.components.state.InfiniteLoadingState
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 
 @Composable
@@ -159,7 +161,7 @@ fun HistoryScreen(
                         item {
                             InfiniteAttendanceReportSummarySection(
                                 attendanceRateValue = "—",
-                                workHoursValue = remember(uiState.records) { uiState.records.totalWorkHoursLabel() },
+                                workHoursValue = remember(uiState.records) { uiState.records.toReportTotalWorkHoursLabel() },
                                 lateCount = uiState.summary?.totalLate ?: 0,
                                 alphaCount = uiState.summary?.totalAlpha ?: 0,
                                 subtitle = null
@@ -239,17 +241,26 @@ private fun ReportTimelineRow(
     record: AttendanceRecord,
     connectorPosition: TimelineConnectorPosition
 ) {
-    val status = record.reportStatus()
+    val status = record.toReportStatus()
     InfiniteAttendanceTimelineCard(
-        dateLabel = record.fullDateLabel(),
-        modeLabel = record.workModeLabel(),
-        timeRange = record.timeRangeLabel(),
+        dateLabel = record.toReportDateLabel(),
+        modeLabel = record.toReportWorkModeLabel(),
+        timeRange = record.toReportTimeRangeLabel(),
         statusLabel = status.label,
-        statusVariant = status.variant,
+        statusVariant = status.kind.toInfiniteStatusVariant(),
         connectorPosition = connectorPosition,
-        workHourLabel = record.workHourLabel(),
+        workHourLabel = record.toReportWorkHourLabel(),
         locationLabel = record.location
     )
+}
+
+private fun AttendanceReportStatusKind.toInfiniteStatusVariant(): InfiniteStatusVariant = when (this) {
+    AttendanceReportStatusKind.ActiveSession -> InfiniteStatusVariant.Active
+    AttendanceReportStatusKind.OnTime -> InfiniteStatusVariant.OnTime
+    AttendanceReportStatusKind.Late -> InfiniteStatusVariant.Late
+    AttendanceReportStatusKind.Alpha -> InfiniteStatusVariant.Alpha
+    AttendanceReportStatusKind.Unknown -> InfiniteStatusVariant.Unknown
+    AttendanceReportStatusKind.Neutral -> InfiniteStatusVariant.Neutral
 }
 
 private const val PullToRefreshThresholdPx = 160f

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -1,26 +1,24 @@
 package com.example.infinite_track.presentation.screen.history
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -35,7 +33,6 @@ import com.example.infinite_track.presentation.mapper.attendance.workModeLabel
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceModeDistributionCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendancePeriodFilterCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportActionsCard
-import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportHeroCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportNoticeCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportSummarySection
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceTimelineCard
@@ -54,6 +51,24 @@ fun HistoryScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lazyListState = rememberLazyListState()
+    val refreshDragDistance = remember { mutableStateOf(0f) }
+    val pullToRefreshConnection = remember(lazyListState, uiState.isLoading, uiState.isRefreshing) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0 && lazyListState.isAtTop() && !uiState.isLoading && !uiState.isRefreshing) {
+                    refreshDragDistance.value += available.y
+                    if (refreshDragDistance.value >= PullToRefreshThresholdPx) {
+                        refreshDragDistance.value = 0f
+                        viewModel.refreshHistory()
+                    }
+                }
+                if (available.y < 0) {
+                    refreshDragDistance.value = 0f
+                }
+                return Offset.Zero
+            }
+        }
+    }
     val shouldLoadMore = remember {
         derivedStateOf {
             val lastVisibleItem = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()
@@ -73,41 +88,22 @@ fun HistoryScreen(
         modifier = modifier.fillMaxSize(),
         containerColor = InfiniteColors.Transparent
     ) { innerPadding ->
-        Box(
+        LazyColumn(
+            state = lazyListState,
             modifier = Modifier
                 .fillMaxSize()
-                .background(InfiniteColors.AttendanceReportBackground)
-                .padding(innerPadding)
+                .nestedScroll(pullToRefreshConnection),
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            DecorativeOrb(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(top = 24.dp, end = 24.dp),
-                color = InfiniteColors.Accent.copy(alpha = 0.32f),
-                size = 132
-            )
-            DecorativeOrb(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(top = 128.dp, start = 18.dp),
-                color = InfiniteColors.Secondary.copy(alpha = 0.20f),
-                size = 84
-            )
-
-            LazyColumn(
-                state = lazyListState,
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                item { InfiniteAttendanceReportHeroCard() }
-
-                item {
-                    InfiniteAttendancePeriodFilterCard(
-                        selectedPeriod = uiState.selectedPeriod,
-                        onPeriodSelected = viewModel::onFilterChanged
-                    )
-                }
+            item {
+                InfiniteAttendancePeriodFilterCard(
+                    selectedPeriod = uiState.selectedPeriod,
+                    onPeriodSelected = viewModel::onFilterChanged,
+                    title = "My Attendance Report",
+                    subtitle = null
+                )
+            }
 
                 if (uiState.selectedPeriod == AttendancePeriod.CUSTOM) {
                     item {
@@ -115,6 +111,14 @@ fun HistoryScreen(
                             title = "Custom range needs verification",
                             message = "Date range picker is not available in this branch yet. The Custom filter is visible for the report contract, but runtime date-range behavior still needs verification."
                         )
+                    }
+                }
+
+                if (uiState.isRefreshing) {
+                    item {
+                        InfiniteGlassReportCard {
+                            InfiniteLoadingState(message = "Refreshing attendance report...")
+                        }
                     }
                 }
 
@@ -155,25 +159,31 @@ fun HistoryScreen(
                                 attendanceRateValue = "—",
                                 workHoursValue = remember(uiState.records) { uiState.records.totalWorkHoursLabel() },
                                 lateCount = uiState.summary?.totalLate ?: 0,
-                                alphaCount = uiState.summary?.totalAlpha ?: 0
+                                alphaCount = uiState.summary?.totalAlpha ?: 0,
+                                subtitle = null
                             )
                         }
 
                         item {
                             InfiniteAttendanceModeDistributionCard(
                                 wfoCount = uiState.summary?.totalWfo ?: 0,
-                                wfaCount = uiState.summary?.totalWfa ?: 0
+                                wfaCount = uiState.summary?.totalWfa ?: 0,
+                                subtitle = null,
+                                unavailableModeMessage = null
                             )
                         }
 
                         item {
-                            InfiniteAttendanceReportActionsCard(selectedPeriod = uiState.selectedPeriod)
+                            InfiniteAttendanceReportActionsCard(
+                                selectedPeriod = uiState.selectedPeriod,
+                                subtitle = null
+                            )
                         }
 
                         item {
                             InfiniteSectionHeader(
                                 title = "Attendance Timeline",
-                                subtitle = "Recent attendance records only"
+                                subtitle = null
                             )
                         }
 
@@ -218,7 +228,6 @@ fun HistoryScreen(
                         }
                     }
                 }
-            }
         }
     }
 }
@@ -241,15 +250,7 @@ private fun ReportTimelineRow(
     )
 }
 
-@Composable
-private fun DecorativeOrb(
-    modifier: Modifier,
-    color: Color,
-    size: Int
-) {
-    Box(
-        modifier = modifier
-            .size(size.dp)
-            .background(color, CircleShape)
-    )
-}
+private const val PullToRefreshThresholdPx = 160f
+
+private fun LazyListState.isAtTop(): Boolean =
+    firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
@@ -20,6 +20,7 @@ import javax.inject.Inject
  */
 data class HistoryScreenState(
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val isLoadingMore: Boolean = false,
     val canLoadMore: Boolean = true,
     val error: String? = null,
@@ -62,6 +63,7 @@ class HistoryViewModel @Inject constructor(
                 currentPage = 1,
                 canLoadMore = newPeriod != AttendancePeriod.CUSTOM,
                 isLoading = false,
+                isRefreshing = false,
                 isLoadingMore = false,
                 error = null
             )}
@@ -92,31 +94,35 @@ class HistoryViewModel @Inject constructor(
      * Refresh the attendance history (reload from first page)
      */
     fun refreshHistory() {
-        if (uiState.value.selectedPeriod == AttendancePeriod.CUSTOM) {
-            _uiState.update { it.copy(
-                currentPage = 1,
-                records = emptyList(),
-                summary = null,
-                canLoadMore = false,
-                isLoading = false,
-                isLoadingMore = false,
-                error = null
-            )}
+        val currentState = uiState.value
+        if (currentState.selectedPeriod == AttendancePeriod.CUSTOM || currentState.isLoading || currentState.isRefreshing) {
+            if (currentState.selectedPeriod == AttendancePeriod.CUSTOM) {
+                _uiState.update { it.copy(
+                    currentPage = 1,
+                    records = emptyList(),
+                    summary = null,
+                    canLoadMore = false,
+                    isLoading = false,
+                    isRefreshing = false,
+                    isLoadingMore = false,
+                    error = null
+                )}
+            }
             return
         }
 
-        _uiState.update { it.copy(
-            currentPage = 1,
-            records = emptyList()
-        )}
-        loadHistory(isRefresh = true)
+        _uiState.update { it.copy(currentPage = 1) }
+        loadHistory(isRefresh = true, isPullRefresh = true)
     }
 
     /**
      * Load attendance history with the current settings
      * @param isRefresh Whether to refresh the data (true) or append to existing data (false)
      */
-    private fun loadHistory(isRefresh: Boolean) {
+    private fun loadHistory(
+        isRefresh: Boolean,
+        isPullRefresh: Boolean = false
+    ) {
         // Cancel any ongoing loading job
         loadingJob?.cancel()
 
@@ -126,7 +132,8 @@ class HistoryViewModel @Inject constructor(
 
         // Update state to show loading
         _uiState.update { it.copy(
-            isLoading = isRefresh,
+            isLoading = isRefresh && !isPullRefresh,
+            isRefreshing = isPullRefresh,
             isLoadingMore = !isRefresh,
             error = null
         )}
@@ -144,6 +151,7 @@ class HistoryViewModel @Inject constructor(
                 _uiState.update { currentState ->
                     currentState.copy(
                         isLoading = false,
+                        isRefreshing = false,
                         isLoadingMore = false,
                         summary = historyPage.summary,
                         records = if (isRefresh) historyPage.records else currentState.records + historyPage.records,
@@ -156,6 +164,7 @@ class HistoryViewModel @Inject constructor(
                 // Update state to show error
                 _uiState.update { it.copy(
                     isLoading = false,
+                    isRefreshing = false,
                     isLoadingMore = false,
                     canLoadMore = false,
                     error = error.message ?: "Unknown error occurred"
@@ -179,6 +188,7 @@ class HistoryViewModel @Inject constructor(
                 summary = null,
                 canLoadMore = it.selectedPeriod != AttendancePeriod.CUSTOM,
                 isLoading = false,
+                isRefreshing = false,
                 isLoadingMore = false,
                 error = null
             )}

--- a/app/src/test/java/com/example/infinite_track/data/mapper/attendance/AttendanceReportMapperTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/mapper/attendance/AttendanceReportMapperTest.kt
@@ -1,15 +1,15 @@
-package com.example.infinite_track.presentation.mapper.attendance
+package com.example.infinite_track.data.mapper.attendance
 
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
-import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
-class AttendanceReportUiMapperTest {
+class AttendanceReportMapperTest {
 
     @Test
-    fun reportStatus_returnsAlpha_whenStatusIndicatesAlpha() {
+    fun toReportStatus_returnsAlpha_whenStatusIndicatesAlpha() {
         val record = attendanceRecord(
             status = "alpha",
             category = "WFO",
@@ -17,14 +17,14 @@ class AttendanceReportUiMapperTest {
             workHour = null
         )
 
-        val status = record.reportStatus()
+        val status = record.toReportStatus()
 
         assertEquals("Alpha", status.label)
-        assertEquals(InfiniteStatusVariant.Alpha, status.variant)
+        assertEquals(AttendanceReportStatusKind.Alpha, status.kind)
     }
 
     @Test
-    fun reportStatus_returnsActiveSession_whenCheckoutIsMissingForNonAlphaRecord() {
+    fun toReportStatus_returnsActiveSession_whenCheckoutIsMissingForNonAlphaRecord() {
         val record = attendanceRecord(
             status = "on_time",
             category = "WFA",
@@ -32,15 +32,15 @@ class AttendanceReportUiMapperTest {
             workHour = null
         )
 
-        val status = record.reportStatus()
+        val status = record.toReportStatus()
 
         assertEquals("Active Session", status.label)
-        assertEquals(InfiniteStatusVariant.Active, status.variant)
-        assertNull(record.workHourLabel())
+        assertEquals(AttendanceReportStatusKind.ActiveSession, status.kind)
+        assertNull(record.toReportWorkHourLabel())
     }
 
     @Test
-    fun totalWorkHoursLabel_excludesAlphaAndActiveSessionRecords() {
+    fun toReportTotalWorkHoursLabel_excludesAlphaAndActiveSessionRecords() {
         val records = listOf(
             attendanceRecord(status = "on_time", timeOut = "17:00", workHour = "08:00"),
             attendanceRecord(status = "late", timeOut = "17:30", workHour = "07:30"),
@@ -48,24 +48,24 @@ class AttendanceReportUiMapperTest {
             attendanceRecord(status = "on_time", timeOut = null, workHour = "02:00")
         )
 
-        assertEquals("15h 30m", records.totalWorkHoursLabel())
+        assertEquals("15h 30m", records.toReportTotalWorkHoursLabel())
     }
 
     @Test
-    fun workModeLabel_formatsBackendCategoryWithoutInventingMode() {
+    fun toReportWorkModeLabel_formatsBackendCategoryWithoutInventingMode() {
         val record = attendanceRecord(category = "work_from_office")
 
-        assertEquals("Work From Office", record.workModeLabel())
+        assertEquals("Work From Office", record.toReportWorkModeLabel())
     }
 
     @Test
-    fun reportStatus_returnsUnknown_whenBackendStatusIsMissing() {
+    fun toReportStatus_returnsUnknown_whenBackendStatusIsMissing() {
         val record = attendanceRecord(status = "", timeOut = "17:00")
 
-        val status = record.reportStatus()
+        val status = record.toReportStatus()
 
         assertEquals("Unknown", status.label)
-        assertEquals(InfiniteStatusVariant.Unknown, status.variant)
+        assertEquals(AttendanceReportStatusKind.Unknown, status.kind)
     }
 
     private fun attendanceRecord(


### PR DESCRIPTION
## Summary
- Polished My Attendance Report UI layout to better match the approved visual reference.
- Removed local screen background so the page follows the existing global My Attendance Report background.
- Removed the adopted-as-out-of-scope hero/top brand treatment (logo, Infinite Track, profile icon) and the subtitle/personal insight treatment.
- Switched refresh interaction to pull-to-refresh only, aligned with the WFH/WFA request page pattern.
- Added honest Custom unavailable handling in both History report and Details My Attendance.

## Scope notes
- Personal Insight remains intentionally excluded.
- No backend/auth/session changes.
- No attendance check-in/check-out business logic changes.
- Export/share remains UI-only and disabled/honest; endpoint constants are kept as contract reference only.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual verification is still needed on `develop` after merge/pull:
- Confirm layout no longer overlaps
- Confirm no local background collision
- Confirm pull-to-refresh works only on drag-down, not regular taps
- Confirm Custom unavailable state in History and Details
- Confirm filter, summary, mode, timeline, and export/share layout match expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
