### PR TITLE
INF-238: harden attendance work mode target flow

### DIFF
--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/SelectedTargetLocation.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/SelectedTargetLocation.kt
@@ -1,0 +1,10 @@
+package com.example.infinite_track.domain.model.attendance
+
+data class SelectedTargetLocation(
+    val mode: WorkMode,
+    val location: Location?,
+    val displayName: String,
+    val description: String?,
+    val isAvailable: Boolean,
+    val unavailableReason: String? = null
+)

--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/WorkMode.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/WorkMode.kt
@@ -1,0 +1,33 @@
+package com.example.infinite_track.domain.model.attendance
+
+enum class WorkMode(
+    val categoryId: Int,
+    val shortLabel: String,
+    val displayLabel: String
+) {
+    WFO(
+        categoryId = 1,
+        shortLabel = "WFO",
+        displayLabel = "Work From Office"
+    ),
+    WFH(
+        categoryId = 2,
+        shortLabel = "WFH",
+        displayLabel = "Work From Home"
+    ),
+    WFA(
+        categoryId = 3,
+        shortLabel = "WFA",
+        displayLabel = "Work From Anywhere"
+    );
+
+    companion object {
+        fun fromRaw(value: String?): WorkMode? {
+            val normalized = value?.trim().orEmpty()
+            return values().firstOrNull { mode ->
+                normalized.equals(mode.shortLabel, ignoreCase = true) ||
+                    normalized.equals(mode.displayLabel, ignoreCase = true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/domain/model/attendance/WorkModeEligibility.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/attendance/WorkModeEligibility.kt
@@ -1,0 +1,17 @@
+package com.example.infinite_track.domain.model.attendance
+
+data class WorkModeEligibility(
+    val mode: WorkMode,
+    val canContinueToFaceVerification: Boolean,
+    val blockingReason: String? = null,
+    val recoveryAction: WorkModeRecoveryAction? = null,
+    val approvedWfaBookingId: Int? = null
+)
+
+enum class WorkModeRecoveryAction {
+    CHOOSE_WFO,
+    UPDATE_WFH_LOCATION,
+    SELECT_WFA_LOCATION,
+    REQUEST_WFA_BOOKING,
+    VIEW_WFA_REQUESTS
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/EvaluateWorkModeEligibilityUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/EvaluateWorkModeEligibilityUseCase.kt
@@ -1,0 +1,78 @@
+package com.example.infinite_track.domain.use_case.attendance
+
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
+import com.example.infinite_track.domain.model.attendance.WorkMode
+import com.example.infinite_track.domain.model.attendance.WorkModeEligibility
+import com.example.infinite_track.domain.model.attendance.WorkModeRecoveryAction
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
+import javax.inject.Inject
+
+class EvaluateWorkModeEligibilityUseCase @Inject constructor(
+    private val resolveTodayApprovedWfaBookingIdUseCase: ResolveTodayApprovedWfaBookingIdUseCase
+) {
+    suspend operator fun invoke(
+        mode: WorkMode,
+        selectedTargetLocation: SelectedTargetLocation,
+        todayDate: String?
+    ): WorkModeEligibility {
+        if (!selectedTargetLocation.isAvailable) {
+            return WorkModeEligibility(
+                mode = mode,
+                canContinueToFaceVerification = false,
+                blockingReason = selectedTargetLocation.unavailableReason ?: missingTargetReason(mode),
+                recoveryAction = missingTargetRecovery(mode)
+            )
+        }
+
+        if (mode != WorkMode.WFA) {
+            return WorkModeEligibility(
+                mode = mode,
+                canContinueToFaceVerification = true
+            )
+        }
+
+        if (todayDate.isNullOrBlank()) {
+            return WorkModeEligibility(
+                mode = mode,
+                canContinueToFaceVerification = false,
+                blockingReason = "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA.",
+                recoveryAction = WorkModeRecoveryAction.VIEW_WFA_REQUESTS
+            )
+        }
+
+        return resolveTodayApprovedWfaBookingIdUseCase(todayDate)
+            .fold(
+                onSuccess = { bookingId ->
+                    WorkModeEligibility(
+                        mode = mode,
+                        canContinueToFaceVerification = true,
+                        approvedWfaBookingId = bookingId
+                    )
+                },
+                onFailure = {
+                    WorkModeEligibility(
+                        mode = mode,
+                        canContinueToFaceVerification = false,
+                        blockingReason = "Booking WFA yang sudah disetujui untuk hari ini belum tersedia. Ajukan atau cek request WFA terlebih dahulu.",
+                        recoveryAction = WorkModeRecoveryAction.VIEW_WFA_REQUESTS
+                    )
+                }
+            )
+    }
+
+    private fun missingTargetReason(mode: WorkMode): String {
+        return when (mode) {
+            WorkMode.WFO -> "Lokasi WFO belum tersedia. Coba muat ulang status attendance terlebih dahulu."
+            WorkMode.WFH -> "Lokasi WFH belum tersedia. Pilih WFO atau perbarui lokasi WFH terlebih dahulu."
+            WorkMode.WFA -> "Pilih lokasi WFA terlebih dahulu."
+        }
+    }
+
+    private fun missingTargetRecovery(mode: WorkMode): WorkModeRecoveryAction {
+        return when (mode) {
+            WorkMode.WFO -> WorkModeRecoveryAction.CHOOSE_WFO
+            WorkMode.WFH -> WorkModeRecoveryAction.UPDATE_WFH_LOCATION
+            WorkMode.WFA -> WorkModeRecoveryAction.SELECT_WFA_LOCATION
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/ResolveSelectedTargetLocationUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/ResolveSelectedTargetLocationUseCase.kt
@@ -1,0 +1,75 @@
+package com.example.infinite_track.domain.use_case.attendance
+
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
+import com.example.infinite_track.domain.model.attendance.WorkMode
+import com.example.infinite_track.domain.model.wfa.WfaRecommendation
+import javax.inject.Inject
+
+class ResolveSelectedTargetLocationUseCase @Inject constructor() {
+    operator fun invoke(
+        mode: WorkMode,
+        wfoLocation: Location?,
+        wfhLocation: Location?,
+        selectedWfaLocation: WfaRecommendation?
+    ): SelectedTargetLocation {
+        return when (mode) {
+            WorkMode.WFO -> resolveFixedLocation(
+                mode = mode,
+                location = wfoLocation,
+                displayName = wfoLocation?.description ?: "Lokasi kantor belum tersedia",
+                unavailableReason = "Lokasi WFO belum tersedia. Coba muat ulang status attendance terlebih dahulu."
+            )
+
+            WorkMode.WFH -> resolveFixedLocation(
+                mode = mode,
+                location = wfhLocation,
+                displayName = wfhLocation?.description ?: "Lokasi WFH belum tersedia",
+                unavailableReason = "Lokasi WFH belum tersedia. Pilih WFO atau perbarui lokasi WFH terlebih dahulu."
+            )
+
+            WorkMode.WFA -> {
+                val location = selectedWfaLocation?.toAttendanceLocation()
+                SelectedTargetLocation(
+                    mode = mode,
+                    location = location,
+                    displayName = selectedWfaLocation?.name ?: "Pilih lokasi WFA",
+                    description = selectedWfaLocation?.address,
+                    isAvailable = location != null,
+                    unavailableReason = if (location == null) {
+                        "Pilih lokasi WFA terlebih dahulu."
+                    } else {
+                        null
+                    }
+                )
+            }
+        }
+    }
+
+    private fun resolveFixedLocation(
+        mode: WorkMode,
+        location: Location?,
+        displayName: String,
+        unavailableReason: String
+    ): SelectedTargetLocation {
+        return SelectedTargetLocation(
+            mode = mode,
+            location = location,
+            displayName = displayName,
+            description = location?.category,
+            isAvailable = location != null,
+            unavailableReason = if (location == null) unavailableReason else null
+        )
+    }
+
+    private fun WfaRecommendation.toAttendanceLocation(): Location {
+        return Location(
+            locationId = 0,
+            latitude = latitude,
+            longitude = longitude,
+            radius = 100,
+            description = name,
+            category = category
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceActionButtons.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceActionButtons.kt
@@ -28,18 +28,21 @@ fun AttendanceActionButtons(
     checkInButtonText: String,
     onBookingClick: () -> Unit,
     onCheckInClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showBookingAction: Boolean = true
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        StatefulButton(
-            text = "Booking Location",
-            style = ButtonStyle.Outlined,
-            enabled = isBookingEnabled,
-            onClick = onBookingClick
-        )
+        if (showBookingAction) {
+            StatefulButton(
+                text = "Booking Location",
+                style = ButtonStyle.Outlined,
+                enabled = isBookingEnabled,
+                onClick = onBookingClick
+            )
+        }
 
         StatefulButton(
             text = checkInButtonText,

--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.domain.model.attendance.TargetLocationInfo
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import com.example.infinite_track.presentation.components.button.InfiniteTrackButton
 import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
@@ -20,9 +22,9 @@ import com.example.infinite_track.presentation.theme.Purple_500
  * Komponen utama untuk konten BottomSheet attendance yang merakit semua komponen kecil.
  *
  * @param modifier Modifier untuk styling komponen
- * @param targetLocationInfo Informasi lokasi target (description dan nama lokasi dari API)
- * @param currentLocationAddress Alamat lokasi saat ini
- * @param selectedWorkMode Mode kerja yang dipilih ("WFH", "WFA", atau "WFO")
+ * @param targetLocationInfo Informasi lokasi target yang sudah di-resolve dari mode terpilih.
+ * @param currentLocationAddress Alamat lokasi saat ini.
+ * @param selectedWorkMode Mode kerja yang dipilih.
  * @param isBookingEnabled Apakah tombol booking dapat diklik
  * @param isCheckInEnabled Apakah tombol check-in dapat diklik
  * @param checkInButtonText Teks pada tombol check-in
@@ -35,15 +37,16 @@ import com.example.infinite_track.presentation.theme.Purple_500
 @Composable
 fun AttendanceBottomSheetContent(
     modifier: Modifier = Modifier,
-    targetLocationInfo: TargetLocationInfo?,
+    targetLocationInfo: SelectedTargetLocation?,
     currentLocationAddress: String,
-    selectedWorkMode: String,
+    selectedWorkMode: WorkMode,
     isBookingEnabled: Boolean,
     isCheckInEnabled: Boolean,
     checkInButtonText: String,
-    outOfRangeWarningText: String = "Anda berada di luar jangkauan lokasi kerja ?",
+    blockingMessage: String? = null,
+    outOfRangeWarningText: String = "Pilih mode kerja dan lokasi target",
     onSearchLocationClick: () -> Unit = {}, // Untuk navigasi ke LocationSearchScreen
-    onModeSelected: (String) -> Unit,
+    onModeSelected: (WorkMode) -> Unit,
     onBookingClick: () -> Unit,
     onCheckInClick: () -> Unit
 ) {
@@ -56,7 +59,7 @@ fun AttendanceBottomSheetContent(
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         // Search Location Button - Only show when Work From Anywhere is selected
-        if (selectedWorkMode == "WFA" || selectedWorkMode == "Work From Anywhere") {
+        if (selectedWorkMode == WorkMode.WFA) {
             InfiniteTrackButton(
                 label = "Cari Lokasi",
                 onClick = onSearchLocationClick,
@@ -84,6 +87,14 @@ fun AttendanceBottomSheetContent(
                 selectedMode = selectedWorkMode,
                 onModeSelected = onModeSelected
             )
+
+            blockingMessage?.let { message ->
+                Text(
+                    text = message,
+                    style = headline4,
+                    color = Purple_500
+                )
+            }
         }
 
         // Action Buttons
@@ -92,9 +103,27 @@ fun AttendanceBottomSheetContent(
             isCheckInEnabled = isCheckInEnabled,
             checkInButtonText = checkInButtonText,
             onBookingClick = onBookingClick,
-            onCheckInClick = onCheckInClick
+            onCheckInClick = onCheckInClick,
+            showBookingAction = selectedWorkMode == WorkMode.WFA
         )
     }
+}
+
+private fun previewTargetLocation(mode: WorkMode): SelectedTargetLocation {
+    return SelectedTargetLocation(
+        mode = mode,
+        location = Location(
+            locationId = mode.categoryId,
+            description = "Jl. Sudirman No. 123, Jakarta Pusat, DKI Jakarta",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100,
+            category = mode.shortLabel
+        ),
+        displayName = "Jl. Sudirman No. 123, Jakarta Pusat, DKI Jakarta",
+        description = mode.shortLabel,
+        isAvailable = true
+    )
 }
 
 @Preview(showBackground = true)
@@ -104,12 +133,9 @@ private fun AttendanceBottomSheetContentPreview() {
         Column {
             // Preview when in range
             AttendanceBottomSheetContent(
-                targetLocationInfo = TargetLocationInfo(
-                    description = "Jl. Sudirman No. 123, Jakarta Pusat, DKI Jakarta",
-                    locationName = "Sudirman"
-                ),
+                targetLocationInfo = previewTargetLocation(WorkMode.WFH),
                 currentLocationAddress = "Jl. Thamrin No. 456, Jakarta Pusat, DKI Jakarta",
-                selectedWorkMode = "WFH",
+                selectedWorkMode = WorkMode.WFH,
                 isBookingEnabled = true,
                 isCheckInEnabled = true,
                 checkInButtonText = "Check In",
@@ -128,12 +154,9 @@ private fun AttendanceBottomSheetContentOutOfRangePreview() {
         Column {
             // Preview when out of range
             AttendanceBottomSheetContent(
-                targetLocationInfo = TargetLocationInfo(
-                    description = "Jl. Sudirman No. 123, Jakarta Pusat, DKI Jakarta",
-                    locationName = "Sudirman"
-                ),
+                targetLocationInfo = previewTargetLocation(WorkMode.WFA),
                 currentLocationAddress = "Jl. Kemang No. 789, Jakarta Selatan, DKI Jakarta",
-                selectedWorkMode = "WFA",
+                selectedWorkMode = WorkMode.WFA,
                 isBookingEnabled = false,
                 isCheckInEnabled = true,
                 checkInButtonText = "Check In (WFA)",

--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/LocationInfoRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/LocationInfoRow.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.infinite_track.domain.model.attendance.TargetLocationInfo
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
 
@@ -30,7 +32,7 @@ import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
  */
 @Composable
 fun LocationInfoSection(
-    targetLocationInfo: TargetLocationInfo?,
+    targetLocationInfo: SelectedTargetLocation?,
     currentLocationAddress: String,
     modifier: Modifier = Modifier
 ) {
@@ -54,8 +56,8 @@ fun LocationInfoSection(
                 // Location Info Row dengan data dari API
                 LocationInfoRow(
                     icon = Icons.Default.LocationOn,
-                    primaryText = targetInfo.description, // Description dari API
-                    secondaryText = targetInfo.locationName // Nama lokasi dari koordinat API
+                    primaryText = targetInfo.displayName,
+                    secondaryText = targetInfo.description ?: targetInfo.unavailableReason
                 )
             }
         }
@@ -147,9 +149,19 @@ private fun LocationInfoSectionPreview() {
         ) {
             // Preview dengan target location info
             LocationInfoSection(
-                targetLocationInfo = TargetLocationInfo(
-                    description = "Kantor Pusat PT. Technology Indonesia",
-                    locationName = "Gedung Cyber 2, Kuningan"
+                targetLocationInfo = SelectedTargetLocation(
+                    mode = WorkMode.WFO,
+                    location = Location(
+                        locationId = 1,
+                        description = "Kantor Pusat PT. Technology Indonesia",
+                        latitude = 0.0,
+                        longitude = 0.0,
+                        radius = 100,
+                        category = "Gedung Cyber 2, Kuningan"
+                    ),
+                    displayName = "Kantor Pusat PT. Technology Indonesia",
+                    description = "Gedung Cyber 2, Kuningan",
+                    isAvailable = true
                 ),
                 currentLocationAddress = "Jl. Kemang Raya No. 123, Jakarta Selatan, DKI Jakarta"
             )

--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/WorkModeSelector.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/WorkModeSelector.kt
@@ -8,38 +8,44 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.R
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import com.example.infinite_track.presentation.components.button.RadioButtonWithText
 import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.theme.Blue_700
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
 
 /**
- * Komponen selector untuk memilih mode kerja (Work From Home atau Work From Anywhere)
+ * Komponen selector untuk memilih mode kerja (WFO, WFH, atau WFA).
  *
- * @param selectedMode Mode yang dipilih saat ini ("WFH" atau "WFA")
+ * @param selectedMode Mode yang dipilih saat ini.
  * @param onModeSelected Callback yang dipanggil ketika mode dipilih
  */
 @Composable
 fun WorkModeSelector(
-    selectedMode: String,
-    onModeSelected: (String) -> Unit,
+    selectedMode: WorkMode,
+    onModeSelected: (WorkMode) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        RadioButtonWithText(
-            text = stringResource(R.string.work_from_home),
-            selected = selectedMode == "WFH",
-            onClick = { onModeSelected("WFH") }
-        )
+        WorkMode.values().forEach { mode ->
+            RadioButtonWithText(
+                text = mode.labelText(),
+                selected = selectedMode == mode,
+                onClick = { onModeSelected(mode) }
+            )
+        }
+    }
+}
 
-        RadioButtonWithText(
-            text = stringResource(R.string.work_from_anywhere),
-            selected = selectedMode == "WFA",
-            onClick = { onModeSelected("WFA") }
-        )
+@Composable
+private fun WorkMode.labelText(): String {
+    return when (this) {
+        WorkMode.WFO -> stringResource(R.string.work_from_office)
+        WorkMode.WFH -> stringResource(R.string.work_from_home)
+        WorkMode.WFA -> stringResource(R.string.work_from_anywhere)
     }
 }
 
@@ -57,7 +63,7 @@ private fun WorkModeSelectorPreview() {
                 color = Blue_700
             )
 
-            var selectedMode by remember { mutableStateOf("WFH") }
+            var selectedMode by remember { mutableStateOf(WorkMode.WFH) }
 
             WorkModeSelector(
                 selectedMode = selectedMode,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactory.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactory.kt
@@ -1,20 +1,16 @@
 package com.example.infinite_track.presentation.screen.attendance
 
 import com.example.infinite_track.domain.model.attendance.AttendanceRequestModel
+import com.example.infinite_track.domain.model.attendance.WorkMode
 
 object AttendanceCheckInRequestFactory {
     fun create(
-        selectedWorkMode: String,
+        workMode: WorkMode,
         bookingId: Int?
     ): AttendanceRequestModel {
-        val categoryId = when (selectedWorkMode) {
-            "Work From Office", "WFO" -> 1
-            "Work From Home", "WFH" -> 2
-            "WFA", "Work From Anywhere" -> 3
-            else -> 1
-        }
+        val categoryId = workMode.categoryId
 
-        if (categoryId == 3 && bookingId == null) {
+        if (workMode == WorkMode.WFA && bookingId == null) {
             throw IllegalArgumentException("WFA check-in requires bookingId.")
         }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
@@ -41,7 +41,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.example.infinite_track.R
-import com.example.infinite_track.domain.model.attendance.TargetLocationInfo
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import com.example.infinite_track.domain.model.location.LocationResult
 import com.example.infinite_track.domain.model.wfa.WfaRecommendation
 import com.example.infinite_track.presentation.components.button.attendance.AttendanceBottomSheetContent
@@ -340,17 +340,13 @@ fun AttendanceScreen(
 
                             AttendanceBottomSheetContent(
                                 modifier = Modifier.padding(top = 0.dp),
-                                targetLocationInfo = uiState.targetLocation?.let { target ->
-                                    TargetLocationInfo(
-                                        description = target.description,
-                                        locationName = target.category
-                                    )
-                                },
+                                targetLocationInfo = uiState.selectedTargetLocation,
                                 currentLocationAddress = uiState.currentUserAddress.ifEmpty { "Mengambil lokasi saat ini..." },
                                 selectedWorkMode = uiState.selectedWorkMode,
-                                isBookingEnabled = uiState.isBookingEnabled,
-                                isCheckInEnabled = uiState.isButtonEnabled, // Use isButtonEnabled from uiState
+                                isBookingEnabled = uiState.selectedWorkMode == WorkMode.WFA && uiState.selectedTargetLocation?.location != null,
+                                isCheckInEnabled = uiState.isButtonEnabled,
                                 checkInButtonText = uiState.buttonText,
+                                blockingMessage = uiState.workModeEligibility?.blockingReason,
                                 onSearchLocationClick = {
                                     navController.navigate("location_search")
                                 },

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt
@@ -1,7 +1,10 @@
 package com.example.infinite_track.presentation.screen.attendance
 
 import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
 import com.example.infinite_track.domain.model.attendance.TodayStatus
+import com.example.infinite_track.domain.model.attendance.WorkMode
+import com.example.infinite_track.domain.model.attendance.WorkModeEligibility
 import com.example.infinite_track.domain.model.location.LocationResult
 import com.example.infinite_track.domain.model.wfa.WfaRecommendation
 import com.example.infinite_track.utils.LocationPermissionHelper
@@ -26,8 +29,10 @@ data class AttendanceScreenState(
     val currentUserAddress: String = "",
     val currentUserLatitude: Double? = null,
     val currentUserLongitude: Double? = null,
-    val isBookingEnabled: Boolean = false,
-    val selectedWorkMode: String = "Work From Office",
+    val selectedWorkMode: WorkMode = WorkMode.WFO,
+    val selectedTargetLocation: SelectedTargetLocation? = null,
+    val workModeEligibility: WorkModeEligibility? = null,
+    val isEvaluatingWorkMode: Boolean = false,
     val targetLocationMarker: Location? = null,
     val selectedMarkerInfo: Location? = null,
     val pickedLocation: LocationResult? = null,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -7,11 +7,14 @@ import com.example.infinite_track.data.soucre.local.preferences.AttendancePrefer
 import com.example.infinite_track.domain.model.attendance.AttendanceRequestModel
 import com.example.infinite_track.domain.model.attendance.Location
 import com.example.infinite_track.domain.model.attendance.TodayStatus
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import com.example.infinite_track.domain.model.location.LocationResult
 import com.example.infinite_track.domain.model.wfa.WfaRecommendation
 import com.example.infinite_track.domain.use_case.attendance.CheckInUseCase
 import com.example.infinite_track.domain.use_case.attendance.CheckOutUseCase
+import com.example.infinite_track.domain.use_case.attendance.EvaluateWorkModeEligibilityUseCase
 import com.example.infinite_track.domain.use_case.attendance.GetTodayStatusUseCase
+import com.example.infinite_track.domain.use_case.attendance.ResolveSelectedTargetLocationUseCase
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
 import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentAddressUseCase
@@ -76,6 +79,8 @@ class AttendanceViewModel @Inject constructor(
     private val geofenceManager: GeofenceManager,
     private val getLoggedInUserUseCase: GetLoggedInUserUseCase,
     private val resolveTodayApprovedWfaBookingIdUseCase: ResolveTodayApprovedWfaBookingIdUseCase,
+    private val resolveSelectedTargetLocationUseCase: ResolveSelectedTargetLocationUseCase,
+    private val evaluateWorkModeEligibilityUseCase: EvaluateWorkModeEligibilityUseCase,
     // Add UseCase dependencies for attendance operations
     private val checkInUseCase: CheckInUseCase,
     private val checkOutUseCase: CheckOutUseCase
@@ -177,8 +182,7 @@ class AttendanceViewModel @Inject constructor(
                     "Today status fetched successfully: mode=${todayStatus.activeMode}, canCheckIn=${todayStatus.canCheckIn}, canCheckOut=${todayStatus.canCheckOut}, state=${todayStatus.attendanceSessionState?.key}"
                 )
 
-                val isBookingEnabled = todayStatus.activeMode.isNotEmpty()
-                val selectedMode = todayStatus.activeMode.ifEmpty { "Work From Office" }
+                val selectedMode = WorkMode.fromRaw(todayStatus.activeMode) ?: WorkMode.WFO
 
                 // Calculate button state based on today's status
                 val (buttonText, isButtonEnabled, isCheckInMode) = calculateDynamicButtonState(
@@ -190,33 +194,14 @@ class AttendanceViewModel @Inject constructor(
                     targetLocation = todayStatus.activeLocation,
                     wfoLocation = todayStatus.activeLocation, // WFO location from today status
                     targetLocationMarker = todayStatus.activeLocation,
-                    isBookingEnabled = isBookingEnabled,
                     selectedWorkMode = selectedMode,
-                    // FIXED: Now uses isButtonEnabled from calculateDynamicButtonState
                     buttonText = buttonText,
-                    isButtonEnabled = isButtonEnabled,
+                    isButtonEnabled = false,
                     isCheckInMode = isCheckInMode,
                     uiState = UiState.Success(Unit)
                 )
 
-                // Setup geofence for active location (validation purposes)
-                todayStatus.activeLocation?.let { location ->
-                    setupGeofence(location)
-                }
-
-                // Send initial camera focus event to WFO location
-                todayStatus.activeLocation?.let { location ->
-                    val wfoPoint = Point.fromLngLat(location.longitude, location.latitude)
-                    viewModelScope.launch {
-                        _uiState.value = _uiState.value.copy(
-                            mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                                wfoPoint,
-                                15.0
-                            )
-                        )
-                    }
-                    Log.d(TAG, "Initial camera focus event sent to WFO location")
-                }
+                resolveAndApplyTargetForMode(selectedMode)
 
                 Log.d(TAG, "WFO location updated: ${todayStatus.activeLocation}")
                 Log.d(
@@ -317,64 +302,15 @@ class AttendanceViewModel @Inject constructor(
                     wfhLocation = wfhLocation
                 )
 
+                if (_uiState.value.selectedWorkMode == WorkMode.WFH) {
+                    resolveAndApplyTargetForMode(WorkMode.WFH)
+                }
+
                 Log.d(TAG, "WFH location updated: $wfhLocation")
             }
         } catch (e: Exception) {
             Log.w(TAG, "Unexpected error in fetchUserHomeLocation", e)
             // Continue without WFH location
-        }
-    }
-
-    /**
-     * Setup geofence for validation (background monitoring)
-     * UPDATED: Enhanced with permission checking and user feedback
-     */
-    private fun setupGeofence(location: Location) {
-        try {
-            Log.d(TAG, "Setting up geofence for location: ${location.description}")
-            Log.d(
-                TAG,
-                "Location details - ID: ${location.locationId}, Lat: ${location.latitude}, Lng: ${location.longitude}, Radius: ${location.radius}m"
-            )
-
-            // Check if all required permissions are granted
-            if (!geofenceManager.hasAllRequiredPermissions()) {
-                Log.w(TAG, "Missing location permissions for geofencing")
-                
-                // Determine which permission is missing
-                val permissionResult = when {
-                    !geofenceManager.hasForegroundLocationPermission() -> 
-                        LocationPermissionHelper.PermissionResult.ForegroundPermissionDenied
-                    !geofenceManager.hasBackgroundLocationPermission() -> 
-                        LocationPermissionHelper.PermissionResult.BackgroundPermissionDenied
-                    else -> LocationPermissionHelper.PermissionResult.PermanentlyDenied
-                }
-                
-                _uiState.value = _uiState.value.copy(
-                    showPermissionDialog = true,
-                    permissionResult = permissionResult,
-                    permissionMessage = geofenceManager.getPermissionStatusMessage()
-                )
-                return
-            }
-
-            geofenceManager.addGeofence(
-                id = location.locationId.toString(),
-                latitude = location.latitude,
-                longitude = location.longitude,
-                radius = location.radius.toFloat(),
-                onPermissionError = { errorMessage ->
-                    Log.e(TAG, "Permission error during geofence setup: $errorMessage")
-                    _uiState.value = _uiState.value.copy(
-                        showPermissionDialog = true,
-                        permissionMessage = errorMessage
-                    )
-                }
-            )
-
-            Log.d(TAG, "Geofence setup request sent for location: ${location.description}")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to setup geofence for location: ${location.description}", e)
         }
     }
 
@@ -431,68 +367,81 @@ class AttendanceViewModel @Inject constructor(
     }
 
     /**
-     * Handle work mode selection with Pick on Map integration
-     * UPDATED: Added geofence cleanup when switching modes
+     * Handle work mode selection without mutating active monitoring geofences.
      */
-    fun onWorkModeSelected(mode: String) {
-        Log.d(TAG, "Work mode selected: $mode")
-
-        // Clean up any existing geofence before switching modes
-        Log.d(TAG, "Cleaning up geofences before mode switch...")
-        geofenceManager.removeAllGeofences()
+    fun onWorkModeSelected(mode: WorkMode) {
+        Log.d(TAG, "Work mode selected: ${mode.shortLabel}")
 
         _uiState.value = _uiState.value.copy(
             selectedWorkMode = mode,
-            isWfaModeActive = mode == "WFA" || mode == "Work From Anywhere"
+            isWfaModeActive = mode == WorkMode.WFA
         )
 
-        viewModelScope.launch {
-            when (mode) {
-                "WFA", "Work From Anywhere" -> {
-                    // Reset previous WFA selection and enter Pick on Map mode
-                    _uiState.value = _uiState.value.copy(
-                        selectedWfaLocation = null,
-                        pickedLocation = null
-                    )
-                    onEnterPickOnMapMode()
-                    fetchWfaRecommendations()
-                }
-
-                "Work From Home", "WFH" -> {
-                    onExitPickOnMapMode()
-                    _uiState.value.wfhLocation?.let { wfhLocation ->
-                        // Setup geofence for WFH location
-                        setupGeofence(wfhLocation)
-
-                        val wfhPoint = Point.fromLngLat(wfhLocation.longitude, wfhLocation.latitude)
-                        _uiState.value = _uiState.value.copy(
-                            mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                                point = wfhPoint,
-                                zoomLevel = 15.0
-                            )
-                        )
-                        Log.d(TAG, "Auto-focusing camera to WFH location and setting up geofence")
-                    }
-                }
-
-                "Work From Office", "WFO" -> {
-                    onExitPickOnMapMode()
-                    _uiState.value.wfoLocation?.let { wfoLocation ->
-                        // Setup geofence for WFO location
-                        setupGeofence(wfoLocation)
-
-                        val wfoPoint = Point.fromLngLat(wfoLocation.longitude, wfoLocation.latitude)
-                        _uiState.value = _uiState.value.copy(
-                            mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                                point = wfoPoint,
-                                zoomLevel = 15.0
-                            )
-                        )
-                        Log.d(TAG, "Auto-focusing camera to WFO location and setting up geofence")
-                    }
-                }
-            }
+        if (mode == WorkMode.WFA) {
+            _uiState.value = _uiState.value.copy(
+                selectedWfaLocation = null,
+                pickedLocation = null
+            )
+            onEnterPickOnMapMode()
+            fetchWfaRecommendations()
+        } else {
+            onExitPickOnMapMode()
         }
+
+        resolveAndApplyTargetForMode(mode)
+    }
+
+    private fun resolveAndApplyTargetForMode(mode: WorkMode = _uiState.value.selectedWorkMode) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isEvaluatingWorkMode = true,
+                isButtonEnabled = false
+            )
+
+            val state = _uiState.value
+            val target = resolveSelectedTargetLocationUseCase(
+                mode = mode,
+                wfoLocation = state.wfoLocation,
+                wfhLocation = state.wfhLocation,
+                selectedWfaLocation = state.selectedWfaLocation
+            )
+
+            val eligibility = evaluateWorkModeEligibilityUseCase(
+                mode = mode,
+                selectedTargetLocation = target,
+                todayDate = state.todayStatus?.todayDate
+            )
+
+            val baseButtonState = state.todayStatus?.let(::calculateDynamicButtonState)
+            val baseButtonEnabled = baseButtonState?.second ?: state.isButtonEnabled
+
+            val canContinueForCurrentAction = if (state.isCheckInMode) {
+                eligibility.canContinueToFaceVerification
+            } else {
+                true
+            }
+
+            _uiState.value = _uiState.value.copy(
+                selectedTargetLocation = target,
+                targetLocation = target.location,
+                targetLocationMarker = target.location,
+                workModeEligibility = eligibility,
+                isEvaluatingWorkMode = false,
+                isButtonEnabled = baseButtonEnabled && canContinueForCurrentAction
+            )
+
+            target.location?.let { animateMapToTarget(it) }
+        }
+    }
+
+    private fun animateMapToTarget(location: Location, zoomLevel: Double = 15.0) {
+        val point = Point.fromLngLat(location.longitude, location.latitude)
+        _uiState.value = _uiState.value.copy(
+            mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
+                point = point,
+                zoomLevel = zoomLevel
+            )
+        )
     }
 
     /**
@@ -589,16 +538,7 @@ class AttendanceViewModel @Inject constructor(
             selectedWfaMarkerInfo = recommendation // Show marker details
         )
 
-        // Focus camera on selected WFA location
-        viewModelScope.launch {
-            val point = Point.fromLngLat(recommendation.longitude, recommendation.latitude)
-            _uiState.value = _uiState.value.copy(
-                mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                    point,
-                    16.0
-                )
-            ) // Zoom closer for selected marker
-        }
+        resolveAndApplyTargetForMode(WorkMode.WFA)
     }
 
     /**
@@ -642,8 +582,7 @@ class AttendanceViewModel @Inject constructor(
                 Log.w(TAG, "Booking clicked in WFA mode but no location selected.")
             }
         } else {
-            Log.d(TAG, "Booking clicked for mode: ${_uiState.value.selectedWorkMode}")
-            // TODO: Implement booking logic for WFO/WFH
+            Log.d(TAG, "Booking clicked for mode: ${_uiState.value.selectedWorkMode.shortLabel}")
         }
     }
 
@@ -657,7 +596,11 @@ class AttendanceViewModel @Inject constructor(
         val buttonText = _uiState.value.buttonText
 
         if (!isEnabled) {
-            Log.d(TAG, "Attendance button clicked but not enabled (geofence or server restriction)")
+            val blockingReason = _uiState.value.workModeEligibility?.blockingReason
+            Log.d(TAG, "Attendance button clicked but not enabled: $blockingReason")
+            blockingReason?.let { reason ->
+                _uiState.value = _uiState.value.copy(activeDialog = DialogState.Error(reason))
+            }
             return
         }
 
@@ -722,30 +665,35 @@ class AttendanceViewModel @Inject constructor(
                 // Clear any previous error
                 _uiState.value = _uiState.value.copy(activeDialog = null)
 
-                // Determine target location based on selected work mode
-                val targetLocation = when (_uiState.value.selectedWorkMode) {
-                    "Work From Home", "WFH" -> _uiState.value.wfhLocation
-                    "Work From Office", "WFO" -> _uiState.value.wfoLocation
-                    "WFA", "Work From Anywhere" -> {
-                        // For WFA, convert selectedWfaLocation to Location object
-                        _uiState.value.selectedWfaLocation?.let { wfaLocation ->
-                            Location(
-                                locationId = 0, // WFA locations don't have fixed IDs
-                                latitude = wfaLocation.latitude,
-                                longitude = wfaLocation.longitude,
-                                radius = 100, // Default radius for WFA
-                                description = wfaLocation.name,
-                                category = wfaLocation.category
-                            )
-                        }
-                    }
-
-                    else -> _uiState.value.wfoLocation // Default to WFO
-                }
+                val selectedMode = _uiState.value.selectedWorkMode
+                val target = _uiState.value.selectedTargetLocation ?: resolveSelectedTargetLocationUseCase(
+                    mode = selectedMode,
+                    wfoLocation = _uiState.value.wfoLocation,
+                    wfhLocation = _uiState.value.wfhLocation,
+                    selectedWfaLocation = _uiState.value.selectedWfaLocation
+                )
+                val targetLocation = target.location
 
                 if (targetLocation == null) {
                     _uiState.value = _uiState.value.copy(
-                        activeDialog = DialogState.Error("Target location not available for ${_uiState.value.selectedWorkMode}. Please try again.")
+                        activeDialog = DialogState.Error(
+                            target.unavailableReason ?: "Target location not available for ${selectedMode.shortLabel}. Please try again."
+                        )
+                    )
+                    return@launch
+                }
+
+                val eligibility = _uiState.value.workModeEligibility ?: evaluateWorkModeEligibilityUseCase(
+                    mode = selectedMode,
+                    selectedTargetLocation = target,
+                    todayDate = _uiState.value.todayStatus?.todayDate
+                )
+
+                if (!eligibility.canContinueToFaceVerification) {
+                    _uiState.value = _uiState.value.copy(
+                        activeDialog = DialogState.Error(
+                            eligibility.blockingReason ?: "Mode kerja belum memenuhi syarat untuk attendance."
+                        )
                     )
                     return@launch
                 }
@@ -759,42 +707,36 @@ class AttendanceViewModel @Inject constructor(
                         return@collect
                     }
 
-                    // Map work mode to correct category_id
-                    val categoryId = when (_uiState.value.selectedWorkMode) {
-                        "Work From Office", "WFO" -> 1  // Work From Office
-                        "Work From Home", "WFH" -> 2    // Work From Home
-                        "WFA", "Work From Anywhere" -> 3 // Work From Anywhere
-                        else -> 1 // Default to WFO
-                    }
-
-                    val bookingId = if (categoryId == 3) {
-                        val scheduleDateIso = _uiState.value.todayStatus?.todayDate
-                        if (scheduleDateIso.isNullOrBlank()) {
-                            _uiState.value = _uiState.value.copy(
-                                activeDialog = DialogState.Error(
-                                    "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
-                                )
-                            )
-                            return@collect
-                        }
-
-                        resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
-                            .getOrElse { exception ->
+                    val bookingId = if (selectedMode == WorkMode.WFA) {
+                        eligibility.approvedWfaBookingId ?: run {
+                            val scheduleDateIso = _uiState.value.todayStatus?.todayDate
+                            if (scheduleDateIso.isNullOrBlank()) {
                                 _uiState.value = _uiState.value.copy(
                                     activeDialog = DialogState.Error(
-                                        exception.message
-                                            ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
+                                        "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
                                     )
                                 )
                                 return@collect
                             }
+
+                            resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
+                                .getOrElse { exception ->
+                                    _uiState.value = _uiState.value.copy(
+                                        activeDialog = DialogState.Error(
+                                            exception.message
+                                                ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
+                                        )
+                                    )
+                                    return@collect
+                                }
+                        }
                     } else {
                         null
                     }
 
                     val attendanceRequest = try {
                         AttendanceCheckInRequestFactory.create(
-                            selectedWorkMode = _uiState.value.selectedWorkMode,
+                            workMode = selectedMode,
                             bookingId = bookingId
                         )
                     } catch (exception: IllegalArgumentException) {
@@ -967,23 +909,17 @@ class AttendanceViewModel @Inject constructor(
     }
 
     /**
-     * Called when the map is ready to receive commands
-     * This will trigger initial camera focus to WFO location
+     * Called when the map is ready to receive commands.
      */
     fun onMapReady() {
-        Log.d(TAG, "Map is ready, focusing to WFO location")
+        Log.d(TAG, "Map is ready, focusing to selected target location")
         viewModelScope.launch {
-            _uiState.value.wfoLocation?.let { wfoLocation ->
-                val wfoPoint = Point.fromLngLat(wfoLocation.longitude, wfoLocation.latitude)
-                _uiState.value = _uiState.value.copy(
-                    mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                        point = wfoPoint,
-                        zoomLevel = 15.0
-                    )
-                )
-                Log.d(TAG, "Initial camera focus sent to WFO location")
+            val location = _uiState.value.selectedTargetLocation?.location ?: _uiState.value.wfoLocation
+            location?.let { target ->
+                animateMapToTarget(target)
+                Log.d(TAG, "Initial camera focus sent to selected target location")
             } ?: run {
-                Log.w(TAG, "WFO location not available for initial focus")
+                Log.w(TAG, "Target location not available for initial focus")
             }
         }
     }
@@ -1013,16 +949,11 @@ class AttendanceViewModel @Inject constructor(
                     category = "Custom", // Default category for manually selected location
                     distance = 0.0 // Distance will be calculated based on current location
                 ),
+                selectedWorkMode = WorkMode.WFA,
                 isWfaModeActive = true
             )
 
-            // Animate map to the selected location
-            _uiState.value = _uiState.value.copy(
-                mapAnimationTarget = MapAnimationTarget.AnimateToLocation(
-                    Point.fromLngLat(location.longitude, location.latitude),
-                    15.0
-                )
-            )
+            resolveAndApplyTargetForMode(WorkMode.WFA)
         }
     }
 
@@ -1083,6 +1014,7 @@ class AttendanceViewModel @Inject constructor(
                             distance = 0.0
                         )
                     )
+                    resolveAndApplyTargetForMode(WorkMode.WFA)
                 }.onFailure { exception ->
                     Log.e(TAG, "Reverse geocoding failed", exception)
 
@@ -1091,6 +1023,7 @@ class AttendanceViewModel @Inject constructor(
                         selectedWfaLocation = null,
                         error = "Gagal mendapatkan detail lokasi. Periksa koneksi Anda."
                     )
+                    resolveAndApplyTargetForMode(WorkMode.WFA)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Unexpected error in onMapIdle", e)
@@ -1111,24 +1044,8 @@ class AttendanceViewModel @Inject constructor(
             permissionResult = result
         )
 
-        // If permissions are granted, retry geofence setup
         if (result == LocationPermissionHelper.PermissionResult.AllPermissionsGranted) {
-            // Retry setting up geofence for current selected location
-            when (_uiState.value.selectedWorkMode) {
-                "Work From Home", "WFH" -> _uiState.value.wfhLocation?.let { setupGeofence(it) }
-                "Work From Office", "WFO" -> _uiState.value.wfoLocation?.let { setupGeofence(it) }
-                else -> _uiState.value.selectedWfaLocation?.let { wfaLocation ->
-                    val location = Location(
-                        locationId = 0, // WFA doesn't have fixed ID
-                        latitude = wfaLocation.latitude,
-                        longitude = wfaLocation.longitude,
-                        radius = 100, // Default radius for WFA
-                        description = wfaLocation.name,
-                        category = wfaLocation.category
-                    )
-                    setupGeofence(location)
-                }
-            }
+            resolveAndApplyTargetForMode()
         }
     }
 

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/attendance/EvaluateWorkModeEligibilityUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/attendance/EvaluateWorkModeEligibilityUseCaseTest.kt
@@ -1,0 +1,159 @@
+package com.example.infinite_track.domain.use_case.attendance
+
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.SelectedTargetLocation
+import com.example.infinite_track.domain.model.attendance.WorkMode
+import com.example.infinite_track.domain.model.attendance.WorkModeRecoveryAction
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.model.booking.BookingHistoryPage
+import com.example.infinite_track.domain.repository.BookingRepository
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EvaluateWorkModeEligibilityUseCaseTest {
+
+    @Test
+    fun invoke_allowsWfhWhenHomeTargetExists() {
+        runBlocking {
+            val useCase = useCaseWithBookings(emptyList())
+
+            val eligibility = useCase(
+                mode = WorkMode.WFH,
+                selectedTargetLocation = availableTarget(WorkMode.WFH),
+                todayDate = "2026-07-09"
+            )
+
+            assertTrue(eligibility.canContinueToFaceVerification)
+            assertEquals(WorkMode.WFH, eligibility.mode)
+        }
+    }
+
+    @Test
+    fun invoke_blocksWfhBeforeFaceVerificationWhenHomeTargetMissing() {
+        runBlocking {
+            val useCase = useCaseWithBookings(emptyList())
+
+            val eligibility = useCase(
+                mode = WorkMode.WFH,
+                selectedTargetLocation = SelectedTargetLocation(
+                    mode = WorkMode.WFH,
+                    location = null,
+                    displayName = "Lokasi WFH belum tersedia",
+                    description = null,
+                    isAvailable = false,
+                    unavailableReason = "Lokasi WFH belum tersedia. Pilih WFO atau perbarui lokasi WFH terlebih dahulu."
+                ),
+                todayDate = "2026-07-09"
+            )
+
+            assertFalse(eligibility.canContinueToFaceVerification)
+            assertEquals(WorkModeRecoveryAction.UPDATE_WFH_LOCATION, eligibility.recoveryAction)
+        }
+    }
+
+    @Test
+    fun invoke_blocksWfaWhenApprovedBookingIsMissing() {
+        runBlocking {
+            val useCase = useCaseWithBookings(emptyList())
+
+            val eligibility = useCase(
+                mode = WorkMode.WFA,
+                selectedTargetLocation = availableTarget(WorkMode.WFA),
+                todayDate = "2026-07-09"
+            )
+
+            assertFalse(eligibility.canContinueToFaceVerification)
+            assertEquals(WorkModeRecoveryAction.VIEW_WFA_REQUESTS, eligibility.recoveryAction)
+        }
+    }
+
+    @Test
+    fun invoke_allowsWfaWhenApprovedBookingExistsForToday() {
+        runBlocking {
+            val useCase = useCaseWithBookings(
+                listOf(bookingItem(bookingId = 88, scheduleDateRaw = "2026-07-09"))
+            )
+
+            val eligibility = useCase(
+                mode = WorkMode.WFA,
+                selectedTargetLocation = availableTarget(WorkMode.WFA),
+                todayDate = "2026-07-09"
+            )
+
+            assertTrue(eligibility.canContinueToFaceVerification)
+            assertEquals(88, eligibility.approvedWfaBookingId)
+        }
+    }
+
+    private fun useCaseWithBookings(bookings: List<BookingHistoryItem>): EvaluateWorkModeEligibilityUseCase {
+        return EvaluateWorkModeEligibilityUseCase(
+            ResolveTodayApprovedWfaBookingIdUseCase(
+                FakeBookingRepository(bookings)
+            )
+        )
+    }
+
+    private fun availableTarget(mode: WorkMode) = SelectedTargetLocation(
+        mode = mode,
+        location = Location(
+            locationId = mode.categoryId,
+            description = mode.displayLabel,
+            latitude = -0.8,
+            longitude = 119.9,
+            radius = 100,
+            category = mode.shortLabel
+        ),
+        displayName = mode.displayLabel,
+        description = mode.shortLabel,
+        isAvailable = true
+    )
+
+    private fun bookingItem(
+        bookingId: Int,
+        scheduleDateRaw: String
+    ) = BookingHistoryItem(
+        id = bookingId.toString(),
+        bookingId = bookingId,
+        locationDescription = "WFA location",
+        scheduleDate = scheduleDateRaw,
+        scheduleDateRaw = scheduleDateRaw,
+        status = "Approved",
+        statusRaw = "approved",
+        notes = "",
+        suitabilityLabel = ""
+    )
+
+    private class FakeBookingRepository(
+        private val bookings: List<BookingHistoryItem>
+    ) : BookingRepository {
+        override suspend fun getBookingHistory(
+            status: String?,
+            page: Int,
+            limit: Int,
+            sortBy: String,
+            sortOrder: String
+        ): Result<BookingHistoryPage> {
+            return Result.success(
+                BookingHistoryPage(
+                    bookings = if (page == 1) bookings else emptyList(),
+                    hasNextPage = false
+                )
+            )
+        }
+
+        override suspend fun submitBooking(
+            scheduleDate: String,
+            latitude: Double,
+            longitude: Double,
+            radius: Int,
+            description: String,
+            notes: String
+        ): Result<Unit> {
+            throw UnsupportedOperationException("Not needed in this test")
+        }
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/domain/use_case/attendance/ResolveSelectedTargetLocationUseCaseTest.kt
+++ b/app/src/test/java/com/example/infinite_track/domain/use_case/attendance/ResolveSelectedTargetLocationUseCaseTest.kt
@@ -1,0 +1,88 @@
+package com.example.infinite_track.domain.use_case.attendance
+
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.WorkMode
+import com.example.infinite_track.domain.model.wfa.WfaRecommendation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResolveSelectedTargetLocationUseCaseTest {
+
+    private val useCase = ResolveSelectedTargetLocationUseCase()
+
+    @Test
+    fun invoke_resolvesWfoFromStatusTodayLocation() {
+        val wfoLocation = location(description = "Kantor Infinite Track", category = "Office")
+
+        val target = useCase(
+            mode = WorkMode.WFO,
+            wfoLocation = wfoLocation,
+            wfhLocation = null,
+            selectedWfaLocation = null
+        )
+
+        assertEquals(WorkMode.WFO, target.mode)
+        assertEquals(wfoLocation, target.location)
+        assertEquals("Kantor Infinite Track", target.displayName)
+        assertTrue(target.isAvailable)
+    }
+
+    @Test
+    fun invoke_blocksWfhWhenHomeLocationMissing() {
+        val target = useCase(
+            mode = WorkMode.WFH,
+            wfoLocation = location(),
+            wfhLocation = null,
+            selectedWfaLocation = null
+        )
+
+        assertEquals(WorkMode.WFH, target.mode)
+        assertFalse(target.isAvailable)
+        assertEquals(
+            "Lokasi WFH belum tersedia. Pilih WFO atau perbarui lokasi WFH terlebih dahulu.",
+            target.unavailableReason
+        )
+    }
+
+    @Test
+    fun invoke_convertsSelectedWfaRecommendationIntoAttendanceLocation() {
+        val recommendation = WfaRecommendation(
+            name = "Cafe Produktif",
+            address = "Jl. Merdeka",
+            latitude = -0.9,
+            longitude = 119.8,
+            score = 0.8,
+            label = "Good",
+            category = "Cafe",
+            distance = 1.2
+        )
+
+        val target = useCase(
+            mode = WorkMode.WFA,
+            wfoLocation = null,
+            wfhLocation = null,
+            selectedWfaLocation = recommendation
+        )
+
+        assertEquals(WorkMode.WFA, target.mode)
+        assertEquals("Cafe Produktif", target.displayName)
+        assertEquals("Jl. Merdeka", target.description)
+        assertEquals(-0.9, target.location?.latitude ?: 0.0, 0.0)
+        assertEquals(119.8, target.location?.longitude ?: 0.0, 0.0)
+        assertTrue(target.isAvailable)
+    }
+
+    private fun location(
+        description: String = "Target",
+        category: String = "Category"
+    ) = Location(
+        locationId = 1,
+        description = description,
+        latitude = -0.8,
+        longitude = 119.9,
+        radius = 100,
+        category = category
+    )
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactoryTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceCheckInRequestFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.example.infinite_track.presentation.screen.attendance
 
+import com.example.infinite_track.domain.model.attendance.WorkMode
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -8,7 +9,7 @@ class AttendanceCheckInRequestFactoryTest {
     @Test
     fun create_preservesBookingIdForWfaRequests() {
         val request = AttendanceCheckInRequestFactory.create(
-            selectedWorkMode = "WFA",
+            workMode = WorkMode.WFA,
             bookingId = 456
         )
 
@@ -21,7 +22,7 @@ class AttendanceCheckInRequestFactoryTest {
     @Test(expected = IllegalArgumentException::class)
     fun create_rejectsWfaRequestWithoutBookingId() {
         AttendanceCheckInRequestFactory.create(
-            selectedWorkMode = "Work From Anywhere",
+            workMode = WorkMode.WFA,
             bookingId = null
         )
     }

--- a/docs/superpowers/plans/2026-07-09-inf-238-work-mode-target-location-hardening.md
+++ b/docs/superpowers/plans/2026-07-09-inf-238-work-mode-target-location-hardening.md
@@ -1,0 +1,38 @@
+# INF-238 — Work Mode & Target Location Hardening
+
+## Scope
+
+Harden the Attendance Work Mode & Target Location layer without redesigning the full Attendance or FaceScanner flow.
+
+## Architecture note
+
+- Work mode identity is represented by canonical domain model `WorkMode`.
+- Target resolution is centralized in `ResolveSelectedTargetLocationUseCase`.
+- Continue-to-FaceScanner eligibility is centralized in `EvaluateWorkModeEligibilityUseCase`.
+- Mode selection updates selected mode, selected target location, eligibility, WFA recommendation flow, and map focus only.
+- Mode selection must not remove geofences or register active monitoring geofences.
+- Active monitoring geofence ownership remains after successful backend check-in in `CheckInUseCase`.
+- Backend remains the final attendance validation authority.
+
+## Verification status
+
+- `git diff --check`: passed.
+- Code scan: `AttendanceViewModel.kt` no longer contains `removeAllGeofences`, `setupGeofence`, or `addGeofence` calls.
+- Code evidence: `CheckInUseCase` still starts active geofence only after successful backend check-in.
+- Plain Git Bash/JBR Gradle attempts were blocked by `java.io.IOException: Unable to establish loopback connection` before Kotlin compile.
+- Using the project-local PowerShell environment with `JAVA_HOME="D:\Java_Home\java 1.8.2"` resolved the loopback issue.
+- `app:assembleDebug`: passed with the PowerShell env.
+- `app:test`: passed with the PowerShell env.
+- `app:lint`: passed with the PowerShell env.
+
+## Needs Verification
+
+Runtime evidence still needed on emulator/device:
+
+- WFO selected with office target location.
+- WFH selected with registered home target location.
+- WFH unavailable state when home location is missing.
+- WFA selected and WFA action visible.
+- WFA blocked before Face Verification when approved booking is missing.
+- WFA eligible flow when approved booking exists.
+- Map focus changes across mode switches.


### PR DESCRIPTION
## Summary

INF-238 hardens the Attendance Work Mode & Target Location layer.

- Added canonical `WorkMode` domain enum with category mapping WFO=1, WFH=2, WFA=3.
- Added `SelectedTargetLocation` and `WorkModeEligibility` domain models.
- Added target resolution and eligibility use cases.
- Migrated Attendance mode selection away from raw display strings.
- WorkModeSelector now renders WFO, WFH, and WFA.
- Bottom sheet target location now reads from selected target location.
- WFH missing home location blocks before FaceScanner with inline recovery message.
- WFA missing selected location or approved booking blocks before FaceScanner.
- Booking Location action is shown only for WFA.
- Mode switching no longer removes/registers active monitoring geofences.
- Active monitoring geofence remains owned by CheckInUseCase after successful backend check-in.
- Backend remains final validation authority.

## Verification

Passed in isolated worktree with the project PowerShell env:

```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

- `app:assembleDebug` — BUILD SUCCESSFUL
- `app:test` — BUILD SUCCESSFUL
- `app:lint` — BUILD SUCCESSFUL
- `git diff --check` — passed

## Needs Verification

Runtime/emulator validation from `develop` after merge:

- WFO target location.
- WFH registered target.
- WFH missing-location blocked state.
- WFA action visibility.
- WFA missing approved booking blocked before FaceScanner.
- WFA eligible flow reaches FaceScanner.
- Map focus changes on mode switch.

## Docs / ADR

- Added focused implementation/evidence note at `docs/superpowers/plans/2026-07-09-inf-238-work-mode-target-location-hardening.md`.
- No ADR added; architecture shift is documented in this PR unless reviewers request a dedicated ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
