### PR TITLE
fix: Align WFA requests page surface spacing

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -92,8 +92,8 @@ fun WfaRequestsScreen(
                 .fillMaxSize()
                 .nestedScroll(pullToRefreshConnection)
                 .padding(innerPadding)
-                .padding(horizontal = 20.dp),
-            contentPadding = PaddingValues(top = 0.dp, bottom = 16.dp),
+                .padding(start = 20.dp, top = 20.dp, end = 20.dp, bottom = 12.dp),
+            contentPadding = PaddingValues(0.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             item {
@@ -184,7 +184,7 @@ private fun WfaRequestsHeader() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 6.dp, bottom = 12.dp),
+            .padding(bottom = 12.dp),
         horizontalArrangement = Arrangement.Center
     ) {
         Text(


### PR DESCRIPTION
## Summary

Aligns the WFA Requests page surface spacing with the Home page primary-tab layout.

- Applies Home-like page padding to WFA content: `start = 20.dp, top = 20.dp, end = 20.dp, bottom = 12.dp`.
- Removes duplicate list content padding by using `PaddingValues(0.dp)`.
- Keeps the `WFA Requests` header centered with `headline3` while removing extra top padding from the header itself.
- No backend/auth/session/attendance logic changes.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open Home and WFA tabs.
- Confirm WFA content top spacing feels consistent with Home.
- Confirm WFA bottom spacing above bottom bar feels consistent with Home.
- Confirm list/filter/refresh still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
