### PR TITLE
INF-162: align History page spacing with Home

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -32,39 +32,40 @@ fun InfiniteAttendanceModeDistributionCard(
     val totalKnown = wfoCount + wfaCount + (wfhCount ?: 0)
 
     InfiniteGlassReportCard(modifier = modifier) {
-        InfiniteSectionHeader(
-            title = title,
-            subtitle = subtitle
-        )
-        Spacer(modifier = Modifier.height(14.dp))
-        InfiniteAttendanceModeDistributionRow(
-            label = "WFO",
-            count = wfoCount,
-            total = totalKnown,
-            color = InfiniteColors.Primary
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-        InfiniteAttendanceModeDistributionRow(
-            label = "WFA",
-            count = wfaCount,
-            total = totalKnown,
-            color = InfiniteColors.Accent
-        )
-        wfhCount?.let { count ->
-            Spacer(modifier = Modifier.height(12.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            InfiniteSectionHeader(
+                title = title,
+                subtitle = subtitle
+            )
             InfiniteAttendanceModeDistributionRow(
-                label = "WFH",
-                count = count,
+                label = "WFO",
+                count = wfoCount,
                 total = totalKnown,
-                color = InfiniteColors.Secondary
+                color = InfiniteColors.Primary,
+                unitLabel = "days"
             )
-        } ?: unavailableModeMessage?.let { message ->
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = message,
-                color = InfiniteColors.AttendanceReportMutedText,
-                style = MaterialTheme.typography.bodySmall
+            InfiniteAttendanceModeDistributionRow(
+                label = "WFA",
+                count = wfaCount,
+                total = totalKnown,
+                color = InfiniteColors.Accent,
+                unitLabel = "days"
             )
+            wfhCount?.let { count ->
+                InfiniteAttendanceModeDistributionRow(
+                    label = "WFH",
+                    count = count,
+                    total = totalKnown,
+                    color = InfiniteColors.Secondary,
+                    unitLabel = "days"
+                )
+            } ?: unavailableModeMessage?.let { message ->
+                Text(
+                    text = message,
+                    color = InfiniteColors.AttendanceReportMutedText,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
@@ -1,5 +1,7 @@
 package com.example.infinite_track.presentation.design.components.data
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
@@ -24,16 +26,17 @@ fun InfiniteAttendancePeriodFilterCard(
     options: List<InfiniteFilterOption> = attendanceReportPeriodOptions
 ) {
     InfiniteGlassReportCard(modifier = modifier) {
-        InfiniteSectionHeader(
-            title = title,
-            subtitle = subtitle
-        )
-        Spacer(modifier = Modifier.height(12.dp))
-        InfiniteAttendancePeriodFilter(
-            selectedPeriod = selectedPeriod,
-            onPeriodSelected = onPeriodSelected,
-            options = options
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            InfiniteSectionHeader(
+                title = title,
+                subtitle = subtitle
+            )
+            InfiniteAttendancePeriodFilter(
+                selectedPeriod = selectedPeriod,
+                onPeriodSelected = onPeriodSelected,
+                options = options
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
@@ -1,9 +1,8 @@
 package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,32 +27,32 @@ fun InfiniteAttendanceReportActionsCard(
     supportMessage: String = "Expected export endpoint: ${AttendanceReportExportContract.exportPdfPath(selectedPeriod)}. Preview endpoint: ${AttendanceReportExportContract.PERSONAL_PDF_PREVIEW_PATH}. Wiring and backend runtime readiness need verification before enabling these actions."
 ) {
     InfiniteGlassReportCard(modifier = modifier) {
-        InfiniteSectionHeader(
-            title = title,
-            subtitle = subtitle
-        )
-        Spacer(modifier = Modifier.height(14.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteButton(
-                text = "Export PDF",
-                onClick = onExportClick,
-                variant = InfiniteButtonVariant.Primary,
-                state = if (exportEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
-                modifier = Modifier.weight(1f)
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            InfiniteSectionHeader(
+                title = title,
+                subtitle = subtitle
             )
-            InfiniteButton(
-                text = "Share Report",
-                onClick = onShareClick,
-                variant = InfiniteButtonVariant.Glass,
-                state = if (shareEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
-                modifier = Modifier.weight(1f)
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                InfiniteButton(
+                    text = "Export PDF",
+                    onClick = onExportClick,
+                    variant = InfiniteButtonVariant.Primary,
+                    state = if (exportEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
+                    modifier = Modifier.weight(1f)
+                )
+                InfiniteButton(
+                    text = "Share Report",
+                    onClick = onShareClick,
+                    variant = InfiniteButtonVariant.Glass,
+                    state = if (shareEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            Text(
+                text = supportMessage,
+                color = InfiniteColors.AttendanceReportMutedText,
+                style = MaterialTheme.typography.bodySmall
             )
         }
-        Spacer(modifier = Modifier.height(10.dp))
-        Text(
-            text = supportMessage,
-            color = InfiniteColors.AttendanceReportMutedText,
-            style = MaterialTheme.typography.bodySmall
-        )
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -97,8 +97,8 @@ fun HistoryScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
                 .nestedScroll(pullToRefreshConnection),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            contentPadding = PaddingValues(start = 20.dp, top = 4.dp, end = 20.dp, bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             item {
                 InfiniteAttendancePeriodFilterCard(


### PR DESCRIPTION
## Summary
- Aligns My Attendance Report page spacing with the Home screen rhythm.
- Reduces top and bottom spacing so the page sits in the shell more consistently.
- Fixes overlapping report sections by stacking filter, mode, and export card content vertically.
- Keeps pull-to-refresh as drag-down only and preserves the honest Custom unavailable state.

## Scope notes
- No backend/auth/session changes.
- No attendance capture business logic changes.
- No PDF export implementation changes; export/share remains UI-only and disabled/honest.
- No Personal Insight added.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual verification is still needed on `develop` after merge/pull:
- Confirm top spacing matches Home screen feel
- Confirm bottom spacing above bottom bar matches Home screen feel
- Confirm filter/title no longer overlap
- Confirm attendance mode section no longer overlaps
- Confirm export/share section no longer overlaps
- Confirm pull-to-refresh still works on drag-down only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated several attendance-related cards to use more consistent spacing and layout structure.
  * Adjusted history list spacing and padding for a cleaner, more balanced screen.
* **Style**
  * Standardized vertical gaps across report, filter, and distribution sections for a more polished UI.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->