### PR TITLE
fix: sync WFA card transparency and shadow

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/WfaRequestsScreen.kt
@@ -1,6 +1,8 @@
 package com.example.infinite_track.presentation.screen.wfa
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +31,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -44,9 +47,11 @@ import com.example.infinite_track.presentation.core.headline3
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestCard
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestFilterChips
 import com.example.infinite_track.presentation.screen.wfa.components.WfaRequestStatusSummary
+import com.example.infinite_track.presentation.theme.Blue_100
 import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.White
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
@@ -204,7 +209,14 @@ private fun EmptyState() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color.White.copy(alpha = 0.86f), RoundedCornerShape(18.dp))
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(18.dp),
+                ambientColor = Blue_500.copy(alpha = 0.18f),
+                spotColor = Blue_500.copy(alpha = 0.12f)
+            )
+            .background(White.copy(alpha = 0.34f), RoundedCornerShape(18.dp))
+            .border(BorderStroke(1.dp, Blue_100.copy(alpha = 0.9f)), RoundedCornerShape(18.dp))
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -233,7 +245,14 @@ private fun ErrorState(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color.White.copy(alpha = 0.86f), RoundedCornerShape(18.dp))
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(18.dp),
+                ambientColor = Blue_500.copy(alpha = 0.18f),
+                spotColor = Blue_500.copy(alpha = 0.12f)
+            )
+            .background(White.copy(alpha = 0.34f), RoundedCornerShape(18.dp))
+            .border(BorderStroke(1.dp, Blue_100.copy(alpha = 0.9f)), RoundedCornerShape(18.dp))
             .padding(20.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
@@ -1,6 +1,8 @@
 package com.example.infinite_track.presentation.screen.wfa.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -27,15 +29,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.presentation.theme.Blue_100
 import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.presentation.theme.Violet_100
+import com.example.infinite_track.presentation.theme.White
 import com.example.infinite_track.presentation.theme.requestStatusColor
 
 @Composable
@@ -49,8 +54,18 @@ fun WfaRequestCard(
         modifier = modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(18.dp),
+                ambientColor = Blue_500.copy(alpha = 0.18f),
+                spotColor = Blue_500.copy(alpha = 0.12f)
+            )
             .clip(RoundedCornerShape(18.dp))
-            .background(Color.White.copy(alpha = 0.9f))
+            .background(White.copy(alpha = 0.34f))
+            .border(
+                BorderStroke(1.dp, Blue_100.copy(alpha = 0.9f)),
+                RoundedCornerShape(18.dp)
+            )
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
@@ -19,17 +19,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.booking.BookingHistorySummary
+import com.example.infinite_track.presentation.theme.Blue_100
+import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.presentation.theme.Status_Approved
 import com.example.infinite_track.presentation.theme.Status_Pending
 import com.example.infinite_track.presentation.theme.Status_Rejected
+import com.example.infinite_track.presentation.theme.White
 
 @Composable
 fun WfaRequestStatusSummary(
@@ -78,8 +82,14 @@ private fun SummaryCard(
 ) {
     Column(
         modifier = modifier
-            .background(Color.White.copy(alpha = 0.82f), RoundedCornerShape(18.dp))
-            .border(BorderStroke(1.dp, color.copy(alpha = 0.35f)), RoundedCornerShape(18.dp))
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(18.dp),
+                ambientColor = Blue_500.copy(alpha = 0.18f),
+                spotColor = Blue_500.copy(alpha = 0.12f)
+            )
+            .background(White.copy(alpha = 0.34f), RoundedCornerShape(18.dp))
+            .border(BorderStroke(1.dp, Blue_100.copy(alpha = 0.9f)), RoundedCornerShape(18.dp))
             .padding(horizontal = 8.dp, vertical = 14.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {


### PR DESCRIPTION
## Summary
- Syncs WFA request card styling with the existing transparent/shadow card treatment used by internal references.
- Updates WFA summary cards, request cards, and empty/error containers so transparency, border, and shadow feel more consistent.
- Keeps the current WFA card structure and data attributes intact; this is style-only.

## Scope notes
- No backend/auth/session changes.
- No WFA data/logic changes.
- No layout content restructuring; only card styling is adjusted.

## References followed
- `UserMyLeaveCard.kt`
- `OverviewCardAttendance.kt`
- `CardAbsence.kt`
- `AttendanceHistoryC`

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual verification on `develop` after merge/pull:
- WFA request card transparency looks correct
- Shadow and border feel consistent with the reference cards
- Empty/error states visually match the same surface system

🤖 Generated with [Claude Code](https://claude.com/claude-code)
