### PR TITLE
fix: clear auth back stack after login

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/AppNavGraph.kt
@@ -29,12 +29,8 @@ fun NavGraphBuilder.appNavGraph(
         composable(Screen.Login.route) {
             LoginScreen(
                 navigateToHome = {
-                    // Navigate to main_graph after successful login
                     navController.navigate(Screen.Home.route) {
-                        // Clear backstack after successful login
-                        popUpTo(navController.graph.startDestinationId) {
-                            inclusive = true
-                        }
+                        popUpTo(0) { inclusive = true }
                         launchSingleTop = true
                     }
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
@@ -42,18 +42,14 @@ fun SplashScreen(
         when (navigationState) {
             is SplashNavigationState.NavigateToHome -> {
                 navController.navigate(Screen.Home.route) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        saveState = true
-                    }
+                    popUpTo(0) { inclusive = true }
                     launchSingleTop = true
                 }
             }
 
             is SplashNavigationState.NavigateToLogin -> {
                 navController.navigate(Screen.Login.route) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        saveState = true
-                    }
+                    popUpTo(0) { inclusive = true }
                     launchSingleTop = true
                 }
             }
@@ -100,9 +96,7 @@ fun SplashScreen(
 
                 Button(onClick = {
                     navController.navigate(Screen.Login.route) {
-                        popUpTo(navController.graph.startDestinationId) {
-                            saveState = true
-                        }
+                        popUpTo(0) { inclusive = true }
                         launchSingleTop = true
                     }
                 }) {

--- a/docs/superpowers/plans/2026-07-08-android-login-backstack-fix.md
+++ b/docs/superpowers/plans/2026-07-08-android-login-backstack-fix.md
@@ -1,0 +1,44 @@
+# Android Login Back Stack Fix
+
+## Context
+
+After a successful login, pressing the system Back button could return the user to the Login screen. That is incorrect for the authenticated root flow: once Login succeeds and the app enters the main shell, Back should not reveal Login again.
+
+## Root cause
+
+The login-success path navigated to `Screen.Home` with `popUpTo(navController.graph.startDestinationId)`. In the observed flow, Splash can already be removed/replaced before Login, so the start destination is not a reliable anchor for clearing the auth stack. Home was therefore pushed above Login, leaving Login reachable through system Back.
+
+## Fix
+
+Use the same root-stack clearing style already used by forced re-auth navigation:
+
+```kotlin
+popUpTo(0) { inclusive = true }
+```
+
+Applied to:
+
+- Login success -> Home
+- Splash session-valid redirect -> Home
+- Splash session-invalid/manual login -> Login
+
+## Expected behavior
+
+- Splash -> Login -> successful login -> Home/Main shell.
+- Pressing Back from Home/Main shell should exit the app or follow main-shell behavior, not return to Login.
+- Forced re-auth/session-expired navigation to Login remains unchanged and still clears the stack.
+
+## Scope guard
+
+- No backend/auth contract changes.
+- No token/session validity changes.
+- No login business logic changes.
+- No bottom-bar or attendance flow changes.
+
+## Verification needed
+
+- Build: `./gradlew app:assembleDebug`.
+- Runtime smoke on emulator/device:
+  - fresh unauthenticated launch -> Login -> successful login -> Home -> Back must not show Login
+  - authenticated launch via Splash -> Home -> Back must not show Splash/Login
+  - session-expired/forced reauth -> Login still works


### PR DESCRIPTION
## Summary

Fixes a root navigation back-stack bug where pressing Android Back after a successful login could return the user to the Login screen.

- Clears the auth/splash stack when Login succeeds and navigates to the main shell.
- Clears the splash stack for Splash -> Home and Splash -> Login redirects.
- Keeps forced re-auth/session-expired navigation behavior unchanged.
- Adds a focused implementation note for the root cause and expected runtime behavior.

## Root cause

The login-success path navigated to `Screen.Home` with `popUpTo(navController.graph.startDestinationId)`. In the observed flow, Splash can already be removed/replaced before Login, so the start destination is not a reliable anchor for clearing Login from the root stack. Home could be pushed above Login, making Login reachable with system Back.

## Fix

Use the same root-stack clearing style already used by forced re-auth navigation:

```kotlin
popUpTo(0) { inclusive = true }
```

Applied to:

- Login success -> Home
- Splash session-valid redirect -> Home
- Splash session-invalid/manual Login -> Login

## Scope guard

- No backend/auth contract changes.
- No token/session validity changes.
- No login business logic changes.
- No auth refresh changes.
- No attendance or bottom-bar changes.

## Verification

Attempted from isolated worktree:

- `./gradlew app:assembleDebug`

Blocked by local Gradle/JVM issue before the task ran:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

Runtime/emulator smoke required:

- Fresh unauthenticated launch -> Login -> successful login -> Home -> Back must not show Login.
- Authenticated launch via Splash -> Home -> Back must not show Splash/Login.
- Session-expired/forced reauth -> Login still works.

## Worktree

Work done in isolated branch/worktree:

- Branch: `fix/android-login-backstack`
- Worktree: `C:\Users\Febriyadi\.claude\worktrees\android-login-backstack-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
