### PR TITLE
fix: Polish attendance report card styling

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -92,7 +92,8 @@ fun InfiniteAttendanceModeDistributionRow(
             Text(
                 text = label,
                 color = InfiniteColors.Text,
-                fontWeight = FontWeight.SemiBold
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
             )
             Text(
                 text = "$count $unitLabel",

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
@@ -2,8 +2,6 @@ package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,18 +23,19 @@ fun InfiniteAttendancePeriodFilterCard(
     subtitle: String? = "Choose the reporting period",
     options: List<InfiniteFilterOption> = attendanceReportPeriodOptions
 ) {
-    InfiniteGlassReportCard(modifier = modifier) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteSectionHeader(
-                title = title,
-                subtitle = subtitle
-            )
-            InfiniteAttendancePeriodFilter(
-                selectedPeriod = selectedPeriod,
-                onPeriodSelected = onPeriodSelected,
-                options = options
-            )
-        }
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        InfiniteSectionHeader(
+            title = title,
+            subtitle = subtitle
+        )
+        InfiniteAttendancePeriodFilter(
+            selectedPeriod = selectedPeriod,
+            onPeriodSelected = onPeriodSelected,
+            options = options
+        )
     }
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummarySection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummarySection.kt
@@ -4,6 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material.icons.outlined.QueryStats
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -16,8 +21,8 @@ fun InfiniteAttendanceReportSummarySection(
     lateCount: Int,
     alphaCount: Int,
     modifier: Modifier = Modifier,
-    attendanceRateSubtitle: String = "Backend denominator unavailable",
-    workHoursSubtitle: String = "From returned work_hour",
+    attendanceRateSubtitle: String? = null,
+    workHoursSubtitle: String? = null,
     title: String = "Report Summary",
     subtitle: String? = null
 ) {
@@ -36,6 +41,7 @@ fun InfiniteAttendanceReportSummarySection(
                     title = "Attendance Rate",
                     value = attendanceRateValue,
                     subtitle = attendanceRateSubtitle,
+                    icon = Icons.Outlined.QueryStats,
                     semantic = InfiniteSemantic.Primary,
                     modifier = Modifier.weight(1f)
                 )
@@ -43,6 +49,7 @@ fun InfiniteAttendanceReportSummarySection(
                     title = "Work Hours",
                     value = workHoursValue,
                     subtitle = workHoursSubtitle,
+                    icon = Icons.Outlined.AccessTime,
                     semantic = InfiniteSemantic.Info,
                     modifier = Modifier.weight(1f)
                 )
@@ -55,14 +62,16 @@ fun InfiniteAttendanceReportSummarySection(
                 InfiniteMetricCard(
                     title = "Late",
                     value = lateCount.toString(),
-                    subtitle = "Backend summary",
+                    subtitle = null,
+                    icon = Icons.Outlined.Schedule,
                     semantic = InfiniteSemantic.Warning,
                     modifier = Modifier.weight(1f)
                 )
                 InfiniteMetricCard(
                     title = "Alpha",
                     value = alphaCount.toString(),
-                    subtitle = "Backend summary",
+                    subtitle = null,
+                    icon = Icons.Outlined.PersonOutline,
                     semantic = InfiniteSemantic.Error,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSurface.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSurface.kt
@@ -1,10 +1,8 @@
 package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -12,14 +10,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
-import com.example.infinite_track.presentation.design.tokens.InfiniteSize
-import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
 
 @Composable
 fun InfiniteGlassReportCard(
@@ -27,15 +22,19 @@ fun InfiniteGlassReportCard(
     extraContentPadding: Dp = 0.dp,
     content: @Composable () -> Unit
 ) {
-    InfiniteCard(
-        modifier = modifier.fillMaxWidth(),
-        variant = InfiniteSurfaceVariant.Glass,
-        semantic = InfiniteSemantic.Neutral,
-        size = InfiniteSize.Large,
-        showBorder = true,
-        showShadow = true
+    Surface(
+        modifier = modifier
+            .shadow(
+                elevation = 8.dp,
+                shape = RoundedCornerShape(24.dp),
+                ambientColor = InfiniteColors.Primary.copy(alpha = 0.10f),
+                spotColor = InfiniteColors.Accent.copy(alpha = 0.08f)
+            ),
+        shape = RoundedCornerShape(24.dp),
+        color = InfiniteColors.AttendanceReportGlassSurface,
+        border = BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder)
     ) {
-        Box(modifier = Modifier.padding(extraContentPadding)) {
+        Box(modifier = Modifier.padding(16.dp + extraContentPadding)) {
             content()
         }
     }
@@ -48,19 +47,20 @@ fun InfiniteAttendanceReportNoticeCard(
     modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
+        modifier = modifier,
+        shape = RoundedCornerShape(20.dp),
         color = InfiniteColors.AttendanceReportWarningSurface,
         border = BorderStroke(1.dp, InfiniteColors.AttendanceReportWarningBorder)
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(6.dp)
         ) {
             Text(
                 text = title,
                 color = InfiniteColors.Text,
-                fontWeight = FontWeight.SemiBold
+                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.titleSmall
             )
             Text(
                 text = message,

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteFilterChips.kt
@@ -1,17 +1,21 @@
 package com.example.infinite_track.presentation.design.components.data
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
@@ -34,22 +38,34 @@ fun InfiniteFilterChips(
         modifier = modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         options.forEach { option ->
             val selected = option.key == selectedKey
             FilterChip(
                 selected = selected,
                 onClick = { onSelected(option.key) },
-                label = { Text(option.label) },
+                label = {
+                    Text(
+                        text = option.label,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
+                    )
+                },
                 leadingIcon = option.icon?.let { icon ->
                     { Icon(imageVector = icon, contentDescription = null) }
                 },
+                shape = RoundedCornerShape(18.dp),
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = if (selected) Color.Transparent else InfiniteColors.Surface.copy(alpha = 0.92f)
+                ),
                 colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = InfiniteColors.Primary.copy(alpha = 0.16f),
-                    selectedLabelColor = InfiniteColors.Primary,
-                    containerColor = InfiniteColors.Surface.copy(alpha = 0.62f),
-                    labelColor = InfiniteColors.Text
+                    selectedContainerColor = InfiniteColors.Primary,
+                    selectedLabelColor = InfiniteColors.Surface,
+                    selectedLeadingIconColor = InfiniteColors.Surface,
+                    containerColor = InfiniteColors.Surface.copy(alpha = 0.68f),
+                    labelColor = InfiniteColors.Text,
+                    iconColor = InfiniteColors.Primary
                 )
             )
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteMetricCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteMetricCard.kt
@@ -1,18 +1,28 @@
 package com.example.infinite_track.presentation.design.components.data
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
@@ -31,22 +41,68 @@ fun InfiniteMetricCard(
     onClick: (() -> Unit)? = null
 ) {
     val colors = infiniteSemanticColors(semantic)
-    InfiniteCard(
-        modifier = modifier,
-        variant = variant,
-        semantic = semantic,
-        size = size,
-        clickable = onClick != null,
-        onClick = onClick
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(18.dp),
+                ambientColor = colors.accent.copy(alpha = 0.08f),
+                spotColor = colors.accent.copy(alpha = 0.10f)
+            ),
+        shape = RoundedCornerShape(18.dp),
+        color = InfiniteColors.Surface.copy(alpha = 0.58f),
+        border = BorderStroke(1.dp, colors.accent.copy(alpha = 0.22f))
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
-            icon?.let { Icon(imageVector = it, contentDescription = null, tint = colors.accent, modifier = Modifier.size(28.dp)) }
-            androidx.compose.foundation.layout.Column {
-                Text(text = title, color = colors.content.copy(alpha = 0.70f))
-                Text(text = value, color = colors.content, fontWeight = FontWeight.Bold)
-                subtitle?.let { Text(text = it, color = colors.content.copy(alpha = 0.58f)) }
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            icon?.let {
+                Surface(
+                    modifier = Modifier.size(42.dp),
+                    shape = CircleShape,
+                    color = colors.accent.copy(alpha = 0.10f),
+                    border = BorderStroke(1.dp, colors.accent.copy(alpha = 0.16f))
+                ) {
+                    androidx.compose.foundation.layout.Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = it,
+                            contentDescription = null,
+                            tint = colors.accent,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
             }
-            Spacer(modifier = Modifier.weight(1f))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                Text(
+                    text = title,
+                    color = InfiniteColors.AttendanceReportBodyText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Normal
+                )
+                Text(
+                    text = value,
+                    color = colors.accent,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                subtitle?.let {
+                    Text(
+                        text = it,
+                        color = InfiniteColors.AttendanceReportMutedText,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Normal
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.size(0.dp))
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteSectionHeader.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteSectionHeader.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,11 +34,28 @@ fun InfiniteSectionHeader(
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         leadingIcon?.let {
-            Icon(imageVector = it, contentDescription = null, tint = InfiniteColors.Primary, modifier = Modifier.size(22.dp))
+            Icon(
+                imageVector = it,
+                contentDescription = null,
+                tint = InfiniteColors.Primary,
+                modifier = Modifier.size(22.dp)
+            )
         }
         Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, fontWeight = FontWeight.SemiBold, color = InfiniteColors.Text)
-            subtitle?.let { Text(text = it, color = InfiniteColors.Text.copy(alpha = 0.64f)) }
+            Text(
+                text = title,
+                fontWeight = FontWeight.Medium,
+                color = InfiniteColors.Text,
+                style = MaterialTheme.typography.titleMedium
+            )
+            subtitle?.let {
+                Text(
+                    text = it,
+                    color = InfiniteColors.AttendanceReportMutedText,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Normal
+                )
+            }
         }
         if (trailingText != null || trailingIcon != null) {
             Row(
@@ -45,8 +63,22 @@ fun InfiniteSectionHeader(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                trailingText?.let { Text(text = it, color = InfiniteColors.Primary) }
-                trailingIcon?.let { Icon(imageVector = it, contentDescription = trailingText, tint = InfiniteColors.Primary, modifier = Modifier.size(18.dp)) }
+                trailingText?.let {
+                    Text(
+                        text = it,
+                        color = InfiniteColors.Primary,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+                trailingIcon?.let {
+                    Icon(
+                        imageVector = it,
+                        contentDescription = trailingText,
+                        tint = InfiniteColors.Primary,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
             }
         } else {
             Spacer(modifier = Modifier.size(0.dp))


### PR DESCRIPTION
## Summary

Polishes the My Attendance Report / status report visual styling without changing the existing data attributes or screen structure.

### What changed

- Removes the card-wrapped presentation for the report title/filter section so the page header no longer looks like a content card.
- Softens glass transparency, border, and shadow handling for report cards to better match the existing glass references used elsewhere in the app.
- Refines `InfiniteMetricCard` typography and spacing so titles are less bold, values remain prominent, and subtitle text no longer reads like debug output.
- Refines `InfiniteSectionHeader` hierarchy so section titles/subtitles feel calmer and more readable.
- Polishes the report filter chips to better match the intended visual treatment (solid selected purple, softer glass unselected chips).
- Removes default user-facing debug/contract strings like `Backend denominator unavailable`, `From returned work_hour`, and `Backend summary` from the summary card defaults.
- Adds icons to the summary metric cards for clearer composition while preserving the same underlying attributes/data.
- Slightly softens the Attendance Mode row title weight so the composition is less heavy.

### Scope constraints kept

- No backend changes.
- No auth/session changes.
- No attendance business-logic changes.
- No report export/share contract changes.
- Existing section/attribute structure is preserved; this PR is style-only.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due the existing environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open My Attendance Report / History report screen.
- Confirm title/filter is no longer visually wrapped inside a content card.
- Confirm summary cards have calmer typography and cleaner composition.
- Confirm glass transparency / border / shadow look consistent with app references.
- Confirm Attendance Mode, Personal Insight, Timeline, and Export sections still compose correctly after shared component style updates.
- Confirm no field/value data is missing after the visual refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed report cards, headers, and filter chips with updated spacing, typography, borders, shadows, and icon treatments.
  * Added clearer visual icons to summary metrics and improved selection styling for filter chips.
  * Updated attendance report sections and notices for a cleaner, more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->