### PR TITLE
fix: Align WFA requests scaffold with home surface

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -82,103 +81,96 @@ fun WfaRequestsScreen(
         onLoadMore = viewModel::loadMore
     )
 
-    Scaffold(
-        modifier = modifier.fillMaxSize(),
-        containerColor = Color.Transparent
-    ) { innerPadding ->
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .fillMaxSize()
-                .nestedScroll(pullToRefreshConnection)
-                .padding(innerPadding)
-                .padding(start = 20.dp, top = 20.dp, end = 20.dp, bottom = 12.dp),
-            contentPadding = PaddingValues(0.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(pullToRefreshConnection)
+            .padding(start = 20.dp, top = 20.dp, end = 20.dp, bottom = 12.dp),
+        contentPadding = PaddingValues(0.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            WfaRequestsHeader()
+        }
+
+        if (uiState.isRefreshing) {
             item {
-                WfaRequestsHeader()
+                InlineRefreshingIndicator(message = "Refreshing WFA requests...")
+            }
+        }
+
+        item {
+            WfaRequestStatusSummary(summary = uiState.summary)
+        }
+
+        item {
+            WfaRequestFilterChips(
+                selectedFilter = uiState.selectedFilter,
+                onFilterSelected = viewModel::onFilterSelected
+            )
+        }
+
+        item {
+            Text(
+                text = "Recent WFA Requests",
+                style = MaterialTheme.typography.titleLarge,
+                color = Purple_500,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        when {
+            uiState.isLoading -> {
+                item { LoadingState() }
             }
 
-            if (uiState.isRefreshing) {
+            uiState.errorMessage != null && uiState.bookings.isEmpty() -> {
                 item {
-                    InlineRefreshingIndicator(message = "Refreshing WFA requests...")
+                    ErrorState(
+                        message = uiState.errorMessage ?: "Unable to load WFA requests.",
+                        onRetry = viewModel::retry
+                    )
                 }
             }
 
-            item {
-                WfaRequestStatusSummary(summary = uiState.summary)
+            uiState.isEmpty -> {
+                item { EmptyState() }
             }
 
-            item {
-                WfaRequestFilterChips(
-                    selectedFilter = uiState.selectedFilter,
-                    onFilterSelected = viewModel::onFilterSelected
-                )
-            }
-
-            item {
-                Text(
-                    text = "Recent WFA Requests",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = Purple_500,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            when {
-                uiState.isLoading -> {
-                    item { LoadingState() }
+            else -> {
+                items(
+                    items = uiState.bookings,
+                    key = { booking -> "${booking.bookingId}-${booking.scheduleDateRaw}-${booking.statusKey}" }
+                ) { booking ->
+                    WfaRequestCard(booking = booking)
                 }
 
-                uiState.errorMessage != null && uiState.bookings.isEmpty() -> {
+                if (uiState.isLoadingMore) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = Blue_500)
+                        }
+                    }
+                }
+
+                if (uiState.errorMessage != null && uiState.bookings.isNotEmpty()) {
                     item {
                         ErrorState(
-                            message = uiState.errorMessage ?: "Unable to load WFA requests.",
-                            onRetry = viewModel::retry
+                            message = uiState.errorMessage ?: "Unable to load more WFA requests.",
+                            onRetry = viewModel::loadMore
                         )
-                    }
-                }
-
-                uiState.isEmpty -> {
-                    item { EmptyState() }
-                }
-
-                else -> {
-                    items(
-                        items = uiState.bookings,
-                        key = { booking -> "${booking.bookingId}-${booking.scheduleDateRaw}-${booking.statusKey}" }
-                    ) { booking ->
-                        WfaRequestCard(booking = booking)
-                    }
-
-                    if (uiState.isLoadingMore) {
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                CircularProgressIndicator(color = Blue_500)
-                            }
-                        }
-                    }
-
-                    if (uiState.errorMessage != null && uiState.bookings.isNotEmpty()) {
-                        item {
-                            ErrorState(
-                                message = uiState.errorMessage ?: "Unable to load more WFA requests.",
-                                onRetry = viewModel::loadMore
-                            )
-                        }
                     }
                 }
             }
         }
     }
 }
-
 @Composable
 private fun WfaRequestsHeader() {
     Row(


### PR DESCRIPTION
## Summary

Aligns the WFA Requests screen structure with the Home tab surface.

- Removes the nested child `Scaffold` from `WfaRequestsScreen`.
- Lets the WFA page rely on the parent `MainScreen` scaffold, like Home does.
- Keeps the WFA content on a direct `LazyColumn` root with Home-like page padding.
- Removes child `Scaffold` inner padding that caused inconsistent top/bottom spacing against the top screen and bottom bar.
- No backend/auth/session/attendance business logic changes.

## Why

Home is already hosted by `MainScreen` scaffold and renders its content directly. WFA had a nested `Scaffold`, which introduced a different surface/inset behavior. This made WFA spacing feel inconsistent with Home and the bottom bar.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open Home and WFA tabs.
- Confirm WFA top spacing follows Home-like surface behavior.
- Confirm WFA bottom spacing above bottom bar follows Home-like surface behavior.
- Confirm list/filter/refresh still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
