### PR TITLE
INF-230: Add attendance permission readiness gate

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/components/maps/AttendanceMap.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/maps/AttendanceMap.kt
@@ -2,13 +2,7 @@ package com.example.infinite_track.presentation.components.maps
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
-import android.os.Build
-import android.provider.Settings
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,16 +19,11 @@ import com.example.infinite_track.domain.model.attendance.Location
 import com.example.infinite_track.domain.model.wfa.WfaRecommendation
 import com.example.infinite_track.utils.MapUtils
 import com.example.infinite_track.utils.PermissionUtils
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.location
-import com.mapbox.maps.plugin.gestures.OnMapClickListener
-import com.mapbox.maps.CameraChangedCallback
 
-@OptIn(ExperimentalPermissionsApi::class)
 @SuppressLint("MissingPermission")
 @Composable
 fun AttendanceMap(
@@ -53,27 +42,15 @@ fun AttendanceMap(
     val context = LocalContext.current
     var mapView: MapView? by remember { mutableStateOf(null) }
 
-    val locationPermissionsState = rememberMultiplePermissionsState(
-        listOf(
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-        )
-    )
-
-    // Background location permission state
-    val isBackgroundGranted: Boolean = remember(locationPermissionsState.allPermissionsGranted) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) true
-        else ContextCompat.checkSelfPermission(
+    val hasForegroundLocationPermission = remember {
+        ContextCompat.checkSelfPermission(
             context,
-            Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_COARSE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
     }
-
-    val requestBackgroundPermissionLauncher =
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            // On Android 10 (Q), we can request ACCESS_BACKGROUND_LOCATION directly
-            rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op, recomposition checks permission */ }
-        } else null
 
     // Effect untuk update annotations saja - camera control diserahkan ke ViewModel
     LaunchedEffect(
@@ -108,40 +85,13 @@ fun AttendanceMap(
     }
 
     when {
-        // 1) Foreground location not granted yet
-        !locationPermissionsState.allPermissionsGranted -> {
+        !hasForegroundLocationPermission -> {
             PermissionUtils.PermissionRationale(
-                text = "Aplikasi ini membutuhkan izin lokasi untuk menampilkan peta dan memvalidasi absensi Anda.",
-                onRequestPermission = { locationPermissionsState.launchMultiplePermissionRequest() })
-        }
-
-        // 2) Background location required for geofencing on Android 10+
-        !isBackgroundGranted -> {
-            val rationaleText = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                "Untuk pemantauan geofence di latar belakang, izinkan akses lokasi 'Sepanjang waktu' di Pengaturan aplikasi."
-            } else {
-                "Untuk pemantauan geofence di latar belakang, aplikasi membutuhkan izin ACCESS_BACKGROUND_LOCATION."
-            }
-
-            PermissionUtils.PermissionRationale(
-                text = rationaleText,
-                onRequestPermission = {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        // Open App Settings so user can switch to "Allow all the time"
-                        val intent = Intent(
-                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                            Uri.fromParts("package", context.packageName, null)
-                        )
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        context.startActivity(intent)
-                    } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-                        requestBackgroundPermissionLauncher?.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-                    }
-                }
+                text = "Akses lokasi belum siap. Kembali ke layar kesiapan Attendance untuk menyiapkan izin lokasi sebelum membuka peta.",
+                onRequestPermission = { }
             )
         }
 
-        // 3) All permissions granted → show MapView
         else -> {
             AndroidView(
                 factory = {

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
@@ -74,20 +74,21 @@ class GeofenceManager @Inject constructor(
     }
 
     /**
-     * Check if all required permissions are granted
+     * Check if permissions for geofence registration are granted.
+     * Basic/manual attendance readiness is owned by AttendancePermissionReadinessScreen.
      */
     fun hasAllRequiredPermissions(): Boolean {
         return hasForegroundLocationPermission() && hasBackgroundLocationPermission()
     }
 
     /**
-     * Get detailed permission status for UI feedback
+     * Get detailed geofence monitoring permission status for UI feedback.
      */
     fun getPermissionStatusMessage(): String {
         return when {
-            hasAllRequiredPermissions() -> "Semua izin lokasi telah diberikan"
-            !hasForegroundLocationPermission() -> "Izin lokasi diperlukan untuk fitur geofencing"
-            !hasBackgroundLocationPermission() -> "Izin lokasi latar belakang diperlukan untuk pemantauan area kerja secara otomatis"
+            hasAllRequiredPermissions() -> "Izin pemantauan geofence telah diberikan"
+            !hasForegroundLocationPermission() -> "Izin lokasi diperlukan untuk fitur absensi"
+            !hasBackgroundLocationPermission() -> "Lokasi latar belakang belum aktif. Pengingat geofence berjalan terbatas, tetapi absensi manual tetap bisa digunakan."
             else -> "Status izin tidak diketahui"
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -1,20 +1,14 @@
 package com.example.infinite_track.presentation.main
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.camera.core.ExperimentalGetImage
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.lifecycleScope
 import com.example.infinite_track.domain.manager.SessionManager
 import com.example.infinite_track.domain.repository.LocalizationRepository
 import com.example.infinite_track.presentation.navigation.AppNavigator
@@ -27,7 +21,6 @@ import com.example.infinite_track.utils.updateAppLanguage
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
@@ -50,11 +43,6 @@ class MainActivity : ComponentActivity() {
 	// Location permission helper untuk geofencing
 	private lateinit var locationPermissionHelper: LocationPermissionHelper
 
-	private val requestNotificationPermission =
-		registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
-
-	private var notificationPermissionRequestedThisLaunch = false
-
 	@ExperimentalGetImage
 	override fun onCreate(savedInstanceState: Bundle?) {
 		// Install splash screen BEFORE super.onCreate()
@@ -66,8 +54,6 @@ class MainActivity : ComponentActivity() {
 		}
 
 		super.onCreate(savedInstanceState)
-		notificationPermissionRequestedThisLaunch =
-			restoreNotificationPermissionRequestedThisLaunch(savedInstanceState)
 		enableEdgeToEdge()
 
 		// Apply saved language before composing UI
@@ -85,8 +71,6 @@ class MainActivity : ComponentActivity() {
 		// Create notification channel untuk geofencing
 		NotificationHelper.createNotificationChannel(this)
 
-		observeStartupNotificationPermissionPrompt()
-
 		setContent {
 			Infinite_TrackTheme {
 				InfiniteTrackApp(
@@ -102,14 +86,6 @@ class MainActivity : ComponentActivity() {
 		handleIntent(intent)
 	}
 
-	override fun onSaveInstanceState(outState: Bundle) {
-		super.onSaveInstanceState(outState)
-		saveNotificationPermissionRequestedThisLaunch(
-			outState,
-			notificationPermissionRequestedThisLaunch
-		)
-	}
-
 	override fun onNewIntent(intent: Intent) {
 		super.onNewIntent(intent)
 		// Handle intent saat aplikasi sudah berjalan di background dan notifikasi diklik
@@ -122,31 +98,6 @@ class MainActivity : ComponentActivity() {
 			// Gunakan AppNavigator untuk navigasi ke AttendanceScreen
 			appNavigator.navigateToAttendance()
 			Log.d("MainActivity", "Navigating to AttendanceScreen via AppNavigator")
-		}
-	}
-
-	private fun observeStartupNotificationPermissionPrompt() {
-		lifecycleScope.launch {
-			viewModel.navigationState.collect { navigationState ->
-				requestPostNotificationsIfPolicyAllows(navigationState)
-			}
-		}
-	}
-
-	private fun requestPostNotificationsIfPolicyAllows(navigationState: SplashNavigationState) {
-		val granted = ContextCompat.checkSelfPermission(
-			this,
-			Manifest.permission.POST_NOTIFICATIONS
-		) == PackageManager.PERMISSION_GRANTED
-
-		if (shouldRequestPostNotifications(
-				sdkInt = Build.VERSION.SDK_INT,
-				alreadyRequestedThisLaunch = notificationPermissionRequestedThisLaunch,
-				isGranted = granted,
-				navigationState = navigationState
-			)) {
-			notificationPermissionRequestedThisLaunch = true
-			requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
 		}
 	}
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt
@@ -47,8 +47,8 @@ fun MainScreen(
 
     LaunchedEffect(navigateToAttendance, currentRoute) {
         if (navigateToAttendance) {
-            if (currentRoute != Screen.Attendance.route) {
-                mainContentNavController.safeNavigate(Screen.Attendance.route)
+            if (currentRoute != Screen.AttendancePermissionReadiness.route) {
+                mainContentNavController.safeNavigate(Screen.AttendancePermissionReadiness.route)
             }
             onAttendanceNavigationHandled()
         }
@@ -77,7 +77,7 @@ fun MainScreen(
             if (isBottomBarVisible && (userRole == "Management" || userRole == "Internship")) {
                 CustomFAB(userRole = userRole) {
                     when (userRole) {
-                        "Internship" -> mainContentNavController.safeNavigate(Screen.Attendance.route)
+                        "Internship" -> mainContentNavController.safeNavigate(Screen.AttendancePermissionReadiness.route)
                         "Management" -> mainContentNavController.safeNavigate(Screen.TimeOffReq.route)
                         else -> Toast.makeText(
                             context,

--- a/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt
@@ -1,6 +1,5 @@
 package com.example.infinite_track.presentation.main
 
-import android.os.Build
 import android.os.Bundle
 import com.example.infinite_track.presentation.screen.splash.SplashNavigationState
 
@@ -33,7 +32,4 @@ fun shouldRequestPostNotifications(
     alreadyRequestedThisLaunch: Boolean,
     isGranted: Boolean,
     navigationState: SplashNavigationState
-): Boolean = sdkInt >= Build.VERSION_CODES.TIRAMISU &&
-    !alreadyRequestedThisLaunch &&
-    !isGranted &&
-    navigationState is SplashNavigationState.NavigateToHome
+): Boolean = false

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -12,6 +12,7 @@ import androidx.navigation.navArgument
 import com.example.infinite_track.data.soucre.dummy.dummyTimeOff
 import com.example.infinite_track.presentation.screen.attendance.AttendanceScreen
 import com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingScreen
+import com.example.infinite_track.presentation.screen.attendance.permission.AttendancePermissionReadinessScreen
 import com.example.infinite_track.presentation.screen.attendance.booking.WfaBookingViewModel
 import com.example.infinite_track.presentation.screen.attendance.face.FaceScannerScreen
 import com.example.infinite_track.presentation.screen.attendance.search.LocationSearchScreen
@@ -46,7 +47,7 @@ fun NavGraphBuilder.mainContentNavGraph(
 
         HomeScreen(
             viewModel = homeViewModel,
-            navigateAttendance = { navController.safeNavigate(Screen.Attendance.route) },
+            navigateAttendance = { navController.safeNavigate(Screen.AttendancePermissionReadiness.route) },
             navigateTimeOffRequest = { navController.safeNavigate(Screen.TimeOffRequest.route) },
             navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) },
             navigateServiceComingSoon = { navController.safeNavigate(Screen.CompanyServiceComingSoon.route) }
@@ -151,6 +152,14 @@ fun NavGraphBuilder.mainContentNavGraph(
                 onBackClick = { navController.navigateBackToProfile() }
             )
         }
+    }
+
+    // Attendance permission readiness gate
+    composable(Screen.AttendancePermissionReadiness.route) {
+        AttendancePermissionReadinessScreen(
+            onBackClick = { navController.popBackStack() },
+            onContinueToWorkMode = { navController.safeNavigate(Screen.Attendance.route) }
+        )
     }
 
     // Attendance Screen

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt
@@ -7,6 +7,7 @@ sealed class Screen(val route: String) {
     data object Contact : Screen("contact")
     data object Wfa : Screen("wfa")
     data object Profile : Screen("profile")
+    data object AttendancePermissionReadiness : Screen("attendance_permission_readiness")
     data object Attendance : Screen("attendance")
     data object LocationSearch : Screen("location_search") // Tambahan untuk pencarian lokasi
 

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/WfaShellNavigationContract.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/WfaShellNavigationContract.kt
@@ -12,6 +12,7 @@ import com.example.infinite_track.R
 object WfaShellNavigationContract {
     private val hiddenRoutes = setOf(
         Screen.Attendance.route,
+        Screen.AttendancePermissionReadiness.route,
         Screen.EditProfile.route,
         Screen.ContactUs.route,
         Screen.PaySlip.route,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerScreen.kt
@@ -108,10 +108,6 @@ fun FaceScannerScreen(
         // Reset scanner terlebih dahulu untuk memastikan state bersih
         viewModel.initializeScanner()
 
-        // Then request camera permission if not granted
-        if (!cameraPermissionState.status.isGranted) {
-            cameraPermissionState.launchPermissionRequest()
-        }
     }
 
     BackHandler {

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
@@ -1,0 +1,374 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
+import com.example.infinite_track.presentation.design.components.navigation.InfiniteTopBar
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
+
+@Composable
+fun AttendancePermissionReadinessScreen(
+    onBackClick: () -> Unit,
+    onContinueToWorkMode: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var uiState by remember { mutableStateOf(context.readAttendancePermissionState()) }
+
+    fun refreshReadiness() {
+        uiState = context.readAttendancePermissionState()
+    }
+
+    val foregroundLocationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { refreshReadiness() }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { refreshReadiness() }
+
+    val notificationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { refreshReadiness() }
+
+    val backgroundLocationLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { refreshReadiness() }
+
+    val settingsLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { refreshReadiness() }
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                refreshReadiness()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(Unit) {
+        refreshReadiness()
+    }
+
+    fun openAppSettings() {
+        val intent = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", context.packageName, null)
+        )
+        settingsLauncher.launch(intent)
+    }
+
+    fun requestAction(action: AttendancePermissionAction) {
+        when (action) {
+            AttendancePermissionAction.REQUEST_FOREGROUND_LOCATION -> foregroundLocationLauncher.launch(
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                )
+            )
+            AttendancePermissionAction.REQUEST_CAMERA -> cameraLauncher.launch(Manifest.permission.CAMERA)
+            AttendancePermissionAction.OPEN_DEVICE_LOCATION_SETTINGS -> settingsLauncher.launch(
+                Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            )
+            AttendancePermissionAction.REQUEST_NOTIFICATION -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    refreshReadiness()
+                }
+            }
+            AttendancePermissionAction.REQUEST_BACKGROUND_LOCATION -> {
+                when {
+                    Build.VERSION.SDK_INT < Build.VERSION_CODES.Q -> refreshReadiness()
+                    Build.VERSION.SDK_INT == Build.VERSION_CODES.Q -> backgroundLocationLauncher.launch(
+                        Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                    )
+                    else -> openAppSettings()
+                }
+            }
+            AttendancePermissionAction.CONTINUE_TO_WORK_MODE -> onContinueToWorkMode()
+        }
+    }
+
+    AttendancePermissionReadinessContent(
+        uiState = uiState,
+        modifier = modifier,
+        onBackClick = onBackClick,
+        onPrimaryClick = {
+            val nextAction = uiState.nextRequiredAction
+            if (uiState.canContinueToWorkMode || nextAction == AttendancePermissionAction.CONTINUE_TO_WORK_MODE) {
+                onContinueToWorkMode()
+            } else if (nextAction != null) {
+                requestAction(nextAction)
+            }
+        },
+        onForegroundLocationClick = { requestAction(AttendancePermissionAction.REQUEST_FOREGROUND_LOCATION) },
+        onCameraClick = { requestAction(AttendancePermissionAction.REQUEST_CAMERA) },
+        onNotificationClick = { requestAction(AttendancePermissionAction.REQUEST_NOTIFICATION) },
+        onBackgroundLocationClick = { requestAction(AttendancePermissionAction.REQUEST_BACKGROUND_LOCATION) },
+        onDeviceLocationSettingsClick = { requestAction(AttendancePermissionAction.OPEN_DEVICE_LOCATION_SETTINGS) }
+    )
+}
+
+@Composable
+private fun AttendancePermissionReadinessContent(
+    uiState: AttendancePermissionReadinessUiState,
+    onBackClick: () -> Unit,
+    onPrimaryClick: () -> Unit,
+    onForegroundLocationClick: () -> Unit,
+    onCameraClick: () -> Unit,
+    onNotificationClick: () -> Unit,
+    onBackgroundLocationClick: () -> Unit,
+    onDeviceLocationSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(InfiniteColors.AttendanceReportBackground)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(280.dp)
+                .align(Alignment.TopEnd)
+                .padding(top = 24.dp)
+                .background(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            InfiniteColors.Primary.copy(alpha = 0.24f),
+                            Color.Transparent
+                        )
+                    ),
+                    shape = CircleShape
+                )
+                .blur(32.dp)
+        )
+        Box(
+            modifier = Modifier
+                .size(260.dp)
+                .align(Alignment.BottomStart)
+                .background(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            InfiniteColors.Accent.copy(alpha = 0.18f),
+                            Color.Transparent
+                        )
+                    ),
+                    shape = CircleShape
+                )
+                .blur(36.dp)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            InfiniteTopBar(
+                title = "Attendance",
+                navigationIcon = Icons.AutoMirrored.Filled.ArrowBack,
+                navigationContentDescription = "Kembali",
+                onNavigationClick = onBackClick
+            )
+            PermissionHeroCard(uiState = uiState)
+            PermissionProgressHeader(uiState = uiState)
+
+            InfiniteCard(
+                variant = InfiniteSurfaceVariant.Glass,
+                density = InfiniteDensity.Comfortable,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    InfiniteSectionHeader(
+                        title = "Akses wajib",
+                        subtitle = "Harus siap sebelum memilih mode kerja",
+                        leadingIcon = Icons.Default.Shield
+                    )
+                    PermissionMissionRow(
+                        title = "Lokasi presisi",
+                        description = "Dipakai untuk membaca posisi saat absensi.",
+                        icon = Icons.Default.LocationOn,
+                        isGranted = uiState.foregroundLocationGranted,
+                        isRequired = true,
+                        actionLabel = if (uiState.foregroundLocationGranted) null else "Minta izin",
+                        onActionClick = if (uiState.foregroundLocationGranted) null else onForegroundLocationClick
+                    )
+                    PermissionMissionRow(
+                        title = "Kamera",
+                        description = "Dipakai untuk verifikasi wajah saat check-in/check-out.",
+                        icon = Icons.Default.PhotoCamera,
+                        isGranted = uiState.cameraGranted,
+                        isRequired = true,
+                        actionLabel = if (uiState.cameraGranted) null else "Minta izin",
+                        onActionClick = if (uiState.cameraGranted) null else onCameraClick
+                    )
+                    PermissionMissionRow(
+                        title = "Lokasi perangkat aktif",
+                        description = "Pastikan Location/GPS perangkat menyala.",
+                        icon = Icons.Default.Settings,
+                        isGranted = uiState.deviceLocationEnabled,
+                        isRequired = true,
+                        actionLabel = if (uiState.deviceLocationEnabled) null else "Buka pengaturan",
+                        onActionClick = if (uiState.deviceLocationEnabled) null else onDeviceLocationSettingsClick
+                    )
+                }
+            }
+
+            InfiniteCard(
+                variant = InfiniteSurfaceVariant.Glass,
+                density = InfiniteDensity.Comfortable,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    InfiniteSectionHeader(
+                        title = "Opsional untuk pengingat",
+                        subtitle = "Tidak memblokir absensi manual",
+                        leadingIcon = Icons.Default.Notifications,
+                        trailingText = "Degraded OK"
+                    )
+                    PermissionMissionRow(
+                        title = "Notifikasi pengingat",
+                        description = "Membantu mengingatkan aktivitas absensi.",
+                        icon = Icons.Default.Notifications,
+                        isGranted = uiState.notificationGranted,
+                        isRequired = false,
+                        actionLabel = if (uiState.notificationGranted) null else "Aktifkan",
+                        onActionClick = if (uiState.notificationGranted) null else onNotificationClick
+                    )
+                    PermissionMissionRow(
+                        title = "Lokasi latar belakang",
+                        description = "Mengaktifkan reminder geofence dan monitoring aktif.",
+                        icon = Icons.Default.Tune,
+                        isGranted = uiState.backgroundLocationGranted,
+                        isRequired = false,
+                        actionLabel = if (uiState.backgroundLocationGranted) null else "Atur akses",
+                        onActionClick = if (uiState.backgroundLocationGranted) null else onBackgroundLocationClick
+                    )
+                }
+            }
+
+            PermissionReadinessInfoBox(uiState = uiState)
+
+            InfiniteButton(
+                text = if (uiState.canContinueToWorkMode) "Lanjut ke Mode Kerja" else "Lanjutkan Setup",
+                onClick = onPrimaryClick,
+                modifier = Modifier.fillMaxWidth(),
+                variant = InfiniteButtonVariant.Primary,
+                state = InfiniteButtonState.Enabled,
+                fullWidth = true
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+private fun Context.readAttendancePermissionState(): AttendancePermissionReadinessUiState =
+    toAttendancePermissionReadinessUiState(
+        foregroundLocationGranted = isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION),
+        cameraGranted = isPermissionGranted(Manifest.permission.CAMERA),
+        deviceLocationEnabled = isDeviceLocationEnabled(),
+        notificationGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS),
+        backgroundLocationGranted = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            isPermissionGranted(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    )
+
+private fun Context.isPermissionGranted(permission: String): Boolean =
+    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+
+private fun Context.isDeviceLocationEnabled(): Boolean {
+    val locationManager = getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return false
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        locationManager.isLocationEnabled
+    } else {
+        locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
+            locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AttendancePermissionReadinessContentPreview() {
+    Infinite_TrackTheme {
+        AttendancePermissionReadinessContent(
+            uiState = toAttendancePermissionReadinessUiState(
+                foregroundLocationGranted = true,
+                cameraGranted = true,
+                deviceLocationEnabled = false,
+                notificationGranted = false,
+                backgroundLocationGranted = false
+            ),
+            onBackClick = {},
+            onPrimaryClick = {},
+            onForegroundLocationClick = {},
+            onCameraClick = {},
+            onNotificationClick = {},
+            onBackgroundLocationClick = {},
+            onDeviceLocationSettingsClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiState.kt
@@ -1,0 +1,70 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+enum class AttendancePermissionAction {
+    REQUEST_FOREGROUND_LOCATION,
+    REQUEST_CAMERA,
+    OPEN_DEVICE_LOCATION_SETTINGS,
+    REQUEST_NOTIFICATION,
+    REQUEST_BACKGROUND_LOCATION,
+    CONTINUE_TO_WORK_MODE
+}
+
+data class AttendancePermissionReadinessUiState(
+    val foregroundLocationGranted: Boolean,
+    val cameraGranted: Boolean,
+    val deviceLocationEnabled: Boolean,
+    val notificationGranted: Boolean,
+    val backgroundLocationGranted: Boolean,
+    val requiredReadyCount: Int,
+    val requiredTotalCount: Int = REQUIRED_ATTENDANCE_ACCESS_COUNT,
+    val canContinueToWorkMode: Boolean,
+    val nextRequiredAction: AttendancePermissionAction?,
+    val warningMessage: String? = null
+) {
+    val progressCopy: String
+        get() = "$requiredReadyCount/$requiredTotalCount akses wajib siap"
+}
+
+private const val REQUIRED_ATTENDANCE_ACCESS_COUNT = 3
+
+fun toAttendancePermissionReadinessUiState(
+    foregroundLocationGranted: Boolean,
+    cameraGranted: Boolean,
+    deviceLocationEnabled: Boolean,
+    notificationGranted: Boolean,
+    backgroundLocationGranted: Boolean
+): AttendancePermissionReadinessUiState {
+    val requiredReadyCount = listOf(
+        foregroundLocationGranted,
+        cameraGranted,
+        deviceLocationEnabled
+    ).count { it }
+    val canContinue = requiredReadyCount == REQUIRED_ATTENDANCE_ACCESS_COUNT
+    val nextRequiredAction = when {
+        !foregroundLocationGranted -> AttendancePermissionAction.REQUEST_FOREGROUND_LOCATION
+        !cameraGranted -> AttendancePermissionAction.REQUEST_CAMERA
+        !deviceLocationEnabled -> AttendancePermissionAction.OPEN_DEVICE_LOCATION_SETTINGS
+        else -> AttendancePermissionAction.CONTINUE_TO_WORK_MODE
+    }
+    val warningMessage = when {
+        !notificationGranted && !backgroundLocationGranted ->
+            "Pengingat notifikasi dan pemantauan geofence berjalan terbatas. Absensi manual tetap bisa dilanjutkan."
+        !notificationGranted ->
+            "Pengingat notifikasi belum aktif. Absensi manual tetap bisa dilanjutkan."
+        !backgroundLocationGranted ->
+            "Pemantauan geofence latar belakang belum aktif. Absensi manual tetap bisa dilanjutkan."
+        else -> null
+    }
+
+    return AttendancePermissionReadinessUiState(
+        foregroundLocationGranted = foregroundLocationGranted,
+        cameraGranted = cameraGranted,
+        deviceLocationEnabled = deviceLocationEnabled,
+        notificationGranted = notificationGranted,
+        backgroundLocationGranted = backgroundLocationGranted,
+        requiredReadyCount = requiredReadyCount,
+        canContinueToWorkMode = canContinue,
+        nextRequiredAction = nextRequiredAction,
+        warningMessage = warningMessage
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionHeroCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionHeroCard.kt
@@ -1,0 +1,78 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.components.tittle.Tittle
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+@Composable
+internal fun PermissionHeroCard(
+    uiState: AttendancePermissionReadinessUiState,
+    modifier: Modifier = Modifier
+) {
+    InfiniteCard(
+        variant = InfiniteSurfaceVariant.Glass,
+        density = InfiniteDensity.Spacious,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Surface(
+                modifier = Modifier.size(92.dp),
+                shape = CircleShape,
+                color = InfiniteColors.Primary.copy(alpha = 0.12f),
+                border = BorderStroke(1.dp, InfiniteColors.Primary.copy(alpha = 0.24f))
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Default.Shield,
+                        contentDescription = null,
+                        modifier = Modifier.size(46.dp),
+                        tint = InfiniteColors.Primary
+                    )
+                }
+            }
+            Tittle(tittle = "Siapkan akses absensi")
+            Text(
+                text = "Kami cek lokasi, kamera, dan status lokasi perangkat sebelum Anda memilih mode kerja.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = InfiniteColors.Text.copy(alpha = 0.72f),
+                textAlign = TextAlign.Center
+            )
+            InfiniteStatusPill(
+                label = uiState.progressCopy,
+                variant = if (uiState.canContinueToWorkMode) {
+                    InfiniteStatusVariant.Completed
+                } else {
+                    InfiniteStatusVariant.Pending
+                },
+                size = InfiniteSize.Medium
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionMissionRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionMissionRow.kt
@@ -1,0 +1,94 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.button.InfiniteButton
+import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.components.data.InfiniteInfoRow
+import com.example.infinite_track.presentation.design.components.data.InfiniteInfoRowOrientation
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+
+@Composable
+internal fun PermissionMissionRow(
+    title: String,
+    description: String,
+    icon: ImageVector,
+    isGranted: Boolean,
+    isRequired: Boolean,
+    actionLabel: String?,
+    modifier: Modifier = Modifier,
+    onActionClick: (() -> Unit)? = null
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = Color.White.copy(alpha = 0.64f),
+        border = BorderStroke(
+            width = 1.dp,
+            color = if (isGranted) {
+                InfiniteColors.Success.copy(alpha = 0.42f)
+            } else {
+                InfiniteColors.Primary.copy(alpha = 0.12f)
+            }
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                InfiniteInfoRow(
+                    label = title,
+                    value = description,
+                    icon = icon,
+                    semantic = if (isGranted) InfiniteSemantic.Success else InfiniteSemantic.Primary,
+                    orientation = InfiniteInfoRowOrientation.Vertical,
+                    statusContent = {
+                        InfiniteStatusPill(
+                            label = if (isRequired) "Wajib" else "Opsional",
+                            variant = if (isRequired) InfiniteStatusVariant.Pending else InfiniteStatusVariant.Neutral,
+                            size = InfiniteSize.Small
+                        )
+                    }
+                )
+                if (!isGranted && actionLabel != null && onActionClick != null) {
+                    InfiniteButton(
+                        text = actionLabel,
+                        onClick = onActionClick,
+                        variant = InfiniteButtonVariant.Ghost,
+                        size = InfiniteSize.Small
+                    )
+                }
+            }
+            Icon(
+                imageVector = if (isGranted) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                contentDescription = if (isGranted) "Siap" else "Belum siap",
+                tint = if (isGranted) InfiniteColors.Success else InfiniteColors.Neutral.copy(alpha = 0.56f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionProgressHeader.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionProgressHeader.kt
@@ -1,0 +1,58 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
+
+@Composable
+internal fun PermissionProgressHeader(
+    uiState: AttendancePermissionReadinessUiState,
+    modifier: Modifier = Modifier
+) {
+    InfiniteCard(
+        variant = InfiniteSurfaceVariant.StatusTint,
+        semantic = if (uiState.canContinueToWorkMode) InfiniteSemantic.Success else InfiniteSemantic.Warning,
+        density = InfiniteDensity.Comfortable,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = uiState.progressCopy,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = InfiniteColors.Text
+                )
+                Text(
+                    text = if (uiState.canContinueToWorkMode) "Siap" else "Perlu setup",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = InfiniteColors.Text.copy(alpha = 0.68f)
+                )
+            }
+            LinearProgressIndicator(
+                progress = { uiState.requiredReadyCount / uiState.requiredTotalCount.toFloat() },
+                modifier = Modifier.fillMaxWidth(),
+                color = if (uiState.canContinueToWorkMode) InfiniteColors.Success else InfiniteColors.Primary,
+                trackColor = InfiniteColors.Primary.copy(alpha = 0.14f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionReadinessInfoBox.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionReadinessInfoBox.kt
@@ -1,0 +1,25 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+
+@Composable
+internal fun PermissionReadinessInfoBox(
+    uiState: AttendancePermissionReadinessUiState,
+    modifier: Modifier = Modifier
+) {
+    InfiniteInlineAlert(
+        title = if (uiState.canContinueToWorkMode) {
+            "Akses wajib sudah siap"
+        } else {
+            "Selesaikan akses wajib"
+        },
+        message = uiState.warningMessage
+            ?: "Notifikasi dan lokasi latar belakang membantu reminder, tetapi tidak memblokir absensi manual.",
+        semantic = if (uiState.canContinueToWorkMode) InfiniteSemantic.Info else InfiniteSemantic.Warning,
+        modifier = modifier.fillMaxWidth()
+    )
+}

--- a/app/src/main/java/com/example/infinite_track/utils/LocationPermissionHelper.kt
+++ b/app/src/main/java/com/example/infinite_track/utils/LocationPermissionHelper.kt
@@ -59,14 +59,11 @@ class LocationPermissionHelper(
      */
     fun checkAndRequestPermissions() {
         when {
-            hasAllRequiredPermissions() -> {
+            hasRequiredForegroundLocationPermission() -> {
                 onPermissionResult(PermissionResult.AllPermissionsGranted)
             }
             !hasForegroundLocationPermission() -> {
                 requestForegroundLocationPermissions()
-            }
-            !hasBackgroundLocationPermission() -> {
-                requestBackgroundLocationPermission()
             }
         }
     }
@@ -74,6 +71,10 @@ class LocationPermissionHelper(
     /**
      * Check apakah semua permission yang diperlukan sudah diberikan
      */
+    private fun hasRequiredForegroundLocationPermission(): Boolean {
+        return hasForegroundLocationPermission()
+    }
+
     private fun hasAllRequiredPermissions(): Boolean {
         return hasForegroundLocationPermission() && hasBackgroundLocationPermission()
     }
@@ -146,12 +147,7 @@ class LocationPermissionHelper(
 
         when {
             fineLocationGranted || coarseLocationGranted -> {
-                // Foreground permission berhasil, lanjut ke background permission
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    requestBackgroundLocationPermission()
-                } else {
-                    onPermissionResult(PermissionResult.AllPermissionsGranted)
-                }
+                onPermissionResult(PermissionResult.AllPermissionsGranted)
             }
             shouldShowRationale() -> {
                 onPermissionResult(PermissionResult.ForegroundPermissionDenied)
@@ -212,9 +208,9 @@ class LocationPermissionHelper(
      */
     fun getPermissionStatusMessage(): String {
         return when {
-            hasAllRequiredPermissions() -> "Semua izin lokasi telah diberikan"
+            hasAllRequiredPermissions() -> "Izin lokasi dan pemantauan latar belakang telah diberikan"
+            hasRequiredForegroundLocationPermission() -> "Izin lokasi utama siap. Lokasi latar belakang hanya untuk pengingat geofence."
             !hasForegroundLocationPermission() -> "Izin lokasi diperlukan untuk fitur absensi"
-            !hasBackgroundLocationPermission() -> "Izin lokasi latar belakang diperlukan untuk pemantauan area kerja"
             else -> "Status izin tidak diketahui"
         }
     }

--- a/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicyTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class StartupNotificationPermissionPolicyTest {
 
     @Test
-    fun `requests post notifications only after authenticated startup on Android 13 plus`() {
+    fun `does not request post notifications after authenticated startup`() {
         val shouldRequest = shouldRequestPostNotifications(
             sdkInt = Build.VERSION_CODES.TIRAMISU,
             alreadyRequestedThisLaunch = false,
@@ -17,7 +17,7 @@ class StartupNotificationPermissionPolicyTest {
             navigationState = SplashNavigationState.NavigateToHome
         )
 
-        assertTrue(shouldRequest)
+        assertFalse(shouldRequest)
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiStateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiStateTest.kt
@@ -1,0 +1,68 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttendancePermissionReadinessUiStateTest {
+
+    @Test
+    fun `required progress counts foreground camera and device location only`() {
+        val state = toAttendancePermissionReadinessUiState(
+            foregroundLocationGranted = true,
+            cameraGranted = false,
+            deviceLocationEnabled = true,
+            notificationGranted = true,
+            backgroundLocationGranted = true
+        )
+
+        assertEquals(2, state.requiredReadyCount)
+        assertEquals(3, state.requiredTotalCount)
+        assertEquals("2/3 akses wajib siap", state.progressCopy)
+        assertFalse(state.canContinueToWorkMode)
+        assertEquals(AttendancePermissionAction.REQUEST_CAMERA, state.nextRequiredAction)
+    }
+
+    @Test
+    fun `notification denied does not block work mode`() {
+        val state = toAttendancePermissionReadinessUiState(
+            foregroundLocationGranted = true,
+            cameraGranted = true,
+            deviceLocationEnabled = true,
+            notificationGranted = false,
+            backgroundLocationGranted = true
+        )
+
+        assertTrue(state.canContinueToWorkMode)
+        assertEquals(AttendancePermissionAction.CONTINUE_TO_WORK_MODE, state.nextRequiredAction)
+    }
+
+    @Test
+    fun `background location denied does not block work mode`() {
+        val state = toAttendancePermissionReadinessUiState(
+            foregroundLocationGranted = true,
+            cameraGranted = true,
+            deviceLocationEnabled = true,
+            notificationGranted = true,
+            backgroundLocationGranted = false
+        )
+
+        assertTrue(state.canContinueToWorkMode)
+        assertEquals(AttendancePermissionAction.CONTINUE_TO_WORK_MODE, state.nextRequiredAction)
+    }
+
+    @Test
+    fun `device location setting is a hard blocker`() {
+        val state = toAttendancePermissionReadinessUiState(
+            foregroundLocationGranted = true,
+            cameraGranted = true,
+            deviceLocationEnabled = false,
+            notificationGranted = true,
+            backgroundLocationGranted = true
+        )
+
+        assertFalse(state.canContinueToWorkMode)
+        assertEquals(AttendancePermissionAction.OPEN_DEVICE_LOCATION_SETTINGS, state.nextRequiredAction)
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-inf-230-attendance-permission-readiness.md
+++ b/docs/superpowers/plans/2026-07-09-inf-230-attendance-permission-readiness.md
@@ -1,0 +1,288 @@
+# INF-230 Implementation Plan — Attendance Permission Readiness
+
+Date: 2026-07-09
+Branch/worktree: `fix/android-attendance-permission-readiness` / `C:\Users\Febriyadi\.claude\worktrees\android-attendance-permission-readiness`
+Spec: `docs/superpowers/specs/2026-07-09-inf-230-attendance-permission-readiness.md`
+
+## Scope
+
+Implement an Attendance Permission Readiness screen before the existing Attendance work-mode UI and consolidate normal Attendance permission ownership there.
+
+This plan intentionally avoids backend contract changes, check-in/check-out submission changes, Work Mode Selection redesign, and FaceScanner redesign.
+
+## Pre-flight Evidence
+
+- Main checkout `E:\skrisi\android` is dirty and must not be edited.
+- Isolated branch/worktree created from `develop` HEAD `c5b8e6c`.
+- Existing attendance-related worktrees are stale/different scope and not used for this issue.
+- `.claude/rules/*.md` files requested by operator are not present; `CLAUDE.md` remains the active repo contract.
+
+## Implementation Steps
+
+### 1. Add navigation route and gate normal Attendance entries
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/navigation/Screen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/main/MainScreen.kt`
+
+Actions:
+
+1. Add `Screen.AttendancePermissionReadiness` route.
+2. Add composable route for readiness screen in `MainContentNavGraph`.
+3. Change Home attendance entry to navigate to readiness instead of `Screen.Attendance`.
+4. Change Internship FAB attendance entry to navigate to readiness instead of `Screen.Attendance`.
+5. Keep `Screen.Attendance` as the existing Work Mode Selection / Attendance screen target.
+
+Expected outcome:
+
+- Normal user path becomes Home/FAB → readiness → Attendance.
+- Existing Attendance route remains available for post-readiness navigation and defensive direct route cases.
+
+### 2. Remove startup/Home notification permission prompt
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/main/StartupNotificationPermissionPolicy.kt`
+- Related unit tests if present.
+
+Actions:
+
+1. Stop observing startup navigation state for notification permission request.
+2. Remove the `POST_NOTIFICATIONS` launcher from `MainActivity` if no longer needed.
+3. Remove or neutralize startup policy usage so Home is not a prompt trigger.
+4. Keep notification channel creation intact because channels are not the same as runtime permission prompts.
+5. If policy tests exist, update them to reflect that startup no longer owns this prompt, or remove policy if unused.
+
+Expected outcome:
+
+- App can open to Home without Android 13+ notification prompt.
+- Notification permission can only be requested from readiness after user action.
+
+### 3. Add readiness state and permission gateway
+
+Recommended files:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiState.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionAction.kt`
+
+Optional if needed for testability:
+
+- `app/src/main/java/com/example/infinite_track/domain/attendance/permission/*`
+- `app/src/main/java/com/example/infinite_track/data/attendance/permission/*`
+
+Actions:
+
+1. Model required state:
+   - foreground precise location granted
+   - camera granted
+   - device location setting enabled
+2. Model optional state:
+   - notification granted or not applicable pre-Android 13
+   - background location granted or not applicable pre-Android 10
+3. Derive:
+   - `requiredReadyCount`
+   - `requiredTotalCount = 3`
+   - `canContinueToWorkMode`
+   - `nextRequiredAction`
+4. Use Android APIs carefully:
+   - `ContextCompat.checkSelfPermission` for location/camera/notification/background.
+   - `LocationManager` or Google location settings check for device location enabled.
+   - Activity result launchers in the screen for permission/settings user actions.
+5. Refresh readiness on resume/settings return.
+
+Expected outcome:
+
+- Screen can honestly show readiness and degraded optional access without invoking backend or attendance submission code.
+
+### 4. Build readiness UI with existing design system components
+
+Files:
+
+- `AttendancePermissionReadinessScreen.kt`
+- Small local wrapper composables in same package/file if simple.
+
+Actions:
+
+1. Compose top bar, background, hero/card, permission rows, progress header, info box, and CTAs.
+2. Use progress copy like `2/3 akses wajib siap`.
+3. Required rows:
+   - Lokasi presisi
+   - Kamera
+   - Lokasi perangkat aktif
+4. Optional/degraded rows:
+   - Notifikasi pengingat
+   - Lokasi latar belakang
+5. Primary CTA behavior:
+   - If required incomplete: execute next required action.
+   - If required complete: navigate to `Screen.Attendance.route` with CTA `Lanjut ke Mode Kerja`.
+6. Optional actions must be user-initiated and must not block continue.
+
+Expected outcome:
+
+- Readiness screen matches product direction and makes required vs optional semantics visible.
+
+### 5. Refactor AttendanceMap to defensive fallback only
+
+File:
+
+- `app/src/main/java/com/example/infinite_track/presentation/components/maps/AttendanceMap.kt`
+
+Actions:
+
+1. Remove normal foreground permission request ownership from map.
+2. Remove background location as a map rendering blocker.
+3. Keep a defensive missing-foreground UI if route is reached unexpectedly without foreground permission.
+4. Ensure `location.enabled = true` is only called when foreground location is granted.
+5. Avoid opening settings/requesting background from map.
+
+Expected outcome:
+
+- Map consumes readiness assumptions but does not own normal permission flow.
+- Background missing does not prevent basic/manual attendance UI from loading.
+
+### 6. Refactor FaceScanner fallback
+
+File:
+
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerScreen.kt`
+
+Actions:
+
+1. Remove automatic `cameraPermissionState.launchPermissionRequest()` from `LaunchedEffect(Unit)`.
+2. Keep scanner initialization.
+3. Keep rationale/denied UI as defensive fallback with explicit user action.
+4. Ensure normal path after readiness opens camera content without prompt.
+
+Expected outcome:
+
+- Camera permission is requested from readiness, not FaceScanner, in the normal path.
+
+### 7. Clarify LocationPermissionHelper and AttendanceScreen permission dialog behavior
+
+Files:
+
+- `app/src/main/java/com/example/infinite_track/utils/LocationPermissionHelper.kt`
+- `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt`
+
+Actions:
+
+1. Split helper semantics so foreground required and background optional/degraded are not conflated.
+2. Avoid using `checkAndRequestPermissions()` as a normal Attendance gate after readiness.
+3. Keep `LocationPermissionDialog` only if it remains defensive and does not force background as a hard blocker.
+4. Update user-facing copy to avoid saying all location/background access is required for basic attendance.
+
+Expected outcome:
+
+- Existing fallback does not fight the new readiness gate.
+
+### 8. Clarify GeofenceManager readiness naming/copy
+
+File:
+
+- `app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt`
+
+Actions:
+
+1. Preserve strict permission checks for actual geofence registration.
+2. Clarify methods/copy so `hasAllRequiredPermissions()` is not used as basic attendance readiness.
+3. Prefer names like `hasRequiredGeofencePermissions()` if changing call sites is safe.
+4. Do not make background location required for continuing to Work Mode Selection.
+
+Expected outcome:
+
+- Background location remains required for geofence registration, but optional/degraded for basic attendance readiness.
+
+### 9. Add/update tests where practical
+
+Search first for existing tests around:
+
+- startup notification policy
+- readiness state derivation
+- route policy/navigation helper if testable
+
+Recommended tests:
+
+1. Required count derives from foreground/camera/device-location only.
+2. Notification denied does not block `canContinueToWorkMode`.
+3. Background denied does not block `canContinueToWorkMode`.
+4. Startup notification policy no longer allows Home prompt, or policy is removed and tests updated accordingly.
+
+### 10. Verification
+
+Run from isolated worktree:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+Recommended if time/environment allows:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime/emulator smoke:
+
+```text
+Open app -> Home -> no notification permission prompt
+Tap Attendance -> Permission Readiness screen
+Grant foreground location from readiness
+Grant camera from readiness
+Turn device location ON via settings if needed
+Skip/deny notification and background location
+Continue to Work Mode Selection
+Open scanner -> no normal camera prompt if readiness granted camera
+```
+
+If emulator/runtime capture cannot be produced, mark all required recordings/screenshots as `Needs Verification`.
+
+## File Ownership Boundaries
+
+Do not touch:
+
+- Backend contract files.
+- Attendance submission DTO/API logic unless compile forces an import-only change.
+- Work Mode Selection layout beyond wiring route/gate.
+- Face scanner visual design beyond removing auto permission request.
+- Unrelated Home dashboard/service features.
+
+High-risk files must be changed narrowly:
+
+- `MainActivity.kt`
+- `AttendanceMap.kt`
+- `FaceScannerScreen.kt`
+- `GeofenceManager.kt`
+- `LocationPermissionHelper.kt`
+
+## Rollback Strategy
+
+If readiness route causes navigation issues:
+
+1. Revert entry route changes to `Screen.Attendance.route`.
+2. Keep new readiness files isolated if they compile independently.
+3. Revert startup notification removal only if product explicitly wants Home prompt back.
+
+If map/scanner fallback causes runtime issues:
+
+1. Restore defensive UI first, but keep normal request ownership in readiness.
+2. Do not restore startup/Home notification prompt unless directed.
+
+## PR Notes Checklist
+
+- Work done in isolated branch/worktree.
+- INF-230 handled as permission ownership consolidation, not only UI.
+- Attendance entry now goes through grouped readiness gate.
+- Notification prompt removed from startup/Home.
+- Foreground location, camera, and device location setting are hard blockers.
+- Notification and background location are optional/degraded.
+- AttendanceMap and FaceScanner no longer own normal permission request flow.
+- Existing fallbacks remain defensive only.
+- No backend/check-in/check-out contract changes.
+- Build evidence included.
+- Runtime evidence included or marked `Needs Verification`.
+- Docs/ADR note included.

--- a/docs/superpowers/specs/2026-07-09-inf-230-attendance-permission-readiness.md
+++ b/docs/superpowers/specs/2026-07-09-inf-230-attendance-permission-readiness.md
@@ -1,0 +1,242 @@
+# INF-230 — Android Attendance Permission Readiness
+
+Date: 2026-07-09
+Branch/worktree: `fix/android-attendance-permission-readiness` / `C:\Users\Febriyadi\.claude\worktrees\android-attendance-permission-readiness`
+
+## Summary
+
+INF-230 consolidates Attendance-related permission ownership into one readiness gate before the user reaches the existing Attendance work-mode UI. This is a permission ownership change, not a backend contract change and not a redesign of Work Mode Selection, Attendance submission, or FaceScanner.
+
+Final target flow:
+
+```text
+Home / Attendance entry
+→ Attendance Permission Readiness Screen
+→ required access check/request
+→ Work Mode Selection / AttendanceScreen
+→ Attendance flow
+```
+
+Android remains a trusted data-capture client. Backend remains authoritative for attendance outcomes, auth/session validity, booking approval semantics, scheduled-job effects, and final reporting state.
+
+## Current Repo Evidence
+
+- Attendance route is `Screen.Attendance : Screen("attendance")` in `presentation/navigation/Screen.kt`.
+- Home attendance entry currently navigates directly to `Screen.Attendance.route` in `presentation/navigation/MainContentNavGraph.kt`.
+- Internship FAB currently navigates directly to `Screen.Attendance.route` in `presentation/main/MainScreen.kt`.
+- `MainActivity` currently requests `POST_NOTIFICATIONS` after startup navigation resolves to Home through `StartupNotificationPermissionPolicy`.
+- `AttendanceMap` currently owns foreground location request and background location request/settings fallback.
+- `AttendanceScreen` still shows `LocationPermissionDialog` through `LocationPermissionHelper`.
+- `FaceScannerScreen` currently launches camera permission request from `LaunchedEffect(Unit)` when the scanner opens.
+- `LocationPermissionHelper` currently treats foreground + background location as all required permissions.
+- `GeofenceManager` currently treats foreground + background location as full geofence readiness.
+
+## Product Contract
+
+### Required access — hard blocker before Work Mode Selection
+
+1. Foreground precise location.
+2. Camera access.
+3. Device location setting ON.
+
+The readiness screen must not continue to Work Mode Selection until all required access is ready.
+
+### Optional / degraded access — not a blocker
+
+4. Notification reminder.
+5. Background location for geofence reminder / active monitoring.
+
+Notification denied/skipped and background location denied/skipped must not block basic/manual attendance. They should mark reminder/background monitoring as degraded.
+
+### Progress copy
+
+Primary progress must use required count only:
+
+```text
+2/3 akses wajib siap
+3/3 akses wajib siap
+```
+
+Do not use `2/5 akses siap` as the primary progress because notification/background location are optional rows.
+
+## UX Requirements
+
+The readiness screen should follow the visual direction from the issue:
+
+- Attendance top bar.
+- Soft blurred map-like background.
+- Semi-liquid white/lavender card.
+- Hero illustration/metaphor for secure location and camera access.
+- Checklist permission rows.
+- Progress indicator using required gate count.
+- Info box explaining required vs optional/degraded access.
+- Primary CTA:
+  - `Minta Izin` / `Lanjutkan Setup` while required access is pending.
+  - `Lanjut ke Mode Kerja` when required access is complete.
+- Secondary action for device location settings or optional setup when applicable.
+
+Use existing INF-222 design components where practical:
+
+- `InfiniteCard` / `InfiniteSurface`
+- `InfiniteStatusPill`
+- `InfiniteInfoRow`
+- `InfiniteButton`
+- `InfiniteIconButton`
+- `InfiniteInlineAlert`
+
+Small local wrappers are allowed:
+
+- `AttendancePermissionReadinessScreen`
+- `PermissionMissionRow`
+- `PermissionProgressHeader`
+- `PermissionReadinessInfoBox`
+
+## State Model
+
+Recommended presentation state:
+
+```kotlin
+data class AttendancePermissionReadinessUiState(
+    val foregroundLocationGranted: Boolean,
+    val cameraGranted: Boolean,
+    val deviceLocationEnabled: Boolean,
+    val notificationGranted: Boolean,
+    val backgroundLocationGranted: Boolean,
+    val requiredReadyCount: Int,
+    val requiredTotalCount: Int = 3,
+    val canContinueToWorkMode: Boolean,
+    val nextRequiredAction: AttendancePermissionAction?,
+    val warningMessage: String? = null
+)
+
+enum class AttendancePermissionAction {
+    REQUEST_FOREGROUND_LOCATION,
+    REQUEST_CAMERA,
+    OPEN_DEVICE_LOCATION_SETTINGS,
+    REQUEST_NOTIFICATION,
+    REQUEST_BACKGROUND_LOCATION,
+    CONTINUE_TO_WORK_MODE
+}
+```
+
+Required readiness must be derived from:
+
+```text
+foregroundLocationGranted && cameraGranted && deviceLocationEnabled
+```
+
+Optional readiness must be derived separately:
+
+```text
+hasOptionalReminderAccess = notificationGranted
+hasOptionalBackgroundGeofenceAccess = backgroundLocationGranted
+```
+
+## Architecture / Ownership
+
+### New owner
+
+`AttendancePermissionReadinessScreen` owns the normal permission request sequence for Attendance:
+
+- foreground location request
+- camera request
+- device location settings action
+- optional notification request after user action
+- optional background location request/settings action after user action
+
+The screen must refresh readiness when returning from permission or settings flows.
+
+### Downstream consumers
+
+`AttendanceScreen`, `AttendanceMap`, `FaceScannerScreen`, and `GeofenceManager` are consumers/defensive fallbacks, not normal permission owners.
+
+- `AttendanceMap` may show a defensive fallback if foreground permission is unexpectedly missing, but should not own normal request flow and should not require background location to render basic/manual attendance UI.
+- `FaceScannerScreen` may show a defensive camera permission fallback, but should not automatically request camera permission on open.
+- `AttendanceScreen` should avoid prompting location permission as the normal path. Existing dialog can remain only if it is clearly defensive and does not reintroduce foreground/background as required before readiness.
+- `GeofenceManager` may still require background location to register geofences, but helper naming/copy must not imply background location blocks basic/manual attendance.
+
+## Navigation Contract
+
+Add a new route before Attendance:
+
+```text
+Screen.AttendancePermissionReadiness.route
+```
+
+Normal attendance entries should navigate to readiness:
+
+- Home attendance action.
+- Internship FAB attendance action.
+- AppNavigator / notification-triggered attendance navigation.
+
+Readiness should navigate to `Screen.Attendance.route` only when required access is ready.
+
+## Non-goals
+
+- Do not change backend contracts.
+- Do not change check-in/check-out submission logic.
+- Do not redesign Work Mode Selection.
+- Do not redesign FaceScanner.
+- Do not request all permissions automatically on screen open.
+- Do not make notification/background location hard blockers.
+- Do not create a global `InfiniteIcons` object.
+- Do not refactor unrelated Home dashboard features.
+
+## Acceptance Criteria
+
+- Attendance-specific notification permission is no longer requested automatically on Home/startup.
+- User sees notification permission request only after entering readiness screen and taking an action.
+- Readiness checks foreground location, camera, device location setting, notification, and background location in one grouped screen.
+- Progress uses required gate count, e.g. `2/3 akses wajib siap`.
+- Foreground location, camera, and device location setting are hard blockers before Work Mode Selection.
+- Notification denied/skipped does not block Work Mode Selection.
+- Background location denied/skipped does not block Work Mode Selection.
+- Background location denied/skipped marks reminder/background geofence as degraded.
+- AttendanceMap no longer owns the normal permission request flow.
+- FaceScanner no longer owns the normal camera permission request flow.
+- Existing fallback permission UIs may remain defensive only.
+- Permission Readiness screen appears before Work Mode Selection when required readiness is incomplete.
+- Screen follows the provided visual direction.
+- `./gradlew app:assembleDebug` passes.
+
+## Verification Requirements
+
+Build:
+
+```bash
+./gradlew app:assembleDebug
+```
+
+Recommended additional checks:
+
+```bash
+./gradlew app:test
+./gradlew app:lint
+```
+
+Runtime/emulator evidence required before Done:
+
+- App opens to Home without notification permission prompt.
+- User taps Attendance and sees Permission Readiness screen.
+- Screenshot: default readiness screen.
+- Screenshot: granted/check state.
+- Screenshot: required pending state.
+- Screenshot: optional skipped/degraded state.
+- Screenshot: `3/3 akses wajib siap` and CTA `Lanjut ke Mode Kerja`.
+- Recording: camera permission requested from readiness, not FaceScanner.
+- Recording: foreground location requested from readiness, not AttendanceMap.
+- Recording: notification permission requested from readiness, not Home.
+- Recording: background location denied but manual attendance can continue.
+
+If runtime/emulator verification cannot be executed, status must remain `Needs Verification`.
+
+## Docs / ADR Note
+
+This work changes permission ownership architecture and navigation gating. At minimum, PR notes must document:
+
+- Attendance permissions are now grouped under one readiness gate.
+- Notification prompt removed from startup/Home flow.
+- Required vs optional access clarified.
+- Downstream screens keep defensive fallback only.
+
+A focused ADR/implementation note is recommended if this change becomes a durable architecture precedent for feature-scoped permission ownership.


### PR DESCRIPTION
## Summary
- Add grouped Attendance Permission Readiness gate before the existing Attendance / Work Mode flow.
- Move normal Attendance permission ownership into readiness: foreground precise location, camera, device location setting, notification, and background location.
- Remove startup/Home notification permission prompt ownership.
- Keep notification and background location optional/degraded so manual attendance can continue.
- Convert AttendanceMap and FaceScanner to defensive fallback behavior instead of normal permission owners.
- Add INF-230 spec/plan notes and state derivation tests.

## Scope / Boundaries
- No backend contract changes.
- No check-in/check-out submission logic changes.
- No Work Mode Selection redesign.
- No FaceScanner redesign beyond removing auto camera permission request on entry.

## Verification
Using JVM 18:

```text
JAVA_HOME=D:\Java_Home\java 1.8.2
openjdk version "18.0.2" Corretto-18.0.2.9.1
```

- `./gradlew.bat --no-daemon app:assembleDebug` — BUILD SUCCESSFUL
- `./gradlew.bat --no-daemon app:test` — BUILD SUCCESSFUL
- `./gradlew.bat --no-daemon app:lint` — BUILD SUCCESSFUL

## Needs Verification
Runtime/emulator validation is intentionally left for human validation on `develop`:
- Home opens without notification permission prompt.
- Tap Attendance shows Permission Readiness screen.
- Foreground location prompt comes from readiness, not AttendanceMap.
- Camera prompt comes from readiness, not FaceScanner.
- Notification prompt comes from readiness, not Home/startup.
- Background location denied/skipped does not block manual attendance.
- Screenshots/recordings for required/optional readiness states.

## Docs / ADR
- Added focused spec and plan under `docs/superpowers/`.
- DOCS/ADR UPDATE REQUIRED / implementation note included for permission ownership architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)