### PR TITLE
INF-239: Add attendance action state machine

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
@@ -12,7 +12,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.attendance.TargetLocationInfo
 import com.example.infinite_track.presentation.components.button.InfiniteTrackButton
+import com.example.infinite_track.presentation.components.status.InfiniteTrackInlineAlert
+import com.example.infinite_track.presentation.components.status.StatusStates
 import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.screen.attendance.AttendanceActionState
+import com.example.infinite_track.presentation.screen.attendance.AttendanceBlockReason
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
 import com.example.infinite_track.presentation.theme.Purple_500
 
@@ -41,6 +45,7 @@ fun AttendanceBottomSheetContent(
     isBookingEnabled: Boolean,
     isCheckInEnabled: Boolean,
     checkInButtonText: String,
+    actionState: AttendanceActionState? = null,
     outOfRangeWarningText: String = "Anda berada di luar jangkauan lokasi kerja ?",
     onSearchLocationClick: () -> Unit = {}, // Untuk navigasi ke LocationSearchScreen
     onModeSelected: (String) -> Unit,
@@ -86,6 +91,10 @@ fun AttendanceBottomSheetContent(
             )
         }
 
+        actionState?.let { state ->
+            AttendanceActionInlineAlert(actionState = state)
+        }
+
         // Action Buttons
         AttendanceActionButtons(
             isBookingEnabled = isBookingEnabled,
@@ -94,6 +103,62 @@ fun AttendanceBottomSheetContent(
             onBookingClick = onBookingClick,
             onCheckInClick = onCheckInClick
         )
+    }
+}
+
+@Composable
+private fun AttendanceActionInlineAlert(
+    actionState: AttendanceActionState
+) {
+    when (actionState) {
+        is AttendanceActionState.Blocked -> {
+            val status = when (actionState.reason) {
+                AttendanceBlockReason.SERVER_RESTRICTION,
+                AttendanceBlockReason.UNKNOWN -> StatusStates.Error
+                else -> StatusStates.Warning
+            }
+            InfiniteTrackInlineAlert(
+                status = status,
+                title = actionState.title,
+                message = actionState.message
+            )
+        }
+
+        is AttendanceActionState.VerifyingFace -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStates.Info,
+                title = "Verifikasi wajah",
+                message = "Membuka scanner wajah untuk melanjutkan absensi."
+            )
+        }
+
+        is AttendanceActionState.Submitting -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStates.Info,
+                title = "Mengirim absensi",
+                message = actionState.message
+            )
+        }
+
+        is AttendanceActionState.RetryableFailure -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStates.Error,
+                title = actionState.title,
+                message = actionState.message
+            )
+        }
+
+        AttendanceActionState.Completed -> {
+            InfiniteTrackInlineAlert(
+                status = StatusStates.Info,
+                title = "Absensi selesai",
+                message = "Anda sudah absen hari ini."
+            )
+        }
+
+        AttendanceActionState.Loading,
+        is AttendanceActionState.Ready,
+        is AttendanceActionState.Success -> Unit
     }
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionResolver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionResolver.kt
@@ -1,0 +1,69 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+object AttendanceActionResolver {
+    fun resolve(state: AttendanceScreenState): AttendanceActionState {
+        val todayStatus = state.todayStatus ?: return AttendanceActionState.Loading
+        val intent = when {
+            todayStatus.checkedInAt == null && todayStatus.canCheckIn -> AttendanceActionIntent.CHECK_IN
+            todayStatus.checkedInAt != null && todayStatus.canCheckOut -> AttendanceActionIntent.CHECK_OUT
+            else -> return AttendanceActionState.Completed
+        }
+
+        if (intent == AttendanceActionIntent.CHECK_IN) {
+            val blockState = resolveLayerTwoBlocker(state)
+            if (blockState != null) return blockState
+        }
+
+        return AttendanceActionState.Ready(
+            intent = intent,
+            label = intent.readyLabel()
+        )
+    }
+
+    private fun resolveLayerTwoBlocker(
+        state: AttendanceScreenState
+    ): AttendanceActionState.Blocked? {
+        val selectedMode = state.selectedWorkMode
+        return when (selectedMode) {
+            "Work From Home", "WFH" -> {
+                if (state.wfhLocation == null) {
+                    AttendanceActionState.Blocked(
+                        reason = AttendanceBlockReason.WFH_LOCATION_MISSING,
+                        title = "Lokasi WFH belum tersedia",
+                        message = "Lengkapi lokasi WFH sebelum melanjutkan verifikasi wajah."
+                    )
+                } else {
+                    null
+                }
+            }
+
+            "WFA", "Work From Anywhere" -> {
+                when {
+                    state.selectedWfaLocation == null && state.targetLocation == null -> AttendanceActionState.Blocked(
+                        reason = AttendanceBlockReason.TARGET_LOCATION_UNAVAILABLE,
+                        title = "Target location tidak tersedia",
+                        message = "Pilih lokasi WFA sebelum melanjutkan verifikasi wajah."
+                    )
+                    state.todayStatus?.todayDate.isNullOrBlank() -> AttendanceActionState.Blocked(
+                        reason = AttendanceBlockReason.WFA_BOOKING_REQUIRED,
+                        title = "Booking WFA belum disetujui",
+                        message = "Booking WFA yang disetujui diperlukan sebelum absen dari lokasi WFA."
+                    )
+                    else -> null
+                }
+            }
+
+            else -> {
+                if (state.targetLocation == null && state.wfoLocation == null) {
+                    AttendanceActionState.Blocked(
+                        reason = AttendanceBlockReason.TARGET_LOCATION_UNAVAILABLE,
+                        title = "Target location tidak tersedia",
+                        message = "Lokasi kerja belum tersedia. Muat ulang status absensi atau coba lagi nanti."
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionState.kt
@@ -1,0 +1,96 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+enum class AttendanceActionIntent {
+    CHECK_IN,
+    CHECK_OUT
+}
+
+enum class AttendanceBlockReason {
+    PERMISSION_REQUIRED,
+    TARGET_LOCATION_UNAVAILABLE,
+    WFH_LOCATION_MISSING,
+    WFA_BOOKING_REQUIRED,
+    ALREADY_COMPLETED,
+    SERVER_RESTRICTION,
+    UNKNOWN
+}
+
+sealed interface AttendanceActionState {
+    data object Loading : AttendanceActionState
+
+    data class Ready(
+        val intent: AttendanceActionIntent,
+        val label: String
+    ) : AttendanceActionState
+
+    data class Blocked(
+        val reason: AttendanceBlockReason,
+        val title: String,
+        val message: String
+    ) : AttendanceActionState
+
+    data class VerifyingFace(
+        val intent: AttendanceActionIntent
+    ) : AttendanceActionState
+
+    data class Submitting(
+        val intent: AttendanceActionIntent,
+        val message: String
+    ) : AttendanceActionState
+
+    data class Success(
+        val intent: AttendanceActionIntent,
+        val message: String
+    ) : AttendanceActionState
+
+    data class RetryableFailure(
+        val intent: AttendanceActionIntent?,
+        val title: String,
+        val message: String
+    ) : AttendanceActionState
+
+    data object Completed : AttendanceActionState
+}
+
+val AttendanceActionState.ctaLabel: String
+    get() = when (this) {
+        AttendanceActionState.Loading -> "Memuat status absensi..."
+        is AttendanceActionState.Ready -> label
+        is AttendanceActionState.Blocked -> title
+        is AttendanceActionState.VerifyingFace -> when (intent) {
+            AttendanceActionIntent.CHECK_IN -> "Membuka verifikasi wajah..."
+            AttendanceActionIntent.CHECK_OUT -> "Membuka verifikasi wajah..."
+        }
+        is AttendanceActionState.Submitting -> message
+        is AttendanceActionState.Success -> when (intent) {
+            AttendanceActionIntent.CHECK_IN -> "Check-in berhasil"
+            AttendanceActionIntent.CHECK_OUT -> "Check-out berhasil"
+        }
+        is AttendanceActionState.RetryableFailure -> "Coba lagi"
+        AttendanceActionState.Completed -> "Anda sudah absen hari ini"
+    }
+
+val AttendanceActionState.isCtaEnabled: Boolean
+    get() = this is AttendanceActionState.Ready ||
+        (this is AttendanceActionState.RetryableFailure && intent != null)
+
+val AttendanceActionState.legacyIsCheckInMode: Boolean
+    get() = when (this) {
+        is AttendanceActionState.Ready -> intent == AttendanceActionIntent.CHECK_IN
+        is AttendanceActionState.VerifyingFace -> intent == AttendanceActionIntent.CHECK_IN
+        is AttendanceActionState.Submitting -> intent == AttendanceActionIntent.CHECK_IN
+        is AttendanceActionState.Success -> intent == AttendanceActionIntent.CHECK_IN
+        is AttendanceActionState.RetryableFailure -> intent != AttendanceActionIntent.CHECK_OUT
+        AttendanceActionState.Completed -> false
+        else -> true
+    }
+
+fun AttendanceActionIntent.readyLabel(): String = when (this) {
+    AttendanceActionIntent.CHECK_IN -> "Check-in di sini"
+    AttendanceActionIntent.CHECK_OUT -> "Check-out di sini"
+}
+
+fun AttendanceActionIntent.submittingMessage(): String = when (this) {
+    AttendanceActionIntent.CHECK_IN -> "Mengirim check-in..."
+    AttendanceActionIntent.CHECK_OUT -> "Mengirim check-out..."
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
@@ -109,7 +109,10 @@ fun AttendanceScreen(
         uiState.navigationTarget?.let { target ->
             when (target) {
                 is NavigationTarget.FaceScanner -> {
-                    val action = if (target.isCheckIn) "checkin" else "checkout"
+                    val action = when (target.intent) {
+                        AttendanceActionIntent.CHECK_IN -> "checkin"
+                        AttendanceActionIntent.CHECK_OUT -> "checkout"
+                    }
                     val route = Screen.FaceScanner.createRoute(action)
                     navController.navigate(route)
                     android.util.Log.d(
@@ -349,8 +352,9 @@ fun AttendanceScreen(
                                 currentLocationAddress = uiState.currentUserAddress.ifEmpty { "Mengambil lokasi saat ini..." },
                                 selectedWorkMode = uiState.selectedWorkMode,
                                 isBookingEnabled = uiState.isBookingEnabled,
-                                isCheckInEnabled = uiState.isButtonEnabled, // Use isButtonEnabled from uiState
+                                isCheckInEnabled = uiState.isButtonEnabled,
                                 checkInButtonText = uiState.buttonText,
+                                actionState = uiState.actionState,
                                 onSearchLocationClick = {
                                     navController.navigate("location_search")
                                 },

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt
@@ -33,6 +33,7 @@ data class AttendanceScreenState(
     val pickedLocation: LocationResult? = null,
     val isPickOnMapModeActive: Boolean = false,
     val error: String? = null,
+    val actionState: AttendanceActionState = AttendanceActionState.Loading,
     val buttonText: String = "Loading...",
     val isButtonEnabled: Boolean = false,
     val isCheckInMode: Boolean = true,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -36,7 +36,7 @@ import javax.inject.Inject
  * Sealed class untuk merepresentasikan target navigasi
  */
 sealed class NavigationTarget {
-    data class FaceScanner(val isCheckIn: Boolean) : NavigationTarget()
+    data class FaceScanner(val intent: AttendanceActionIntent) : NavigationTarget()
     data class WfaBooking(val route: String) : NavigationTarget()
     data class LocationSearch(val params: String) : NavigationTarget()
 }
@@ -166,8 +166,7 @@ class AttendanceViewModel @Inject constructor(
     }
 
     /**
-     * Fetch today status to get WFO location
-     * FIXED: Now uses isButtonEnabled from calculateDynamicButtonState directly
+     * Fetch today status to get WFO location and resolve explicit attendance action state.
      */
     private suspend fun fetchTodayStatus(forceRefresh: Boolean = false) {
         try {
@@ -180,23 +179,18 @@ class AttendanceViewModel @Inject constructor(
                 val isBookingEnabled = todayStatus.activeMode.isNotEmpty()
                 val selectedMode = todayStatus.activeMode.ifEmpty { "Work From Office" }
 
-                // Calculate button state based on today's status
-                val (buttonText, isButtonEnabled, isCheckInMode) = calculateDynamicButtonState(
-                    todayStatus
-                )
-
-                _uiState.value = _uiState.value.copy(
+                val nextState = _uiState.value.copy(
                     todayStatus = todayStatus,
                     targetLocation = todayStatus.activeLocation,
                     wfoLocation = todayStatus.activeLocation, // WFO location from today status
                     targetLocationMarker = todayStatus.activeLocation,
                     isBookingEnabled = isBookingEnabled,
                     selectedWorkMode = selectedMode,
-                    // FIXED: Now uses isButtonEnabled from calculateDynamicButtonState
-                    buttonText = buttonText,
-                    isButtonEnabled = isButtonEnabled,
-                    isCheckInMode = isCheckInMode,
+                    isWfaModeActive = selectedMode == "WFA" || selectedMode == "Work From Anywhere",
                     uiState = UiState.Success(Unit)
+                )
+                _uiState.value = nextState.withActionState(
+                    AttendanceActionResolver.resolve(nextState)
                 )
 
                 // Setup geofence for active location (validation purposes)
@@ -221,7 +215,7 @@ class AttendanceViewModel @Inject constructor(
                 Log.d(TAG, "WFO location updated: ${todayStatus.activeLocation}")
                 Log.d(
                     TAG,
-                    "Button state updated: $buttonText, enabled: $isButtonEnabled, mode: $isCheckInMode"
+                    "Attendance action state updated: ${_uiState.value.actionState}"
                 )
 
                 // Register/refresh reminder geofences (WFO/WFH) after fetching status
@@ -248,47 +242,47 @@ class AttendanceViewModel @Inject constructor(
 
             }.onFailure { exception ->
                 Log.e(TAG, "Failed to fetch today status", exception)
+                val message = exception.message ?: "Status absensi gagal dimuat."
                 _uiState.value = _uiState.value.copy(
-                    uiState = UiState.Error("Failed to load attendance status: ${exception.message}"),
-                    buttonText = "Error",
-                    isButtonEnabled = false
+                    uiState = UiState.Error("Failed to load attendance status: $message")
+                ).withActionState(
+                    AttendanceActionState.RetryableFailure(
+                        intent = null,
+                        title = "Status absensi gagal dimuat",
+                        message = message
+                    )
                 )
             }
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error in fetchTodayStatus", e)
+            val message = e.message ?: "Terjadi kesalahan tidak terduga."
             _uiState.value = _uiState.value.copy(
-                uiState = UiState.Error("Unexpected error: ${e.message}"),
-                buttonText = "Error",
-                isButtonEnabled = false
+                uiState = UiState.Error("Unexpected error: $message")
+            ).withActionState(
+                AttendanceActionState.RetryableFailure(
+                    intent = null,
+                    title = "Status absensi gagal dimuat",
+                    message = message
+                )
             )
         }
     }
 
-    /**
-     * Calculate dynamic button state based on today's status
-     * Returns Triple(buttonText, isEnabled, isCheckInMode)
-     * FIXED: Tombol selalu aktif kecuali sudah selesai absensi - validasi lokasi diserahkan ke backend
-     */
-    private fun calculateDynamicButtonState(todayStatus: TodayStatus): Triple<String, Boolean, Boolean> {
-        return when {
-            // PRIORITAS 1: Belum check-in sama sekali (checked_in_at == null)
-            // Selalu aktif - biarkan backend yang validasi lokasi
-            todayStatus.checkedInAt == null -> {
-                Triple("Check-in di sini", true, true)
-            }
+    private fun AttendanceScreenState.withActionState(
+        actionState: AttendanceActionState
+    ): AttendanceScreenState {
+        return copy(
+            actionState = actionState,
+            buttonText = actionState.ctaLabel,
+            isButtonEnabled = actionState.isCtaEnabled,
+            isCheckInMode = actionState.legacyIsCheckInMode
+        )
+    }
 
-            // PRIORITAS 2: Sudah check-in, bisa check-out (checked_in_at != null && can_check_out == true)
-            // Selalu aktif - biarkan backend yang validasi lokasi
-            todayStatus.checkedInAt != null && todayStatus.canCheckOut -> {
-                Triple("Check-out di sini", true, false)
-            }
-
-            // PRIORITAS 3: Sudah selesai absensi hari ini
-            // Hanya kondisi ini yang tombolnya nonaktif
-            else -> {
-                Triple("Anda sudah absen hari ini", false, false)
-            }
-        }
+    private fun refreshResolvedActionState() {
+        _uiState.value = _uiState.value.withActionState(
+            AttendanceActionResolver.resolve(_uiState.value)
+        )
     }
 
     /**
@@ -316,6 +310,7 @@ class AttendanceViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     wfhLocation = wfhLocation
                 )
+                refreshResolvedActionState()
 
                 Log.d(TAG, "WFH location updated: $wfhLocation")
             }
@@ -445,6 +440,7 @@ class AttendanceViewModel @Inject constructor(
             selectedWorkMode = mode,
             isWfaModeActive = mode == "WFA" || mode == "Work From Anywhere"
         )
+        refreshResolvedActionState()
 
         viewModelScope.launch {
             when (mode) {
@@ -454,6 +450,7 @@ class AttendanceViewModel @Inject constructor(
                         selectedWfaLocation = null,
                         pickedLocation = null
                     )
+                    refreshResolvedActionState()
                     onEnterPickOnMapMode()
                     fetchWfaRecommendations()
                 }
@@ -588,6 +585,7 @@ class AttendanceViewModel @Inject constructor(
             selectedWfaLocation = recommendation,
             selectedWfaMarkerInfo = recommendation // Show marker details
         )
+        refreshResolvedActionState()
 
         // Focus camera on selected WFA location
         viewModelScope.launch {
@@ -648,65 +646,129 @@ class AttendanceViewModel @Inject constructor(
     }
 
     /**
-     * Handle attendance button click - navigates to face scanner
-     * FIXED: Uses new Screen.FaceScanner.createRoute with action parameter
+     * Handle attendance button click using explicit action state.
      */
     fun onAttendanceButtonClicked() {
-        // Use the reactive StateFlow value instead of recalculating
-        val isEnabled = _uiState.value.isButtonEnabled
-        val buttonText = _uiState.value.buttonText
+        val currentActionState = _uiState.value.actionState
+        val intent = when (currentActionState) {
+            is AttendanceActionState.Ready -> currentActionState.intent
+            is AttendanceActionState.RetryableFailure -> currentActionState.intent
+            else -> null
+        }
 
-        if (!isEnabled) {
-            Log.d(TAG, "Attendance button clicked but not enabled (geofence or server restriction)")
+        if (intent == null || !_uiState.value.isButtonEnabled) {
+            Log.d(TAG, "Attendance button clicked but action is not ready: $currentActionState")
             return
         }
 
-        val isCheckIn = buttonText.contains("Check-in", ignoreCase = true)
-        val action = if (isCheckIn) "checkin" else "checkout"
-
-        Log.d(TAG, "Attendance button clicked - $action")
-
-        // Update isCheckInMode state before navigation
-        _uiState.value = _uiState.value.copy(isCheckInMode = isCheckIn)
+        Log.d(TAG, "Attendance button clicked - $intent")
 
         viewModelScope.launch {
+            if (intent == AttendanceActionIntent.CHECK_IN && _uiState.value.isWfaModeActive) {
+                val scheduleDateIso = _uiState.value.todayStatus?.todayDate
+                if (scheduleDateIso.isNullOrBlank()) {
+                    _uiState.value = _uiState.value.withActionState(
+                        AttendanceActionState.Blocked(
+                            reason = AttendanceBlockReason.WFA_BOOKING_REQUIRED,
+                            title = "Booking WFA belum disetujui",
+                            message = "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
+                        )
+                    )
+                    return@launch
+                }
+
+                resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
+                    .onFailure { exception ->
+                        _uiState.value = _uiState.value.withActionState(
+                            AttendanceActionState.Blocked(
+                                reason = AttendanceBlockReason.WFA_BOOKING_REQUIRED,
+                                title = "Booking WFA belum disetujui",
+                                message = exception.message
+                                    ?: "Booking WFA yang disetujui diperlukan sebelum absen dari lokasi WFA."
+                            )
+                        )
+                    }
+                    .getOrNull() ?: return@launch
+            }
+
+            val verifyingState = AttendanceActionState.VerifyingFace(intent)
             _uiState.value = _uiState.value.copy(
-                navigationTarget = NavigationTarget.FaceScanner(isCheckIn)
-            )
+                navigationTarget = NavigationTarget.FaceScanner(intent)
+            ).withActionState(verifyingState)
         }
     }
 
     /**
-     * Handle face verification result - GATEWAY after face verification
-     * Called from FaceScannerScreen when verification is complete
+     * Handle face verification result - GATEWAY after face verification.
+     * Face success only moves to backend submission; backend result remains authoritative.
      */
     fun onFaceVerificationResult(result: FaceVerificationResult) {
         Log.d(TAG, "Face verification result: $result")
 
+        val intent = (_uiState.value.actionState as? AttendanceActionState.VerifyingFace)?.intent
+            ?: _uiState.value.takeIf { it.isButtonEnabled }?.let { state ->
+                (state.actionState as? AttendanceActionState.Ready)?.intent
+                    ?: (state.actionState as? AttendanceActionState.RetryableFailure)?.intent
+            }
+
+        if (intent == null) {
+            Log.w(TAG, "Face verification result received without active attendance intent: $result")
+            _uiState.value = _uiState.value.withActionState(
+                AttendanceActionState.RetryableFailure(
+                    intent = null,
+                    title = "Verifikasi wajah tidak dapat diproses",
+                    message = "Status aksi absensi tidak tersedia. Silakan muat ulang halaman absensi."
+                )
+            )
+            return
+        }
+
         if (result.submitsAttendance) {
-            if (_uiState.value.isCheckInMode) {
-                proceedWithCheckIn()
-            } else {
-                proceedWithCheckOut()
+            val submittingState = AttendanceActionState.Submitting(
+                intent = intent,
+                message = intent.submittingMessage()
+            )
+            _uiState.value = _uiState.value.withActionState(submittingState)
+            when (intent) {
+                AttendanceActionIntent.CHECK_IN -> proceedWithCheckIn(intent)
+                AttendanceActionIntent.CHECK_OUT -> proceedWithCheckOut(intent)
             }
             return
         }
 
         result.attendanceErrorMessage?.let { errorMessage ->
             Log.d(TAG, "Face verification did not submit attendance: $result")
-            _uiState.value = _uiState.value.copy(
-                activeDialog = DialogState.Error(errorMessage)
+            _uiState.value = _uiState.value.withActionState(
+                AttendanceActionState.RetryableFailure(
+                    intent = intent,
+                    title = "Verifikasi wajah gagal",
+                    message = errorMessage
+                )
             )
             return
         }
 
-        Log.d(TAG, "Face verification cancelled - attendance process remains idle")
+        Log.d(TAG, "Face verification cancelled - attendance action returns to ready")
+        _uiState.value = _uiState.value.withActionState(
+            AttendanceActionState.Ready(
+                intent = intent,
+                label = intent.readyLabel()
+            )
+        )
     }
 
     fun onUnexpectedFaceVerificationResult() {
         Log.e(TAG, "Unexpected face verification result payload received")
+        val intent = (_uiState.value.actionState as? AttendanceActionState.VerifyingFace)?.intent
+        val message = "Hasil verifikasi wajah tidak dikenali. Silakan coba lagi."
         _uiState.value = _uiState.value.copy(
-            activeDialog = DialogState.Error("Hasil verifikasi wajah tidak dikenali. Silakan coba lagi.")
+            activeDialog = DialogState.Error(message)
+        ).withActionState(
+            AttendanceActionState.RetryableFailure(
+                intent = intent,
+                title = "Verifikasi wajah gagal",
+                message = message
+            )
         )
     }
 
@@ -714,7 +776,7 @@ class AttendanceViewModel @Inject constructor(
      * Proceed with check-in after successful face verification
      * FIXED: Added proper error message extraction from server response
      */
-    private fun proceedWithCheckIn() {
+    private fun proceedWithCheckIn(intent: AttendanceActionIntent) {
         viewModelScope.launch {
             try {
                 Log.d(TAG, "Proceeding with check-in after face verification")
@@ -744,8 +806,15 @@ class AttendanceViewModel @Inject constructor(
                 }
 
                 if (targetLocation == null) {
+                    val message = "Target location not available for ${_uiState.value.selectedWorkMode}. Please try again."
                     _uiState.value = _uiState.value.copy(
-                        activeDialog = DialogState.Error("Target location not available for ${_uiState.value.selectedWorkMode}. Please try again.")
+                        activeDialog = DialogState.Error(message)
+                    ).withActionState(
+                        AttendanceActionState.RetryableFailure(
+                            intent = intent,
+                            title = "Target location tidak tersedia",
+                            message = message
+                        )
                     )
                     return@launch
                 }
@@ -753,8 +822,15 @@ class AttendanceViewModel @Inject constructor(
                 // Get user info for the request
                 getLoggedInUserUseCase().collect { user ->
                     if (user == null) {
+                        val message = "User information not available. Please try again."
                         _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Error("User information not available. Please try again.")
+                            activeDialog = DialogState.Error(message)
+                        ).withActionState(
+                            AttendanceActionState.RetryableFailure(
+                                intent = intent,
+                                title = "Check-in gagal",
+                                message = message
+                            )
                         )
                         return@collect
                     }
@@ -770,9 +846,14 @@ class AttendanceViewModel @Inject constructor(
                     val bookingId = if (categoryId == 3) {
                         val scheduleDateIso = _uiState.value.todayStatus?.todayDate
                         if (scheduleDateIso.isNullOrBlank()) {
+                            val message = "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
                             _uiState.value = _uiState.value.copy(
-                                activeDialog = DialogState.Error(
-                                    "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
+                                activeDialog = DialogState.Error(message)
+                            ).withActionState(
+                                AttendanceActionState.RetryableFailure(
+                                    intent = intent,
+                                    title = "Booking WFA belum disetujui",
+                                    message = message
                                 )
                             )
                             return@collect
@@ -780,10 +861,15 @@ class AttendanceViewModel @Inject constructor(
 
                         resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
                             .getOrElse { exception ->
+                                val message = exception.message
+                                    ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
                                 _uiState.value = _uiState.value.copy(
-                                    activeDialog = DialogState.Error(
-                                        exception.message
-                                            ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
+                                    activeDialog = DialogState.Error(message)
+                                ).withActionState(
+                                    AttendanceActionState.RetryableFailure(
+                                        intent = intent,
+                                        title = "Booking WFA belum disetujui",
+                                        message = message
                                     )
                                 )
                                 return@collect
@@ -798,9 +884,14 @@ class AttendanceViewModel @Inject constructor(
                             bookingId = bookingId
                         )
                     } catch (exception: IllegalArgumentException) {
+                        val message = exception.message ?: "Payload check-in WFA tidak valid."
                         _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Error(
-                                exception.message ?: "Payload check-in WFA tidak valid."
+                            activeDialog = DialogState.Error(message)
+                        ).withActionState(
+                            AttendanceActionState.RetryableFailure(
+                                intent = intent,
+                                title = "Check-in gagal",
+                                message = message
                             )
                         )
                         return@collect
@@ -813,9 +904,14 @@ class AttendanceViewModel @Inject constructor(
                         // Refresh today's status from backend after mutation invalidates local cache.
                         fetchTodayStatus(forceRefresh = true)
 
-                        // Send success event to UI with appropriate message
+                        val successMessage = "Check-in berhasil! Selamat bekerja hari ini."
                         _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Success("Check-in berhasil! Selamat bekerja hari ini.")
+                            activeDialog = DialogState.Success(successMessage)
+                        ).withActionState(
+                            AttendanceActionState.Success(
+                                intent = intent,
+                                message = successMessage
+                            )
                         )
 
                     }.onFailure { exception ->
@@ -824,17 +920,29 @@ class AttendanceViewModel @Inject constructor(
                         // Extract the actual error message from the exception
                         val errorMessage = exception.message ?: "Check-in gagal. Silakan coba lagi."
 
-                        // Send error event to UI with the actual server message
                         _uiState.value = _uiState.value.copy(
                             activeDialog = DialogState.Error(errorMessage)
+                        ).withActionState(
+                            AttendanceActionState.RetryableFailure(
+                                intent = intent,
+                                title = "Check-in gagal",
+                                message = errorMessage
+                            )
                         )
                     }
                 }
 
             } catch (e: Exception) {
                 Log.e(TAG, "Error in proceedWithCheckIn", e)
+                val message = "Unexpected error during check-in: ${e.message}"
                 _uiState.value = _uiState.value.copy(
-                    activeDialog = DialogState.Error("Unexpected error during check-in: ${e.message}")
+                    activeDialog = DialogState.Error(message)
+                ).withActionState(
+                    AttendanceActionState.RetryableFailure(
+                        intent = intent,
+                        title = "Check-in gagal",
+                        message = message
+                    )
                 )
             }
         }
@@ -844,7 +952,7 @@ class AttendanceViewModel @Inject constructor(
      * Proceed with check-out after successful face verification
      * FIXED: Added proper error message extraction from server response
      */
-    private fun proceedWithCheckOut() {
+    private fun proceedWithCheckOut(intent: AttendanceActionIntent) {
         viewModelScope.launch {
             try {
                 Log.d(TAG, "Proceeding with check-out after face verification")
@@ -859,9 +967,14 @@ class AttendanceViewModel @Inject constructor(
                     // Refresh today's status from backend after mutation invalidates local cache.
                     fetchTodayStatus(forceRefresh = true)
 
-                    // Send success event to UI with appropriate message
+                    val successMessage = "Check-out berhasil! Terima kasih atas kerja keras Anda hari ini."
                     _uiState.value = _uiState.value.copy(
-                        activeDialog = DialogState.Success("Check-out berhasil! Terima kasih atas kerja keras Anda hari ini.")
+                        activeDialog = DialogState.Success(successMessage)
+                    ).withActionState(
+                        AttendanceActionState.Success(
+                            intent = intent,
+                            message = successMessage
+                        )
                     )
 
                 }.onFailure { exception ->
@@ -870,16 +983,28 @@ class AttendanceViewModel @Inject constructor(
                     // Extract the actual error message from the exception
                     val errorMessage = exception.message ?: "Check-out gagal. Silakan coba lagi."
 
-                    // Send error event to UI with the actual server message
                     _uiState.value = _uiState.value.copy(
                         activeDialog = DialogState.Error(errorMessage)
+                    ).withActionState(
+                        AttendanceActionState.RetryableFailure(
+                            intent = intent,
+                            title = "Check-out gagal",
+                            message = errorMessage
+                        )
                     )
                 }
 
             } catch (e: Exception) {
                 Log.e(TAG, "Error in proceedWithCheckOut", e)
+                val message = "Unexpected error during check-out: ${e.message}"
                 _uiState.value = _uiState.value.copy(
-                    activeDialog = DialogState.Error("Unexpected error during check-out: ${e.message}")
+                    activeDialog = DialogState.Error(message)
+                ).withActionState(
+                    AttendanceActionState.RetryableFailure(
+                        intent = intent,
+                        title = "Check-out gagal",
+                        message = message
+                    )
                 )
             }
         }
@@ -1015,6 +1140,7 @@ class AttendanceViewModel @Inject constructor(
                 ),
                 isWfaModeActive = true
             )
+            refreshResolvedActionState()
 
             // Animate map to the selected location
             _uiState.value = _uiState.value.copy(
@@ -1083,6 +1209,7 @@ class AttendanceViewModel @Inject constructor(
                             distance = 0.0
                         )
                     )
+                    refreshResolvedActionState()
                 }.onFailure { exception ->
                     Log.e(TAG, "Reverse geocoding failed", exception)
 

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionResolverTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionResolverTest.kt
@@ -1,0 +1,151 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+import com.example.infinite_track.domain.model.attendance.CheckinWindow
+import com.example.infinite_track.domain.model.attendance.Location
+import com.example.infinite_track.domain.model.attendance.TodayStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttendanceActionResolverTest {
+
+    @Test
+    fun resolve_returnsReadyCheckInWhenBackendAllowsCheckInAndTargetExists() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = null, canCheckIn = true, canCheckOut = false),
+            selectedWorkMode = "Work From Office",
+            targetLocation = location(),
+            wfoLocation = location()
+        )
+
+        val actionState = AttendanceActionResolver.resolve(state)
+
+        assertEquals(
+            AttendanceActionState.Ready(
+                intent = AttendanceActionIntent.CHECK_IN,
+                label = "Check-in di sini"
+            ),
+            actionState
+        )
+    }
+
+    @Test
+    fun resolve_returnsReadyCheckOutWhenBackendAllowsCheckOutAndTargetExists() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = "08:00", canCheckIn = false, canCheckOut = true),
+            selectedWorkMode = "Work From Office",
+            targetLocation = location(),
+            wfoLocation = location()
+        )
+
+        val actionState = AttendanceActionResolver.resolve(state)
+
+        assertEquals(
+            AttendanceActionState.Ready(
+                intent = AttendanceActionIntent.CHECK_OUT,
+                label = "Check-out di sini"
+            ),
+            actionState
+        )
+    }
+
+    @Test
+    fun resolve_returnsReadyCheckOutWhenTargetLocationMissing() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = "08:00", canCheckIn = false, canCheckOut = true),
+            selectedWorkMode = "Work From Anywhere",
+            targetLocation = null,
+            wfoLocation = null,
+            selectedWfaLocation = null
+        )
+
+        val actionState = AttendanceActionResolver.resolve(state)
+
+        assertEquals(
+            AttendanceActionState.Ready(
+                intent = AttendanceActionIntent.CHECK_OUT,
+                label = "Check-out di sini"
+            ),
+            actionState
+        )
+    }
+
+    @Test
+    fun resolve_returnsCompletedWhenBackendAllowsNoAction() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = "08:00", canCheckIn = false, canCheckOut = false),
+            selectedWorkMode = "Work From Office",
+            targetLocation = location(),
+            wfoLocation = location()
+        )
+
+        assertEquals(AttendanceActionState.Completed, AttendanceActionResolver.resolve(state))
+    }
+
+    @Test
+    fun resolve_blocksWfhWhenHomeLocationMissing() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = null, canCheckIn = true, canCheckOut = false),
+            selectedWorkMode = "Work From Home",
+            wfhLocation = null
+        )
+
+        val actionState = AttendanceActionResolver.resolve(state)
+
+        assertTrue(actionState is AttendanceActionState.Blocked)
+        assertEquals(
+            AttendanceBlockReason.WFH_LOCATION_MISSING,
+            (actionState as AttendanceActionState.Blocked).reason
+        )
+    }
+
+    @Test
+    fun resolve_blocksWfoWhenTargetLocationMissing() {
+        val state = AttendanceScreenState(
+            todayStatus = todayStatus(checkedInAt = null, canCheckIn = true, canCheckOut = false),
+            selectedWorkMode = "Work From Office",
+            targetLocation = null,
+            wfoLocation = null
+        )
+
+        val actionState = AttendanceActionResolver.resolve(state)
+
+        assertTrue(actionState is AttendanceActionState.Blocked)
+        assertEquals(
+            AttendanceBlockReason.TARGET_LOCATION_UNAVAILABLE,
+            (actionState as AttendanceActionState.Blocked).reason
+        )
+    }
+
+    private fun todayStatus(
+        checkedInAt: String?,
+        canCheckIn: Boolean,
+        canCheckOut: Boolean
+    ): TodayStatus {
+        return TodayStatus(
+            canCheckIn = canCheckIn,
+            canCheckOut = canCheckOut,
+            checkedInAt = checkedInAt,
+            checkedOutAt = null,
+            activeMode = "Work From Office",
+            activeLocation = location(),
+            todayDate = "2026-07-09",
+            isHoliday = false,
+            holidayCheckinEnabled = false,
+            currentTime = "08:00",
+            checkinWindow = CheckinWindow(startTime = "07:00", endTime = "09:00"),
+            checkoutAutoTime = "17:00"
+        )
+    }
+
+    private fun location(): Location {
+        return Location(
+            locationId = 1,
+            description = "Office",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100,
+            category = "WFO"
+        )
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt
@@ -1,0 +1,55 @@
+package com.example.infinite_track.presentation.screen.attendance
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttendanceActionStateTest {
+
+    @Test
+    fun readyCheckIn_exposesEnabledCheckInBridge() {
+        val state = AttendanceActionState.Ready(
+            intent = AttendanceActionIntent.CHECK_IN,
+            label = "Check-in di sini"
+        )
+
+        assertEquals("Check-in di sini", state.ctaLabel)
+        assertTrue(state.isCtaEnabled)
+        assertTrue(state.legacyIsCheckInMode)
+    }
+
+    @Test
+    fun readyCheckOut_exposesEnabledCheckOutBridge() {
+        val state = AttendanceActionState.Ready(
+            intent = AttendanceActionIntent.CHECK_OUT,
+            label = "Check-out di sini"
+        )
+
+        assertEquals("Check-out di sini", state.ctaLabel)
+        assertTrue(state.isCtaEnabled)
+        assertFalse(state.legacyIsCheckInMode)
+    }
+
+    @Test
+    fun blocked_exposesDisabledBridgeAndReasonCopy() {
+        val state = AttendanceActionState.Blocked(
+            reason = AttendanceBlockReason.WFH_LOCATION_MISSING,
+            title = "Lokasi WFH belum tersedia",
+            message = "Lengkapi lokasi WFH sebelum absen dari rumah."
+        )
+
+        assertEquals("Lokasi WFH belum tersedia", state.ctaLabel)
+        assertFalse(state.isCtaEnabled)
+        assertTrue(state.legacyIsCheckInMode)
+    }
+
+    @Test
+    fun completed_exposesHonestDisabledCompletedCopy() {
+        val state = AttendanceActionState.Completed
+
+        assertEquals("Anda sudah absen hari ini", state.ctaLabel)
+        assertFalse(state.isCtaEnabled)
+        assertFalse(state.legacyIsCheckInMode)
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-inf-239-attendance-action-state-machine.md
+++ b/docs/superpowers/plans/2026-07-09-inf-239-attendance-action-state-machine.md
@@ -1,0 +1,413 @@
+# INF-239 Attendance Action State Machine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement an explicit AttendanceActionState state machine so Android attendance check-in/check-out flow is honest, predictable, and no longer infers business action from button text.
+
+**Architecture:** Add a presentation-layer state model as the source of truth for attendance CTA and transitions. Keep legacy bridge fields temporarily for existing bottom-sheet wiring, but derive them from AttendanceActionState instead of using them for business decisions. Face verification success transitions to Submitting only; backend mutation success is the only source of attendance Success.
+
+**Tech Stack:** Kotlin, Jetpack Compose, MVVM ViewModel, kotlinx.coroutines StateFlow, existing InfiniteTrack status/button components, JUnit unit tests.
+
+## Global Constraints
+
+- Work only in isolated worktree: `C:\Users\Febriyadi\.claude\worktrees\android-attendance-action-state-machine`.
+- Do not edit main checkout `E:\skrisi\android`.
+- Android is a trusted data-capture client, not final attendance source of truth.
+- Do not change backend contract.
+- Do not redesign Attendance screen visuals.
+- Do not infer check-in/check-out from `buttonText`.
+- Face verification success is not attendance success.
+- Backend check-in/check-out success is the only trigger for attendance success.
+- Reuse existing `StatefulButton`, `ButtonStateType`, `InfiniteTrackInlineAlert`, `InfiniteTrackStatusDialog`, `LoadingAnimation`, and `StatusStates`.
+
+---
+
+## File Structure
+
+- Create: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionState.kt`
+  - Defines `AttendanceActionIntent`, `AttendanceBlockReason`, `AttendanceActionState`, and presentation bridge helpers.
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt`
+  - Adds `actionState` while retaining legacy bridge fields.
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt`
+  - Replaces dynamic triple resolver with explicit action resolver and transitions.
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt`
+  - Renders terminal dialogs from action state and keeps navigation side effect intact.
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt`
+  - Accepts action state and shows inline alert/loading guidance.
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceActionButtons.kt`
+  - Uses action-state-derived labels/enabled/loading state with `StatefulButton`.
+- Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt`
+  - Locks state model bridge semantics.
+- Create/Modify: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModelActionStateTest.kt`
+  - Locks no-button-text intent detection and face/backend transition semantics where feasible.
+
+## Task 1: Add explicit action model and bridge tests
+
+**Files:**
+- Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt`
+- Create: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionState.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreenState.kt`
+
+**Interfaces:**
+- Produces: `enum class AttendanceActionIntent { CHECK_IN, CHECK_OUT }`
+- Produces: `enum class AttendanceBlockReason { PERMISSION_REQUIRED, TARGET_LOCATION_UNAVAILABLE, WFH_LOCATION_MISSING, WFA_BOOKING_REQUIRED, ALREADY_COMPLETED, SERVER_RESTRICTION, UNKNOWN }`
+- Produces: `sealed interface AttendanceActionState`
+- Produces bridge helpers: `ctaLabel`, `isCtaEnabled`, `legacyIsCheckInMode`
+
+- [ ] **Step 1: Write failing tests for action-state bridge behavior**
+
+Create `AttendanceActionStateTest.kt` with tests for:
+
+```kotlin
+@Test
+fun readyCheckIn_exposesEnabledCheckInBridge() {
+    val state = AttendanceActionState.Ready(
+        intent = AttendanceActionIntent.CHECK_IN,
+        label = "Check-in di sini"
+    )
+
+    assertEquals("Check-in di sini", state.ctaLabel)
+    assertTrue(state.isCtaEnabled)
+    assertTrue(state.legacyIsCheckInMode)
+}
+
+@Test
+fun readyCheckOut_exposesEnabledCheckOutBridge() {
+    val state = AttendanceActionState.Ready(
+        intent = AttendanceActionIntent.CHECK_OUT,
+        label = "Check-out di sini"
+    )
+
+    assertEquals("Check-out di sini", state.ctaLabel)
+    assertTrue(state.isCtaEnabled)
+    assertFalse(state.legacyIsCheckInMode)
+}
+
+@Test
+fun blocked_exposesDisabledBridgeAndReasonCopy() {
+    val state = AttendanceActionState.Blocked(
+        reason = AttendanceBlockReason.WFH_LOCATION_MISSING,
+        title = "Lokasi WFH belum tersedia",
+        message = "Lengkapi lokasi WFH sebelum absen dari rumah."
+    )
+
+    assertEquals("Lokasi WFH belum tersedia", state.ctaLabel)
+    assertFalse(state.isCtaEnabled)
+    assertTrue(state.legacyIsCheckInMode)
+}
+
+@Test
+fun completed_exposesHonestDisabledCompletedCopy() {
+    val state = AttendanceActionState.Completed
+
+    assertEquals("Anda sudah absen hari ini", state.ctaLabel)
+    assertFalse(state.isCtaEnabled)
+    assertFalse(state.legacyIsCheckInMode)
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+./gradlew app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.AttendanceActionStateTest"
+```
+
+Expected: FAIL because `AttendanceActionState` does not exist.
+
+- [ ] **Step 3: Implement minimal action model and bridge helpers**
+
+Create `AttendanceActionState.kt` with required enums/sealed interface and helper properties.
+
+- [ ] **Step 4: Add `actionState` to `AttendanceScreenState`**
+
+Add:
+
+```kotlin
+val actionState: AttendanceActionState = AttendanceActionState.Loading
+```
+
+Do not remove bridge fields yet.
+
+- [ ] **Step 5: Run action-state tests to verify GREEN**
+
+Run same targeted test command. Expected: PASS.
+
+## Task 2: Resolve action state from TodayStatus and work-mode eligibility
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt`
+- Create/Modify: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModelActionStateTest.kt`
+
+**Interfaces:**
+- Produces private resolver: `resolveAttendanceActionState(todayStatus: TodayStatus): AttendanceActionState`
+- Produces private update helper: `applyActionState(actionState: AttendanceActionState)`
+
+- [ ] **Step 1: Write failing tests for resolver semantics if current test construction supports ViewModel dependencies**
+
+Cover at minimum:
+- `checkedInAt == null` -> `Ready(CHECK_IN)`
+- `checkedInAt != null && canCheckOut` -> `Ready(CHECK_OUT)`
+- otherwise -> `Completed`
+- WFH mode without `wfhLocation` -> `Blocked(WFH_LOCATION_MISSING)`
+- WFA mode without selected/approved booking path -> `Blocked(WFA_BOOKING_REQUIRED)` or `TARGET_LOCATION_UNAVAILABLE` depending current data availability
+
+If direct ViewModel construction is too coupled, test public bridge behavior through a small internal resolver object extracted into `AttendanceActionResolver.kt` in the same package.
+
+- [ ] **Step 2: Run resolver tests to verify RED**
+
+Run targeted tests. Expected: FAIL because resolver/action state is not wired.
+
+- [ ] **Step 3: Replace `calculateDynamicButtonState()` with explicit resolver**
+
+In `fetchTodayStatus()`, compute:
+
+```kotlin
+val actionState = resolveAttendanceActionState(todayStatus)
+```
+
+Then write state with:
+
+```kotlin
+actionState = actionState,
+buttonText = actionState.ctaLabel,
+isButtonEnabled = actionState.isCtaEnabled,
+isCheckInMode = actionState.legacyIsCheckInMode
+```
+
+- [ ] **Step 4: Ensure failure loading branches set honest action state**
+
+For today-status load failures, set:
+
+```kotlin
+actionState = AttendanceActionState.RetryableFailure(
+    intent = null,
+    title = "Status absensi gagal dimuat",
+    message = errorMessage
+)
+```
+
+- [ ] **Step 5: Run targeted resolver tests to verify GREEN**
+
+Expected: PASS.
+
+## Task 3: Remove buttonText business-action inference and add VerifyingFace transition
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt`
+- Modify/Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModelActionStateTest.kt`
+
+**Interfaces:**
+- Consumes: `AttendanceActionState.Ready(intent, label)`
+- Produces: `AttendanceActionState.VerifyingFace(intent)` before navigation
+- Produces: `NavigationTarget.FaceScanner(intent: AttendanceActionIntent)` or continues boolean bridge from explicit intent only
+
+- [ ] **Step 1: Write failing test that button label cannot determine action**
+
+Test shape:
+
+```kotlin
+@Test
+fun attendanceButtonClick_usesReadyIntentNotButtonText() {
+    // Given Ready(CHECK_OUT) but buttonText contains Check-in-like stale copy
+    // When onAttendanceButtonClicked()
+    // Then navigation target is checkout and actionState is VerifyingFace(CHECK_OUT)
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Expected: FAIL because current code uses `buttonText.contains("Check-in")`.
+
+- [ ] **Step 3: Update `onAttendanceButtonClicked()`**
+
+Use only:
+
+```kotlin
+val readyState = _uiState.value.actionState as? AttendanceActionState.Ready ?: return
+val intent = readyState.intent
+```
+
+Set:
+
+```kotlin
+actionState = AttendanceActionState.VerifyingFace(intent)
+navigationTarget = NavigationTarget.FaceScanner(intent)
+```
+
+If keeping boolean navigation bridge, derive `isCheckIn = intent == AttendanceActionIntent.CHECK_IN`.
+
+- [ ] **Step 4: Run grep evidence**
+
+Run:
+
+```bash
+rg 'buttonText\.contains\("Check-in"|contains\("Check-in"' app/src/main/java app/src/test/java
+```
+
+Expected: no production business logic match.
+
+- [ ] **Step 5: Run targeted tests to verify GREEN**
+
+Expected: PASS.
+
+## Task 4: Add Submitting, Success, and RetryableFailure backend transitions
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt`
+- Modify/Create: `app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModelActionStateTest.kt`
+
+**Interfaces:**
+- Consumes: `FaceVerificationResult`
+- Produces: `Submitting(intent, message)` after face success and before backend use case
+- Produces: `Success(intent, message)` only after backend success
+- Produces: `RetryableFailure(intent, title, message)` for backend failure or face failure/timeout
+
+- [ ] **Step 1: Write failing tests for face/backend transition semantics**
+
+Cover:
+- `FaceVerificationResult.FAILED` does not call backend and becomes `RetryableFailure` or returns to Ready with visible error.
+- `FaceVerificationResult.TIMEOUT` does not call backend and becomes `RetryableFailure` or returns to Ready with visible error.
+- `FaceVerificationResult.CANCELLED` does not call backend and returns to previous Ready action.
+- `FaceVerificationResult.SUCCESS` first sets `Submitting(intent)` before backend result.
+- backend success sets `Success(intent)`.
+- backend failure sets `RetryableFailure(intent)`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Expected: FAIL because current code jumps from face success directly to use case/dialog.
+
+- [ ] **Step 3: Update `onFaceVerificationResult()`**
+
+Use current action state to recover intent from `VerifyingFace(intent)`.
+
+Rules:
+- SUCCESS -> `Submitting(intent)` -> `proceedWithCheckIn(intent)` or `proceedWithCheckOut(intent)`.
+- FAILED/TIMEOUT -> `RetryableFailure(intent, title, message)` and no backend call.
+- CANCELLED -> return to `Ready(intent, label)` and no backend call.
+
+- [ ] **Step 4: Update backend methods**
+
+In check-in/check-out success callbacks:
+
+```kotlin
+actionState = AttendanceActionState.Success(intent, message)
+activeDialog = DialogState.Success(message)
+```
+
+In failure callbacks:
+
+```kotlin
+actionState = AttendanceActionState.RetryableFailure(intent, "Absensi gagal", errorMessage)
+activeDialog = DialogState.Error(errorMessage)
+```
+
+- [ ] **Step 5: Run targeted transition tests to verify GREEN**
+
+Expected: PASS.
+
+## Task 5: Render blocked/submitting states with existing components
+
+**Files:**
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceActionButtons.kt`
+- Modify: `app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt`
+
+**Interfaces:**
+- Consumes: `AttendanceActionState`
+- Produces: inline alert for `Blocked`, `VerifyingFace`, `Submitting`, and optionally recoverable `RetryableFailure`
+- Produces: status dialog for terminal `Success` and backend `RetryableFailure`
+
+- [ ] **Step 1: Add actionState parameter to bottom sheet**
+
+Pass `uiState.actionState` from `AttendanceScreen` to `AttendanceBottomSheetContent`.
+
+- [ ] **Step 2: Render InlineAlert for Blocked**
+
+Use:
+
+```kotlin
+InfiniteTrackInlineAlert(
+    status = StatusStates.Warning,
+    title = state.title,
+    message = state.message
+)
+```
+
+Use `StatusStates.Error` for hard server/unknown blockers.
+
+- [ ] **Step 3: Render submitting/verifying guidance**
+
+Use `InfiniteTrackInlineAlert(StatusStates.Info, ...)` plus disabled CTA. Keep `LoadingAnimation` overlay for global loading/submitting if appropriate.
+
+- [ ] **Step 4: Keep StatefulButton for CTA**
+
+Ready states use enabled `StatefulButton` label:
+- `Check-in di sini`
+- `Check-out di sini`
+
+Completed uses disabled button:
+- `Anda sudah absen hari ini`
+
+- [ ] **Step 5: Run Compose compile via assembleDebug later**
+
+Compile will validate UI signatures.
+
+## Task 6: Final verification and evidence
+
+**Files:**
+- All modified files above
+
+- [ ] **Step 1: Run code evidence grep**
+
+```bash
+rg 'buttonText\.contains\("Check-in"|contains\("Check-in"' app/src/main/java app/src/test/java
+```
+
+Expected: no production business-action inference remains.
+
+- [ ] **Step 2: Run unit tests**
+
+```bash
+./gradlew app:testDebugUnitTest
+```
+
+Expected: PASS, or report failures exactly.
+
+- [ ] **Step 3: Run required build**
+
+```bash
+./gradlew app:assembleDebug
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint if time/environment permits**
+
+```bash
+./gradlew app:lint
+```
+
+Expected: PASS, or report failures exactly.
+
+- [ ] **Step 5: Runtime evidence**
+
+Attempt emulator/device smoke for:
+- Ready Check-in state
+- Ready Checkout state
+- Blocked inline alert
+- VerifyingFace transition/scanner navigation
+- Submitting state after face success
+- Check-in success dialog
+- Check-out success dialog
+- Backend failure/retryable failure
+
+If emulator/backend cannot run, report each as `Needs Verification`.
+
+## Self-Review
+
+- Spec coverage: This plan covers explicit models, state field, resolver replacement, removal of button text inference, face/submitting/backend transitions, blocked inline alert rendering, and verification.
+- Placeholder scan: No implementation task uses TBD/TODO as a deliverable.
+- Type consistency: Model names match requested INF-239 names and current package paths.


### PR DESCRIPTION
## Summary

- Implement explicit AttendanceActionState state machine for attendance CTA behavior.
- Add AttendanceActionIntent and AttendanceBlockReason for CHECK_IN / CHECK_OUT flow.
- Add AttendanceActionResolver and unit coverage for Ready, Blocked, Completed, and bridge semantics.
- Remove business action inference from button text; no more buttonText.contains("Check-in") business logic.
- Separate Ready, Blocked, VerifyingFace, Submitting, Success, RetryableFailure, and Completed states.
- Reuse existing InfiniteTrackInlineAlert, InfiniteTrackStatusDialog, LoadingAnimation, StatefulButton, and StatusStates.
- Keep backend as final attendance success authority: face verification success only transitions to Submitting before backend submit.

## Verification

- PASS: `app:assembleDebug`
- PASS: `app:testDebugUnitTest --tests com.example.infinite_track.presentation.screen.attendance.AttendanceActionStateTest --tests com.example.infinite_track.presentation.screen.attendance.AttendanceActionResolverTest`
- PASS: `app:testDebugUnitTest`
- PASS: `app:lintDebug`
- PASS: `app:lint`
- PASS: static grep confirms no `buttonText.contains("Check-in")` / `calculateDynamicButtonState` remains.

Commands were run from the isolated worktree using PowerShell + `gradlew.bat --no-daemon --max-workers=1` because Git Bash Gradle daemon hit a Java loopback issue.

## Runtime evidence

- Emulator install + launch: PASS.
- Initial launch showed Android 16 KB compatibility system dialog, dismissed successfully.
- App navigated to Login after session verification failed.
- Attendance runtime states still need authenticated backend/session smoke:
  - Ready Check-in state
  - Ready Checkout state
  - Blocked inline alert
  - VerifyingFace transition / scanner navigation
  - Submitting after face success
  - Check-in success dialog
  - Check-out success dialog
  - Backend failure / retryable failure

## Docs / ADR note

- Added implementation plan under `docs/superpowers/plans/`.
- No backend contract change.
- No full Attendance visual redesign.
- Architecture note for reviewers: AttendanceActionState is now the source of truth for attendance CTA behavior; buttonText is now bridge copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attendance screen now uses a more consistent, state-driven flow for check-in and check-out, including face-scanner navigation tied to the intended action.
  * Inline alerts and status guidance were improved, showing clearer messages (e.g., verifying, submitting, completed) directly within the bottom sheet.

* **Bug Fixes**
  * Better handling for missing locations, missing/invalid booking info, and permission/eligibility issues, with more actionable retry guidance.
  * More reliable transitions after errors or cancellations so users can recover without restarting the flow.

* **Tests**
  * Added unit test coverage for the attendance action decisioning and UI state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->