### PR TITLE
fix: align Profile detail pages to global surface

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.example.infinite_track.R
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt
@@ -1,24 +1,22 @@
 package com.example.infinite_track.presentation.screen.profile.details.about
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.infinite_track.presentation.design.components.navigation.InfiniteTopBar
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutAchievementCard
 import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutCreatorCard
@@ -27,7 +25,6 @@ import com.example.infinite_track.presentation.screen.profile.details.about.comp
 import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutImpactSection
 import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutOverviewCard
 import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutTimelineSection
-import com.example.infinite_track.presentation.screen.profile.details.about.components.AboutTopBar
 
 @Composable
 fun AboutScreen(
@@ -40,13 +37,18 @@ fun AboutScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(InfiniteColors.AccountHubBackgroundGradient)
     ) {
-        LiquidBackgroundDecor()
         Scaffold(
             modifier = Modifier.fillMaxSize(),
             containerColor = InfiniteColors.Transparent,
-            topBar = { AboutTopBar(onBackClick = onBackClick) }
+            topBar = {
+                InfiniteTopBar(
+                    title = stringResource(R.string.account_hub_about_title),
+                    navigationIcon = Icons.Default.KeyboardArrowLeft,
+                    navigationContentDescription = stringResource(R.string.cancel),
+                    onNavigationClick = onBackClick
+                )
+            }
         ) { paddingValues ->
             Box(
                 modifier = Modifier
@@ -71,38 +73,4 @@ fun AboutScreen(
             }
         }
     }
-}
-
-@Composable
-private fun LiquidBackgroundDecor() {
-    Box(
-        modifier = Modifier
-            .offset(x = 280.dp, y = (-22).dp)
-            .size(150.dp)
-            .clip(CircleShape)
-            .background(
-                Brush.radialGradient(
-                    colors = listOf(
-                        InfiniteColors.Surface.copy(alpha = 0.82f),
-                        InfiniteColors.AboutLavender.copy(alpha = 0.28f),
-                        InfiniteColors.Transparent
-                    )
-                )
-            )
-    )
-    Box(
-        modifier = Modifier
-            .offset(x = (-42).dp, y = 640.dp)
-            .size(150.dp)
-            .clip(CircleShape)
-            .background(
-                Brush.radialGradient(
-                    colors = listOf(
-                        InfiniteColors.Surface.copy(alpha = 0.72f),
-                        InfiniteColors.AboutPurpleSoft.copy(alpha = 0.22f),
-                        InfiniteColors.Transparent
-                    )
-                )
-            )
-    )
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -62,6 +63,7 @@ import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
 import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.navigation.InfiniteTopBar
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
@@ -86,7 +88,12 @@ fun EditProfile(
         modifier = Modifier.fillMaxSize(),
         containerColor = Color.Transparent,
         topBar = {
-            EditProfileTopBar(onBackClick = onBackClick)
+            InfiniteTopBar(
+                title = stringResource(R.string.edit_profile_title),
+                navigationIcon = Icons.Default.KeyboardArrowLeft,
+                navigationContentDescription = stringResource(R.string.cancel),
+                onNavigationClick = onBackClick
+            )
         },
         bottomBar = {
             EditProfileBottomActionBar(
@@ -103,7 +110,6 @@ fun EditProfile(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(InfiniteColors.AccountHubBackgroundGradient)
                 .verticalScroll(rememberScrollState())
                 .padding(innerPadding)
                 .padding(horizontal = 16.dp, vertical = 14.dp),
@@ -124,56 +130,6 @@ fun EditProfile(
                 onDismiss = { viewModel.resetUpdateState() }
             )
             Spacer(modifier = Modifier.height(88.dp))
-        }
-    }
-}
-
-@Composable
-private fun EditProfileTopBar(onBackClick: () -> Unit) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(containerColor = InfiniteColors.AccountHubHeroSurface),
-        border = BorderStroke(1.dp, InfiniteColors.AccountHubHeroOutline),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(78.dp)
-                .background(InfiniteColors.AccountHubHeroGradient)
-                .padding(horizontal = 18.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .size(52.dp)
-                    .clickable { onBackClick() },
-                shape = CircleShape,
-                color = InfiniteColors.AccountHubFloatingSurface,
-                border = BorderStroke(1.dp, InfiniteColors.AccountHubStrongOutline),
-                shadowElevation = 4.dp
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_backks),
-                        contentDescription = stringResource(R.string.cancel),
-                        tint = InfiniteColors.AccountHubTitle,
-                        modifier = Modifier.size(24.dp)
-                    )
-                }
-            }
-            Text(
-                text = stringResource(R.string.edit_profile_title),
-                style = headline2,
-                color = InfiniteColors.AccountHubTitle,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Aligns Profile-family detail pages with the app's global background/surface approach.

Changes:

- removes the extra local page background layer from `EditProfile.kt`
- removes the extra local page background layer and decorative background blobs from `AboutScreen.kt`
- switches both pages to the existing reusable `InfiniteTopBar`
- keeps the existing page content/cards/behavior intact as much as possible

## Scope

- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/edit_profile/EditProfile.kt`
- `app/src/main/java/com/example/infinite_track/presentation/screen/profile/details/about/AboutScreen.kt`

## Guardrails

- No backend changes
- No auth/session changes
- No navigation changes
- No Profile main screen changes
- No Edit Profile form logic changes
- No About content/data changes
- No bottom navigation changes

## Verification

Static checks completed:

- `git diff --check` passed
- `EditProfile.kt` no longer has the root `AccountHubBackgroundGradient` page background
- `EditProfile.kt` now uses `InfiniteTopBar`
- `AboutScreen.kt` no longer has the root `AccountHubBackgroundGradient` page background
- `AboutScreen.kt` no longer renders the local `LiquidBackgroundDecor`
- `AboutScreen.kt` now uses `InfiniteTopBar`

Attempted build:

```bash
./gradlew --no-daemon -Djava.net.preferIPv4Stack=true app:assembleDebug
```

Local build remains blocked before Kotlin compile by the known environment-level bootstrap issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Needs Verification

- `./gradlew app:assembleDebug` in CI/Android Studio or another environment without the loopback issue
- Runtime visual check:
  - Edit Profile uses the global page surface/background like Home/Profile main screen
  - Edit Profile top bar uses the shared top bar style
  - About page uses the global page surface/background
  - About page top bar uses the shared top bar style
  - Content cards still render correctly and remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
