### PR TITLE
fix: Reuse global attendance timeline on home

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
@@ -1,0 +1,132 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.data.mapper.attendance.toReportDateLabel
+import com.example.infinite_track.data.mapper.attendance.toReportStatus
+import com.example.infinite_track.data.mapper.attendance.toReportTimeRangeLabel
+import com.example.infinite_track.data.mapper.attendance.toReportWorkHourLabel
+import com.example.infinite_track.data.mapper.attendance.toReportWorkModeLabel
+import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusKind
+import com.example.infinite_track.presentation.components.button.SeeAllButton
+import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
+import com.example.infinite_track.presentation.components.loading.LoadingAnimation
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.utils.UiState
+
+@Composable
+fun InfiniteAttendanceTimelineSection(
+    attendanceState: UiState<List<AttendanceRecord>>,
+    onSeeAllClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String = "Attendance TimeLine",
+    maxItems: Int = 3
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SeeAllButton(
+            label = title,
+            onClickButton = onSeeAllClick
+        )
+
+        when (attendanceState) {
+            is UiState.Loading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingAnimation()
+                }
+            }
+
+            is UiState.Success -> {
+                if (attendanceState.data.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            EmptyListAnimation(modifier = Modifier.size(150.dp))
+                            Text(
+                                text = "No attendance records found",
+                                style = headline4,
+                            )
+                        }
+                    }
+                } else {
+                    val timelineItems = attendanceState.data.take(maxItems)
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        timelineItems.forEachIndexed { index, attendance ->
+                            val status = attendance.toReportStatus()
+                            InfiniteAttendanceTimelineCard(
+                                dateLabel = attendance.toReportDateLabel(),
+                                modeLabel = attendance.toReportWorkModeLabel(),
+                                timeRange = attendance.toReportTimeRangeLabel(),
+                                statusLabel = status.label,
+                                statusVariant = status.kind.toTimelineVariant(),
+                                connectorPosition = connectorPositionFor(index, timelineItems.size),
+                                workHourLabel = attendance.toReportWorkHourLabel(),
+                                locationLabel = attendance.location
+                            )
+                        }
+                    }
+                }
+            }
+
+            is UiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        EmptyListAnimation(modifier = Modifier.size(150.dp))
+                        Text(
+                            text = attendanceState.errorMessage,
+                            style = headline4,
+                        )
+                    }
+                }
+            }
+
+            is UiState.Idle -> Unit
+        }
+    }
+}
+
+private fun connectorPositionFor(index: Int, totalCount: Int): TimelineConnectorPosition = when {
+    totalCount <= 1 -> TimelineConnectorPosition.None
+    index == 0 -> TimelineConnectorPosition.First
+    index == totalCount - 1 -> TimelineConnectorPosition.Last
+    else -> TimelineConnectorPosition.Middle
+}
+
+private fun AttendanceReportStatusKind.toTimelineVariant(): InfiniteStatusVariant = when (this) {
+    AttendanceReportStatusKind.ActiveSession -> InfiniteStatusVariant.Active
+    AttendanceReportStatusKind.OnTime -> InfiniteStatusVariant.OnTime
+    AttendanceReportStatusKind.Late -> InfiniteStatusVariant.Late
+    AttendanceReportStatusKind.Alpha -> InfiniteStatusVariant.Alpha
+    AttendanceReportStatusKind.Unknown -> InfiniteStatusVariant.Unknown
+    AttendanceReportStatusKind.Neutral -> InfiniteStatusVariant.Neutral
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -1,7 +1,6 @@
 package com.example.infinite_track.presentation.screen.home.content
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,23 +8,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.R
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.presentation.components.button.SeeAllButton
-import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.components.tittle.Location
 import com.example.infinite_track.presentation.components.tittle.nameCards
-import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceTimelineSection
 import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
 import com.example.infinite_track.utils.UiState
 import com.example.infinite_track.utils.getCurrentDate
@@ -96,71 +88,11 @@ fun EmployeeAndManagerComponent(
                         LoadingAnimation()
                     }
                 } else {
-                    SeeAllButton(
-                        label = stringResource(R.string.attendance_history),
-                        onClickButton = navigateListMyAttendance
+                    InfiniteAttendanceTimelineSection(
+                        attendanceState = attendanceState,
+                        maxItems = 5,
+                        onSeeAllClick = navigateListMyAttendance
                     )
-
-                    Spacer(modifier.height(12.dp))
-
-                    when (attendanceState) {
-                        is UiState.Success -> {
-                            if (attendanceState.data.isEmpty()) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                        Text(
-                                            text = "No attendance records found",
-                                            style = headline4,
-                                        )
-                                    }
-                                }
-                            } else {
-                                val attendanceItems = attendanceState.data.take(5)
-                                Column(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    attendanceItems.forEach { attendance ->
-                                        AttendanceHistoryC(record = attendance)
-                                    }
-                                }
-                            }
-                        }
-
-                        is UiState.Error -> {
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                    Text(
-                                        text = attendanceState.errorMessage,
-                                        style = headline4,
-                                    )
-                                }
-                            }
-                        }
-
-                        is UiState.Loading -> {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 24.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                LoadingAnimation()
-                            }
-                        }
-
-                        is UiState.Idle -> Unit
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -1,6 +1,5 @@
 package com.example.infinite_track.presentation.screen.home.content
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,23 +7,14 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.R
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
 import com.example.infinite_track.domain.model.auth.UserModel
-import com.example.infinite_track.presentation.components.button.SeeAllButton
-import com.example.infinite_track.presentation.components.cards.AttendanceHistoryC
-import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
-import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.components.tittle.Location
 import com.example.infinite_track.presentation.components.tittle.nameCards
-import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceTimelineSection
 import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
 import com.example.infinite_track.utils.UiState
 import com.example.infinite_track.utils.getCurrentDate
@@ -73,73 +63,11 @@ fun InternshipContent(
 
             Spacer(modifier = Modifier.height(14.dp))
 
-            SeeAllButton(
-                label = stringResource(R.string.attendance_history),
-                onClickButton = navigateToListMyAttendance
+            InfiniteAttendanceTimelineSection(
+                attendanceState = attendanceState,
+                maxItems = 3,
+                onSeeAllClick = navigateToListMyAttendance
             )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            when (attendanceState) {
-                is UiState.Loading -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        LoadingAnimation()
-                    }
-                }
-
-                is UiState.Success -> {
-                    if (attendanceState.data.isEmpty()) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 24.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                EmptyListAnimation(modifier = Modifier.size(150.dp))
-                                Text(
-                                    text = "No attendance records found",
-                                    style = headline4,
-                                )
-                            }
-                        }
-                    } else {
-                        val attendanceItems = attendanceState.data.take(3)
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            attendanceItems.forEach { attendance ->
-                                AttendanceHistoryC(record = attendance)
-                            }
-                        }
-                    }
-                }
-
-                is UiState.Error -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            EmptyListAnimation(modifier = Modifier.size(150.dp))
-                            Text(
-                                text = attendanceState.errorMessage,
-                                style = headline4,
-                            )
-                        }
-                    }
-                }
-
-                is UiState.Idle -> Unit
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the local Attendance History content on Home (all roles) with a reusable global Attendance TimeLine section component.

### What changed

- Adds reusable `InfiniteAttendanceTimelineSection` under `presentation/design/components/data/`.
- Reuses existing global building blocks instead of designing a separate local Home-only timeline UI:
  - `InfiniteAttendanceTimelineCard`
  - attendance report mappers (`toReportDateLabel`, `toReportWorkModeLabel`, `toReportTimeRangeLabel`, `toReportStatus`, `toReportWorkHourLabel`)
  - `SeeAllButton`
  - `LoadingAnimation`
  - `EmptyListAnimation`
- Updates Home content for Internship and Employee/Management to call the new global section component.
- Replaces the old local `AttendanceHistoryC`-based Home rendering with the global Attendance TimeLine content.

### Scope constraints kept

- No backend changes.
- No auth/session changes.
- No attendance business-logic changes.
- Home still shows a limited number of items per role:
  - Internship: 3
  - Employee/Management: 5
- `See More` behavior is preserved.

## Verification

- `git diff --check`: passed locally.
- `./gradlew app:assembleDebug`: **Needs Verification** — local Gradle bootstrap still fails before Kotlin compile due the existing environment loopback/JDK selector issue:

```text
java.io.IOException: Unable to establish loopback connection
```

## Runtime verification needed

- Open Home as Internship.
- Confirm Attendance TimeLine section appears and uses global timeline styling.
- Open Home as Employee/Management.
- Confirm Attendance TimeLine section appears and uses global timeline styling.
- Confirm `See More` still navigates correctly.
- Confirm loading / error / empty states remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable attendance timeline section with a “See all” action and support for loading, empty, success, and error states.
  * Attendance items now display in a timeline-style list with status, time, location, and work-hour details.
* **Refactor**
  * Updated home and internship screens to use the new shared timeline component instead of rendering the attendance preview separately.
  * Attendance previews now consistently limit the number of visible items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->