### PR TITLE
INF-230: Polish attendance readiness styling

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
@@ -51,6 +51,7 @@ import com.example.infinite_track.presentation.components.maps.AttendanceMap
 import com.example.infinite_track.presentation.components.maps.MarkerView
 import com.example.infinite_track.presentation.components.dialog.LocationPermissionDialog
 import com.example.infinite_track.utils.LocalLocationPermissionHelper
+import com.example.infinite_track.utils.LocationPermissionHelper
 import com.example.infinite_track.presentation.components.maps.MarkerViewWfa
 import com.example.infinite_track.presentation.components.status.InfiniteTrackStatusDialog
 import com.example.infinite_track.presentation.components.status.StatusStates
@@ -533,10 +534,16 @@ fun AttendanceScreen(
         }
     }
 
-    // Permission Dialog for Geofencing
-    if (uiState.showPermissionDialog && uiState.permissionResult != null) {
+    val defensivePermissionResult = uiState.permissionResult
+    val shouldShowDefensivePermissionDialog = uiState.showPermissionDialog &&
+        defensivePermissionResult != null &&
+        defensivePermissionResult != LocationPermissionHelper.PermissionResult.BackgroundPermissionDenied
+
+    // Permission Dialog for defensive foreground/settings recovery only.
+    // Background location is optional/degraded and stays owned by the readiness screen.
+    if (shouldShowDefensivePermissionDialog) {
         LocationPermissionDialog(
-            permissionResult = uiState.permissionResult!!,
+            permissionResult = defensivePermissionResult!!,
             onRequestPermission = {
                 locationPermissionHelper?.checkAndRequestPermissions()
             },

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
@@ -56,10 +56,7 @@ import com.example.infinite_track.presentation.design.components.button.Infinite
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
 import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
 import com.example.infinite_track.presentation.design.components.navigation.InfiniteTopBar
-import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
-import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
 
 @Composable
@@ -236,15 +233,13 @@ private fun AttendancePermissionReadinessContent(
             PermissionHeroCard(uiState = uiState)
             PermissionProgressHeader(uiState = uiState)
 
-            InfiniteCard(
-                variant = InfiniteSurfaceVariant.Glass,
-                density = InfiniteDensity.Comfortable,
+            PermissionGlassCard(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     InfiniteSectionHeader(
                         title = "Akses wajib",
-                        subtitle = "Harus siap sebelum memilih mode kerja",
+                        subtitle = "Lengkapi 3 akses utama sebelum lanjut",
                         leadingIcon = Icons.Default.Shield
                     )
                     PermissionMissionRow(
@@ -277,17 +272,15 @@ private fun AttendancePermissionReadinessContent(
                 }
             }
 
-            InfiniteCard(
-                variant = InfiniteSurfaceVariant.Glass,
-                density = InfiniteDensity.Comfortable,
+            PermissionGlassCard(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     InfiniteSectionHeader(
-                        title = "Opsional untuk pengingat",
-                        subtitle = "Tidak memblokir absensi manual",
+                        title = "Pengingat opsional",
+                        subtitle = "Boleh dilewati, absensi manual tetap bisa lanjut",
                         leadingIcon = Icons.Default.Notifications,
-                        trailingText = "Degraded OK"
+                        trailingText = "Opsional"
                     )
                     PermissionMissionRow(
                         title = "Notifikasi pengingat",

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionGlassCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionGlassCard.kt
@@ -1,0 +1,52 @@
+package com.example.infinite_track.presentation.screen.attendance.permission
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+
+@Composable
+internal fun PermissionGlassCard(
+    modifier: Modifier = Modifier,
+    shadowElevation: Dp = 0.dp,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val shape = RoundedCornerShape(18.dp)
+    Card(
+        modifier = modifier
+            .then(
+                if (shadowElevation > 0.dp) {
+                    Modifier.shadow(
+                        elevation = shadowElevation,
+                        shape = shape,
+                        clip = false,
+                        ambientColor = InfiniteColors.Primary.copy(alpha = 0.32f),
+                        spotColor = InfiniteColors.Primary.copy(alpha = 0.22f)
+                    )
+                } else {
+                    Modifier
+                }
+            ),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0x33FFFFFF)
+        ),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.82f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionHeroCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionHeroCard.kt
@@ -16,26 +16,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.components.tittle.Tittle
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
-import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
-import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
 
 @Composable
 internal fun PermissionHeroCard(
     uiState: AttendancePermissionReadinessUiState,
     modifier: Modifier = Modifier
 ) {
-    InfiniteCard(
-        variant = InfiniteSurfaceVariant.Glass,
-        density = InfiniteDensity.Spacious,
-        modifier = modifier.fillMaxWidth()
+    PermissionGlassCard(
+        modifier = modifier.fillMaxWidth(),
+        shadowElevation = 3.dp
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -57,7 +53,13 @@ internal fun PermissionHeroCard(
                     )
                 }
             }
-            Tittle(tittle = "Siapkan akses absensi")
+            Text(
+                text = "Siapkan akses absensi",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = InfiniteColors.Text.copy(alpha = 0.88f),
+                textAlign = TextAlign.Center
+            )
             Text(
                 text = "Kami cek lokasi, kamera, dan status lokasi perangkat sebelum Anda memilih mode kerja.",
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionMissionRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionMissionRow.kt
@@ -41,14 +41,14 @@ internal fun PermissionMissionRow(
 ) {
     Surface(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        color = Color.White.copy(alpha = 0.64f),
+        shape = RoundedCornerShape(16.dp),
+        color = Color(0x33FFFFFF),
         border = BorderStroke(
             width = 1.dp,
             color = if (isGranted) {
-                InfiniteColors.Success.copy(alpha = 0.42f)
+                InfiniteColors.Success.copy(alpha = 0.38f)
             } else {
-                InfiniteColors.Primary.copy(alpha = 0.12f)
+                Color.White.copy(alpha = 0.72f)
             }
         )
     ) {

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionProgressHeader.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionProgressHeader.kt
@@ -12,22 +12,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.design.components.surface.InfiniteCard
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteDensity
-import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
-import com.example.infinite_track.presentation.design.tokens.InfiniteSurfaceVariant
 
 @Composable
 internal fun PermissionProgressHeader(
     uiState: AttendancePermissionReadinessUiState,
     modifier: Modifier = Modifier
 ) {
-    InfiniteCard(
-        variant = InfiniteSurfaceVariant.StatusTint,
-        semantic = if (uiState.canContinueToWorkMode) InfiniteSemantic.Success else InfiniteSemantic.Warning,
-        density = InfiniteDensity.Comfortable,
-        modifier = modifier.fillMaxWidth()
+    PermissionGlassCard(
+        modifier = modifier.fillMaxWidth(),
+        shadowElevation = if (uiState.canContinueToWorkMode) 3.dp else 0.dp
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(
@@ -37,9 +31,9 @@ internal fun PermissionProgressHeader(
             ) {
                 Text(
                     text = uiState.progressCopy,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = InfiniteColors.Text
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = InfiniteColors.Text.copy(alpha = 0.86f)
                 )
                 Text(
                     text = if (uiState.canContinueToWorkMode) "Siap" else "Perlu setup",


### PR DESCRIPTION
## Summary
- Remove the background-location permission dialog from the Attendance defensive fallback path.
- Keep background location as optional/degraded access owned by the readiness screen.
- Polish Attendance Permission Readiness card styling with a local transparent glass card pattern inspired by existing attendance/leave cards.
- Improve title/text composition so headings are lighter and optional copy is clearer.

## Scope / Boundaries
- No permission contract changes beyond suppressing the obsolete background-location dialog in Attendance.
- No backend/check-in/check-out submission changes.
- No navigation flow changes.
- Existing readiness attributes and structure are preserved; this is a style/copy follow-up.

## Verification
Using JVM 18:

```text
JAVA_HOME=D:\Java_Home\java 1.8.2
openjdk version "18.0.2" Corretto-18.0.2.9.1
```

- `./gradlew.bat --no-daemon app:assembleDebug` — BUILD SUCCESSFUL
- `git diff --check` — no whitespace errors

## Needs Verification
Runtime visual validation on `develop`:
- Background-location denied/skipped no longer shows the old "Izin Lokasi Latar Belakang" dialog.
- Readiness card glass/shadow styling looks consistent with existing card patterns.
- Title/body copy composition is visually balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)