### PR TITLE
fix: polish Profile hub card styling

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,6 +40,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -58,6 +61,8 @@ import com.example.infinite_track.presentation.components.popUp.LanguagePopUp
 import com.example.infinite_track.presentation.components.status.InfiniteTrackConfirmDialog
 import com.example.infinite_track.presentation.components.status.InfiniteTrackStatusDialog
 import com.example.infinite_track.presentation.components.status.StatusStates
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.core.headline2
 import com.example.infinite_track.presentation.core.headline3
 import com.example.infinite_track.presentation.core.headline4
@@ -68,9 +73,6 @@ import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.utils.UiState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-
-private const val DefaultAvatarUrl =
-    "https://w7.pngwing.com/pngs/177/551/png-transparent-user-interface-design-computer-icons-default-stephen-salazar-graphy-user-interface-design-computer-wallpaper-sphere-thumbnail.png"
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -391,6 +393,45 @@ private fun AccountHubContent(
 }
 
 @Composable
+private fun ProfileGlassCard(
+    modifier: Modifier = Modifier,
+    shape: RoundedCornerShape,
+    borderColor: Color = InfiniteColors.AccountHubOutline,
+    shadowColor: Color = InfiniteColors.AccountHubPrimary.copy(alpha = 0.18f),
+    backgroundBrush: Brush = Brush.linearGradient(
+        colors = listOf(
+            InfiniteColors.Surface.copy(alpha = 0.22f),
+            InfiniteColors.Surface.copy(alpha = 0.10f)
+        )
+    ),
+    contentPadding: PaddingValues,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = modifier.shadow(
+            elevation = 8.dp,
+            shape = shape,
+            ambientColor = shadowColor,
+            spotColor = shadowColor,
+            clip = false
+        ),
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = InfiniteColors.Transparent),
+        border = BorderStroke(1.dp, borderColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(backgroundBrush)
+                .padding(contentPadding)
+        ) {
+            Column(content = content)
+        }
+    }
+}
+
+@Composable
 private fun IdentityHeroCard(
     user: UserModel,
     role: String,
@@ -400,18 +441,15 @@ private fun IdentityHeroCard(
     val unavailable = stringResource(R.string.account_hub_not_available)
     val fullName = user.fullName.ifBlank { unavailable }
 
-    Card(
+    ProfileGlassCard(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
-        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
-        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        borderColor = InfiniteColors.AccountHubHeroOutline,
+        backgroundBrush = InfiniteColors.AccountHubHeroGradient,
+        contentPadding = PaddingValues(20.dp)
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(InfiniteColors.AccountHubHeroGradient)
-                .padding(20.dp)
+            modifier = Modifier.fillMaxWidth()
         ) {
             Box(
                 modifier = Modifier
@@ -434,8 +472,11 @@ private fun IdentityHeroCard(
                             .padding(4.dp)
                     ) {
                         AsyncImage(
-                            model = user.photoUrl ?: DefaultAvatarUrl,
+                            model = user.photoUrl?.takeIf { it.isNotBlank() },
                             contentDescription = null,
+                            placeholder = painterResource(R.drawable.ic_profile),
+                            error = painterResource(R.drawable.ic_profile),
+                            fallback = painterResource(R.drawable.ic_profile),
                             modifier = Modifier
                                 .fillMaxSize()
                                 .clip(CircleShape)
@@ -460,13 +501,13 @@ private fun IdentityHeroCard(
                             text = fullName,
                             style = headline2,
                             color = InfiniteColors.AccountHubTitle,
-                            fontWeight = FontWeight.Bold,
+                            fontWeight = FontWeight.Medium,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                         Text(
                             text = position,
-                            style = headline4,
+                            style = body1,
                             color = InfiniteColors.AccountHubSectionAccent,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
@@ -492,17 +533,20 @@ private fun AccountSummaryCard(
     @DrawableRes icon: Int,
     modifier: Modifier = Modifier
 ) {
-    Card(
+    ProfileGlassCard(
         modifier = modifier.height(92.dp),
         shape = RoundedCornerShape(20.dp),
-        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubSummarySurface),
-        border = BorderStroke(1.dp, InfiniteColors.AccountHubOutline),
-        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp)
+        backgroundBrush = Brush.linearGradient(
+            colors = listOf(
+                InfiniteColors.Surface.copy(alpha = 0.20f),
+                InfiniteColors.Surface.copy(alpha = 0.08f)
+            )
+        ),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp)
     ) {
         Row(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 12.dp),
+                .fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
@@ -515,16 +559,16 @@ private fun AccountSummaryCard(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = label,
-                    style = headline4,
+                    style = body2,
                     color = InfiniteColors.AccountHubMutedText,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = value,
-                    style = headline4,
+                    style = body1,
                     color = InfiniteColors.AccountHubTitle,
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -538,22 +582,25 @@ private fun AccountHubSection(
     title: String,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Card(
+    ProfileGlassCard(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
-        border = BorderStroke(1.dp, InfiniteColors.AccountHubOutline),
-        elevation = CardDefaults.cardElevation(defaultElevation = 5.dp)
+        backgroundBrush = Brush.linearGradient(
+            colors = listOf(
+                InfiniteColors.Surface.copy(alpha = 0.18f),
+                InfiniteColors.Surface.copy(alpha = 0.06f)
+            )
+        ),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 14.dp)
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Text(
                 text = title,
-                style = headline4,
+                style = body1,
                 color = InfiniteColors.AccountHubSectionAccent,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Medium
             )
             content()
         }
@@ -600,15 +647,15 @@ private fun AccountHubMenuRow(
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = title,
-                style = headline3,
+                style = body1,
                 color = if (destructive) InfiniteColors.AccountHubDestructive else InfiniteColors.AccountHubTitle,
-                fontWeight = FontWeight.SemiBold,
+                fontWeight = FontWeight.Medium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = description,
-                style = headline4,
+                style = body2,
                 color = InfiniteColors.AccountHubMutedText,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
@@ -654,7 +701,7 @@ private fun SoftPill(
             )
             Text(
                 text = text,
-                style = headline4,
+                style = body2,
                 color = InfiniteColors.AccountHubSectionAccent,
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
@@ -681,7 +728,7 @@ private fun IdentityInfoRow(
         )
         Text(
             text = text,
-            style = headline4,
+            style = body2,
             color = InfiniteColors.AccountHubBodyText,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis

--- a/docs/superpowers/plans/2026-07-09-profile-hub-style-polish.md
+++ b/docs/superpowers/plans/2026-07-09-profile-hub-style-polish.md
@@ -1,0 +1,21 @@
+# Profile Hub Style Polish Plan
+
+Date: 2026-07-09
+Branch: `fix/android-profile-card-style-refresh`
+Spec: `docs/superpowers/specs/2026-07-09-profile-hub-style-polish.md`
+
+## Plan
+
+1. Reuse existing `ProfileScreen.kt` structure and callbacks exactly as-is.
+2. Add local styling helpers in `ProfileScreen.kt` for synchronized card surface/shadow treatment.
+3. Restyle:
+   - identity hero card
+   - summary cards
+   - section cards
+   - menu row icon containers
+4. Soften typography hierarchy:
+   - reduce over-bold titles
+   - align labels/descriptions/value weights
+5. Preserve current transparent global background behavior.
+6. Run static checks and build attempt.
+7. Mark runtime/build as `Needs Verification` if Gradle loopback blocks local verification.

--- a/docs/superpowers/specs/2026-07-09-profile-hub-style-polish.md
+++ b/docs/superpowers/specs/2026-07-09-profile-hub-style-polish.md
@@ -1,0 +1,38 @@
+# Profile Hub Style Polish
+
+Date: 2026-07-09
+
+## Goal
+
+Polish the Profile main screen card styling and text hierarchy without changing its structure, data, callbacks, or navigation behavior.
+
+## Scope
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`
+
+## Guardrails
+
+- Keep the current Account Hub layout and content grouping.
+- Do not change navigation callbacks.
+- Do not change backend/auth/session behavior.
+- Do not change role visibility logic.
+- Do not change section order or routes.
+- Change only card transparency/shadow/border and text composition/weight/size hierarchy.
+
+## Visual direction
+
+Use existing repo card language from:
+
+- `UserMyLeaveCard.kt`
+- `OverviewCardAttendance.kt`
+- `CardAbsence.kt`
+- `AttendanceHistoryCard.kt`
+
+Target outcome:
+
+- Softer transparent glass cards
+- Synchronized white border treatment
+- Softer shadow/glow treatment
+- Less aggressive bold text
+- Better title/description hierarchy
+- Keep existing purple/cyan accent only as subtle support


### PR DESCRIPTION
## Summary

Polishes the Profile / Account Hub main screen styling while preserving the current structure, attributes, callbacks, routing, and behavior.

Changes focus only on card and text styling:

- softens card transparency and makes card surface treatment more consistent
- aligns white border and soft shadow/glow treatment with existing card patterns already present in the app
- reduces overly heavy title/menu typography and improves text hierarchy
- keeps the global transparent background behavior intact
- removes the remaining external dummy avatar fallback and uses current user photo data with local drawable fallback

## Style references used

The styling direction was aligned with existing app card treatments from:

- `UserMyLeaveCard.kt`
- `OverviewCardAttendance.kt`
- `CardAbsence.kt`
- `AttendanceHistoryCard.kt`

## Scope / non-goals

- No layout restructuring
- No callback changes
- No backend changes
- No auth/session changes
- No role visibility changes
- No navigation changes
- No section order changes
- No Edit Profile / About / MyDocument / PaySlip changes

## Files changed

- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt`
- `docs/superpowers/specs/2026-07-09-profile-hub-style-polish.md`
- `docs/superpowers/plans/2026-07-09-profile-hub-style-polish.md`

## Verification

Static checks completed locally:

- `git diff --check` passed (only Windows line-ending warnings for docs)
- `ProfileScreen.kt` no longer contains the external `DefaultAvatarUrl` / `pngwing` fallback
- current Profile callbacks and logout dialog state remain intact
- root transparent/global background behavior remains preserved

Attempted local build:

```bash
./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
```

Local Gradle is still blocked before Kotlin compile by the known environment-level bootstrap issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

- `./gradlew app:assembleDebug` in CI/Android Studio or another environment without the loopback issue
- Runtime visual check:
  - Profile cards feel visually synchronized
  - text hierarchy is calmer and less overly bold
  - transparency and shadow treatment feel closer to the referenced cards
  - profile avatar still uses current user `photoUrl` with local fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the profile screen with softer glass-like cards, gradients, borders, and shadows for a more polished look.
  * Refined text hierarchy across profile sections for clearer emphasis and readability.
  * Improved avatar image handling with better fallback behavior when a profile photo is unavailable.

* **Documentation**
  * Added planning/spec documents for the profile style refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->