### PR TITLE
fix: Reduce WFA requests header top spacing

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -184,7 +184,7 @@ private fun WfaRequestsHeader() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 24.dp),
+            .padding(top = 6.dp, bottom = 12.dp),
         horizontalArrangement = Arrangement.Center
     ) {
         Text(


### PR DESCRIPTION
## Summary

Reduces the excessive top spacing on the WFA Requests screen.

- Keeps the centered `WFA Requests` title and `headline3` style.
- Changes header padding from symmetric `vertical = 24.dp` to `top = 6.dp, bottom = 12.dp`.
- No backend/auth/session/attendance logic changes.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open WFA tab.
- Confirm purple top area above content is reduced.
- Confirm title remains centered and visually acceptable.
- Confirm list/filter/refresh still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the header spacing on the WFA Requests screen for a cleaner layout, with separate top and bottom padding values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->