### PR TITLE
INF-216: register FileProvider for report PDF flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,16 @@
             android:name="com.mapbox.maps.AccessToken"
             android:value="${MAPBOX_PUBLIC_TOKEN}" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceReportPdfRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceReportPdfRepositoryImpl.kt
@@ -1,0 +1,85 @@
+package com.example.infinite_track.data.repository.attendance
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.example.infinite_track.data.soucre.network.retrofit.ApiService
+import com.example.infinite_track.domain.model.attendance.AttendanceReportPdfResult
+import com.example.infinite_track.domain.repository.AttendanceReportPdfRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.ResponseBody
+import retrofit2.Response
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AttendanceReportPdfRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val apiService: ApiService
+) : AttendanceReportPdfRepository {
+
+    override suspend fun previewAttendanceReportPdf(
+        period: String,
+        startDate: String?,
+        endDate: String?,
+        timezone: String?
+    ): Result<AttendanceReportPdfResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            val response = apiService.previewAttendanceReportPdf(period, startDate, endDate, timezone)
+            savePdfResponse(response, defaultPrefix = "attendance-report-preview")
+        }
+    }
+
+    override suspend fun exportAttendanceReportPdf(
+        period: String,
+        startDate: String?,
+        endDate: String?,
+        timezone: String?
+    ): Result<AttendanceReportPdfResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            val response = apiService.exportAttendanceReportPdf(period, startDate, endDate, timezone)
+            savePdfResponse(response, defaultPrefix = "attendance-report-export")
+        }
+    }
+
+    private fun savePdfResponse(
+        response: Response<ResponseBody>,
+        defaultPrefix: String
+    ): AttendanceReportPdfResult {
+        if (!response.isSuccessful) {
+            throw IOException("Unable to fetch attendance report PDF (${response.code()})")
+        }
+
+        val body = response.body() ?: throw IOException("Attendance report PDF body is empty")
+        val fileName = response.extractFileName(defaultPrefix)
+        val file = File(context.cacheDir, fileName)
+        FileOutputStream(file).use { output ->
+            body.byteStream().use { input ->
+                input.copyTo(output)
+            }
+        }
+
+        val uri: Uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+
+        return AttendanceReportPdfResult(
+            fileName = fileName,
+            localUri = uri
+        )
+    }
+}
+
+private fun Response<ResponseBody>.extractFileName(defaultPrefix: String): String {
+    val header = headers()["Content-Disposition"].orEmpty()
+    val quoted = Regex("filename=\"([^\"]+)\"").find(header)?.groupValues?.getOrNull(1)
+    val plain = Regex("filename=([^;]+)").find(header)?.groupValues?.getOrNull(1)?.trim()
+    return (quoted ?: plain ?: "$defaultPrefix.pdf").trim('"')
+}

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
@@ -18,6 +18,8 @@ import com.example.infinite_track.data.soucre.network.response.TodayStatusRespon
 import com.example.infinite_track.data.soucre.network.response.WfaRecommendationResponse
 import com.example.infinite_track.data.soucre.network.response.booking.BookingHistoryResponse
 import com.example.infinite_track.data.soucre.network.response.booking.BookingResponse
+import okhttp3.ResponseBody
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -25,6 +27,7 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Streaming
 import javax.inject.Singleton
 
 @Singleton
@@ -66,6 +69,24 @@ interface ApiService {
         @Query("page") page: Int = 1,
         @Query("limit") limit: Int = 5
     ): AttendanceHistoryResponse
+
+    @Streaming
+    @GET("api/attendance/history/personal/pdf")
+    suspend fun previewAttendanceReportPdf(
+        @Query("period") period: String,
+        @Query("start_date") startDate: String? = null,
+        @Query("end_date") endDate: String? = null,
+        @Query("timezone") timezone: String? = null
+    ): Response<ResponseBody>
+
+    @Streaming
+    @GET("api/attendance/history/export.pdf")
+    suspend fun exportAttendanceReportPdf(
+        @Query("period") period: String,
+        @Query("start_date") startDate: String? = null,
+        @Query("end_date") endDate: String? = null,
+        @Query("timezone") timezone: String? = null
+    ): Response<ResponseBody>
 
     @PATCH("api/users/{id}")
     suspend fun updateUserProfile(

--- a/app/src/main/java/com/example/infinite_track/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/RepositoryModule.kt
@@ -3,6 +3,7 @@ package com.example.infinite_track.di
 import android.content.Context
 import android.util.Log
 import com.example.infinite_track.data.repository.attendance.AttendanceHistoryRepositoryImpl
+import com.example.infinite_track.data.repository.attendance.AttendanceReportPdfRepositoryImpl
 import com.example.infinite_track.data.repository.attendance.AttendanceRepositoryImpl
 import com.example.infinite_track.data.repository.auth.AuthRepositoryImpl
 import com.example.infinite_track.data.repository.auth.AuthRuntimeCleanerImpl
@@ -21,6 +22,7 @@ import com.example.infinite_track.data.soucre.network.retrofit.ApiService
 import com.example.infinite_track.data.soucre.network.retrofit.AuthSessionApiService
 import com.example.infinite_track.data.soucre.network.retrofit.MapboxApiService
 import com.example.infinite_track.domain.repository.AttendanceHistoryRepository
+import com.example.infinite_track.domain.repository.AttendanceReportPdfRepository
 import com.example.infinite_track.domain.repository.AttendanceRepository
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.AuthRuntimeCleaner
@@ -115,6 +117,14 @@ object RepositoryModule {
         apiService: ApiService
     ): AttendanceHistoryRepository {
         return AttendanceHistoryRepositoryImpl(apiService)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAttendanceReportPdfRepository(
+        attendanceReportPdfRepositoryImpl: AttendanceReportPdfRepositoryImpl
+    ): AttendanceReportPdfRepository {
+        return attendanceReportPdfRepositoryImpl
     }
 
     @Provides

--- a/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
@@ -7,6 +7,7 @@ import com.example.infinite_track.data.soucre.local.preferences.UserPreference
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.data.soucre.local.room.UserDao
 import com.example.infinite_track.domain.repository.AttendanceHistoryRepository
+import com.example.infinite_track.domain.repository.AttendanceReportPdfRepository
 import com.example.infinite_track.domain.repository.AttendanceRepository
 import com.example.infinite_track.domain.repository.AuthRepository
 import com.example.infinite_track.domain.repository.AuthRuntimeCleaner
@@ -31,6 +32,7 @@ import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCa
 import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.contact.GetContactsUseCase
+import com.example.infinite_track.domain.use_case.history.ExportAttendanceReportPdfUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
 import com.example.infinite_track.domain.use_case.language.GetSelectedLanguageUseCase
 import com.example.infinite_track.domain.use_case.language.SetSelectedLanguageUseCase
@@ -153,6 +155,13 @@ object UseCaseModule {
         attendanceHistoryRepository: AttendanceHistoryRepository
     ): GetAttendanceHistoryUseCase {
         return GetAttendanceHistoryUseCase(attendanceHistoryRepository)
+    }
+
+    @Provides
+    fun provideExportAttendanceReportPdfUseCase(
+        attendanceReportPdfRepository: AttendanceReportPdfRepository
+    ): ExportAttendanceReportPdfUseCase {
+        return ExportAttendanceReportPdfUseCase(attendanceReportPdfRepository)
     }
 
     // Provide the Get Current Address Use Case

--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceReportPdfResult.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/AttendanceReportPdfResult.kt
@@ -1,0 +1,9 @@
+package com.example.infinite_track.domain.model.attendance
+
+import android.net.Uri
+
+data class AttendanceReportPdfResult(
+    val fileName: String,
+    val localUri: Uri,
+    val mimeType: String = "application/pdf"
+)

--- a/app/src/main/java/com/example/infinite_track/domain/repository/AttendanceReportPdfRepository.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/repository/AttendanceReportPdfRepository.kt
@@ -1,0 +1,19 @@
+package com.example.infinite_track.domain.repository
+
+import com.example.infinite_track.domain.model.attendance.AttendanceReportPdfResult
+
+interface AttendanceReportPdfRepository {
+    suspend fun previewAttendanceReportPdf(
+        period: String,
+        startDate: String? = null,
+        endDate: String? = null,
+        timezone: String? = null
+    ): Result<AttendanceReportPdfResult>
+
+    suspend fun exportAttendanceReportPdf(
+        period: String,
+        startDate: String? = null,
+        endDate: String? = null,
+        timezone: String? = null
+    ): Result<AttendanceReportPdfResult>
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/history/ExportAttendanceReportPdfUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/history/ExportAttendanceReportPdfUseCase.kt
@@ -1,0 +1,27 @@
+package com.example.infinite_track.domain.use_case.history
+
+import com.example.infinite_track.domain.model.attendance.AttendanceReportPdfResult
+import com.example.infinite_track.domain.repository.AttendanceReportPdfRepository
+import javax.inject.Inject
+
+enum class AttendanceReportPdfMode {
+    Preview,
+    Export
+}
+
+class ExportAttendanceReportPdfUseCase @Inject constructor(
+    private val attendanceReportPdfRepository: AttendanceReportPdfRepository
+) {
+    suspend operator fun invoke(
+        mode: AttendanceReportPdfMode,
+        period: String,
+        startDate: String? = null,
+        endDate: String? = null,
+        timezone: String? = null
+    ): Result<AttendanceReportPdfResult> {
+        return when (mode) {
+            AttendanceReportPdfMode.Preview -> attendanceReportPdfRepository.previewAttendanceReportPdf(period, startDate, endDate, timezone)
+            AttendanceReportPdfMode.Export -> attendanceReportPdfRepository.exportAttendanceReportPdf(period, startDate, endDate, timezone)
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -1,5 +1,7 @@
 package com.example.infinite_track.presentation.screen.history
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +22,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -47,13 +50,20 @@ import com.example.infinite_track.presentation.design.components.state.InfiniteL
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 
+private enum class ReportAction {
+    Preview,
+    Share
+}
+
 @Composable
 fun HistoryScreen(
     modifier: Modifier = Modifier,
     viewModel: HistoryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     val lazyListState = rememberLazyListState()
+    val pendingReportAction = remember { mutableStateOf<ReportAction?>(null) }
     val refreshDragDistance = remember { mutableStateOf(0f) }
     val pullToRefreshConnection = remember(lazyListState, uiState.isLoading, uiState.isRefreshing) {
         object : NestedScrollConnection {
@@ -85,6 +95,44 @@ fun HistoryScreen(
 
     LaunchedEffect(shouldLoadMore.value) {
         if (shouldLoadMore.value) viewModel.loadNextPage()
+    }
+
+    LaunchedEffect(uiState.exportState) {
+        when (val exportState = uiState.exportState) {
+            is ReportExportUiState.Success -> {
+                try {
+                    when (pendingReportAction.value) {
+                        ReportAction.Preview -> {
+                            val intent = Intent(Intent.ACTION_VIEW).apply {
+                                setDataAndType(exportState.localUri, "application/pdf")
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            context.startActivity(intent)
+                        }
+                        ReportAction.Share -> {
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "application/pdf"
+                                putExtra(Intent.EXTRA_STREAM, exportState.localUri)
+                                putExtra(Intent.EXTRA_TITLE, exportState.fileName)
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            context.startActivity(Intent.createChooser(intent, "Share Report"))
+                        }
+                        null -> Unit
+                    }
+                } catch (_: ActivityNotFoundException) {
+                    viewModel.clearExportState()
+                    pendingReportAction.value = null
+                }
+                pendingReportAction.value = null
+                viewModel.clearExportState()
+            }
+            is ReportExportUiState.Error -> {
+                pendingReportAction.value = null
+            }
+            ReportExportUiState.Downloading,
+            ReportExportUiState.Idle -> Unit
+        }
     }
 
     Scaffold(
@@ -183,8 +231,27 @@ fun HistoryScreen(
                     item {
                         InfiniteAttendanceReportActionsCard(
                             selectedPeriod = uiState.selectedPeriod,
+                            exportEnabled = uiState.exportState !is ReportExportUiState.Downloading,
+                            shareEnabled = uiState.exportState !is ReportExportUiState.Downloading,
+                            onExportClick = {
+                                pendingReportAction.value = ReportAction.Preview
+                                viewModel.previewReportPdf()
+                            },
+                            onShareClick = {
+                                pendingReportAction.value = ReportAction.Share
+                                viewModel.exportReportPdf()
+                            },
                             subtitle = null
                         )
+                    }
+
+                    if (uiState.exportState is ReportExportUiState.Error) {
+                        item {
+                            InfiniteAttendanceReportNoticeCard(
+                                title = "PDF unavailable",
+                                message = (uiState.exportState as ReportExportUiState.Error).message
+                            )
+                        }
                     }
 
                     item {

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
@@ -6,6 +6,8 @@ import com.example.infinite_track.domain.model.attendance.AttendancePeriod
 import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
+import com.example.infinite_track.domain.use_case.history.AttendanceReportPdfMode
+import com.example.infinite_track.domain.use_case.history.ExportAttendanceReportPdfUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -27,6 +29,7 @@ data class HistoryScreenState(
     val error: String? = null,
     val selectedPeriod: String = AttendancePeriod.MONTHLY,
     val periodInfo: AttendancePeriodInfo? = null,
+    val exportState: ReportExportUiState = ReportExportUiState.Idle,
     val summary: AttendanceSummaryInfo? = null,
     val records: List<AttendanceRecord> = emptyList(),
     val currentPage: Int = 1,
@@ -35,7 +38,8 @@ data class HistoryScreenState(
 
 @HiltViewModel
 class HistoryViewModel @Inject constructor(
-    private val getAttendanceHistoryUseCase: GetAttendanceHistoryUseCase
+    private val getAttendanceHistoryUseCase: GetAttendanceHistoryUseCase,
+    private val exportAttendanceReportPdfUseCase: ExportAttendanceReportPdfUseCase
 ) : ViewModel() {
 
     // Single state flow for the entire UI state
@@ -104,7 +108,7 @@ class HistoryViewModel @Inject constructor(
                     currentPage = 1,
                     records = emptyList(),
                     periodInfo = null,
-                summary = null,
+                    summary = null,
                     canLoadMore = false,
                     isLoading = false,
                     isRefreshing = false,
@@ -117,6 +121,47 @@ class HistoryViewModel @Inject constructor(
 
         _uiState.update { it.copy(currentPage = 1) }
         loadHistory(isRefresh = true, isPullRefresh = true)
+    }
+
+    fun previewReportPdf() {
+        fetchReportPdf(AttendanceReportPdfMode.Preview)
+    }
+
+    fun exportReportPdf() {
+        fetchReportPdf(AttendanceReportPdfMode.Export)
+    }
+
+    fun clearExportState() {
+        _uiState.update { it.copy(exportState = ReportExportUiState.Idle) }
+    }
+
+    private fun fetchReportPdf(mode: AttendanceReportPdfMode) {
+        val currentState = uiState.value
+        if (currentState.selectedPeriod == AttendancePeriod.CUSTOM || currentState.exportState is ReportExportUiState.Downloading) {
+            if (currentState.selectedPeriod == AttendancePeriod.CUSTOM) {
+                _uiState.update {
+                    it.copy(exportState = ReportExportUiState.Error("Custom PDF export is not available until date range support is implemented."))
+                }
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(exportState = ReportExportUiState.Downloading) }
+            exportAttendanceReportPdfUseCase(
+                mode = mode,
+                period = currentState.selectedPeriod,
+                timezone = "Asia/Makassar"
+            ).onSuccess { result ->
+                _uiState.update {
+                    it.copy(exportState = ReportExportUiState.Success(result.localUri, result.fileName))
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(exportState = ReportExportUiState.Error(error.message ?: "Unable to prepare attendance report PDF."))
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/ReportExportUiState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/ReportExportUiState.kt
@@ -1,0 +1,10 @@
+package com.example.infinite_track.presentation.screen.history
+
+import android.net.Uri
+
+sealed interface ReportExportUiState {
+    data object Idle : ReportExportUiState
+    data object Downloading : ReportExportUiState
+    data class Success(val localUri: Uri, val fileName: String) : ReportExportUiState
+    data class Error(val message: String) : ReportExportUiState
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="report_cache"
+        path="." />
+</paths>

--- a/app/src/test/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImplTodayStatusCacheTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImplTodayStatusCacheTest.kt
@@ -48,6 +48,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import okhttp3.ResponseBody
 import retrofit2.Response
 import java.io.File
 import java.time.LocalDate
@@ -319,6 +320,20 @@ private class FakeApiService(
     override suspend fun refresh(request: RefreshRequest): RefreshResponse = unsupported()
 
     override suspend fun getAttendanceHistory(period: String, page: Int, limit: Int): AttendanceHistoryResponse = unsupported()
+
+    override suspend fun previewAttendanceReportPdf(
+        period: String,
+        startDate: String?,
+        endDate: String?,
+        timezone: String?
+    ): Response<ResponseBody> = unsupported()
+
+    override suspend fun exportAttendanceReportPdf(
+        period: String,
+        startDate: String?,
+        endDate: String?,
+        timezone: String?
+    ): Response<ResponseBody> = unsupported()
 
     override suspend fun updateUserProfile(userId: Int, request: ProfileUpdateRequest): ProfileUpdateResponse = unsupported()
 

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplLogoutFallbackTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplLogoutFallbackTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -154,6 +155,8 @@ private class LogoutFallbackFakeApiService(
     override suspend fun checkOut(attendanceId: Int, request: CheckOutRequestDto): AttendanceResponse = throw NotImplementedError()
     override suspend fun getTodayStatus(): TodayStatusResponse = throw NotImplementedError()
     override suspend fun getAttendanceHistory(period: String, page: Int, limit: Int): AttendanceHistoryResponse = throw NotImplementedError()
+    override suspend fun previewAttendanceReportPdf(period: String, startDate: String?, endDate: String?, timezone: String?): Response<ResponseBody> = throw NotImplementedError()
+    override suspend fun exportAttendanceReportPdf(period: String, startDate: String?, endDate: String?, timezone: String?): Response<ResponseBody> = throw NotImplementedError()
     override suspend fun updateUserProfile(userId: Int, request: ProfileUpdateRequest): ProfileUpdateResponse = throw NotImplementedError()
     override suspend fun sendLocationEvent(request: LocationEventRequest): Response<Unit> = throw NotImplementedError()
     override suspend fun getWfaRecommendations(latitude: Double, longitude: Double): WfaRecommendationResponse = throw NotImplementedError()

--- a/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
+++ b/app/src/test/java/com/example/infinite_track/data/repository/auth/AuthRepositoryImplRefreshSessionTest.kt
@@ -1200,6 +1200,14 @@ private class FakeApiService(
         throw NotImplementedError()
     }
 
+    override suspend fun previewAttendanceReportPdf(period: String, startDate: String?, endDate: String?, timezone: String?): Response<ResponseBody> {
+        throw NotImplementedError()
+    }
+
+    override suspend fun exportAttendanceReportPdf(period: String, startDate: String?, endDate: String?, timezone: String?): Response<ResponseBody> {
+        throw NotImplementedError()
+    }
+
     override suspend fun updateUserProfile(userId: Int, request: ProfileUpdateRequest): ProfileUpdateResponse {
         throw NotImplementedError()
     }

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/history/HistoryViewModelTest.kt
@@ -7,8 +7,11 @@ import com.example.infinite_track.domain.model.attendance.AttendanceModeMetricIn
 import com.example.infinite_track.domain.model.attendance.AttendancePeriod
 import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.AttendanceReportPdfResult
 import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
 import com.example.infinite_track.domain.repository.AttendanceHistoryRepository
+import com.example.infinite_track.domain.repository.AttendanceReportPdfRepository
+import com.example.infinite_track.domain.use_case.history.ExportAttendanceReportPdfUseCase
 import com.example.infinite_track.domain.use_case.history.GetAttendanceHistoryUseCase
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -84,7 +87,7 @@ class HistoryViewModelTest {
         Dispatchers.setMain(dispatcher)
         try {
             val repository = FakeAttendanceHistoryRepository()
-            val viewModel = HistoryViewModel(GetAttendanceHistoryUseCase(repository))
+            val viewModel = HistoryViewModel(GetAttendanceHistoryUseCase(repository), ExportAttendanceReportPdfUseCase(FakeAttendanceReportPdfRepository()))
             advanceUntilIdle()
 
             viewModel.onFilterChanged(AttendancePeriod.CUSTOM)
@@ -108,7 +111,7 @@ class HistoryViewModelTest {
         Dispatchers.setMain(dispatcher)
         try {
             val repository = DelayedAttendanceHistoryRepository()
-            val viewModel = HistoryViewModel(GetAttendanceHistoryUseCase(repository))
+            val viewModel = HistoryViewModel(GetAttendanceHistoryUseCase(repository), ExportAttendanceReportPdfUseCase(FakeAttendanceReportPdfRepository()))
             runCurrent()
 
             viewModel.onFilterChanged(AttendancePeriod.CUSTOM)
@@ -230,6 +233,22 @@ class HistoryViewModelTest {
                 )
             )
         }
+    }
+
+    private class FakeAttendanceReportPdfRepository : AttendanceReportPdfRepository {
+        override suspend fun previewAttendanceReportPdf(
+            period: String,
+            startDate: String?,
+            endDate: String?,
+            timezone: String?
+        ): Result<AttendanceReportPdfResult> = Result.failure(NotImplementedError())
+
+        override suspend fun exportAttendanceReportPdf(
+            period: String,
+            startDate: String?,
+            endDate: String?,
+            timezone: String?
+        ): Result<AttendanceReportPdfResult> = Result.failure(NotImplementedError())
     }
 
 }


### PR DESCRIPTION
## Summary
- Registers `FileProvider` in `AndroidManifest.xml` for the My Attendance Report PDF flow.
- Links the provider to `@xml/file_paths` so cache-based PDF files can be opened/shared via content URI.
- Completes the Android-side manifest requirement for the previously merged INF-216 PDF preview/export implementation.

## Scope notes
- No backend/auth/session changes.
- No broad storage permission added.
- No PDF generation changes.
- Focused only on the runtime FileProvider manifest registration needed by the existing PDF flow.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed earlier for the branch implementation:
- `./gradlew.bat --no-daemon app:assembleDebug`
- `./gradlew.bat --no-daemon app:test`
- `./gradlew.bat --no-daemon app:lint`

## Needs Verification
Runtime/device verification on `develop` after merge/pull:
- Export PDF opens via content URI successfully
- Share Report opens Android share sheet successfully
- No `FileProvider` authority/runtime error remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attendance report PDF preview and export, with support for opening or sharing the generated file.
  * Introduced download status handling so users can see when a report is being generated.

* **Bug Fixes**
  * Added clear error feedback when a PDF can’t be opened or generated.
  * Prevented report export from starting when a custom period is selected.

* **Documentation**
  * No user-facing documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->