### PR TITLE
INF-237: harden Layer 4 face verification flow

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/components/cameras/FaceBoundingBox.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/cameras/FaceBoundingBox.kt
@@ -124,6 +124,7 @@ fun FaceBoundingBox(
         LivenessState.IDLE -> vibrantBlue
         LivenessState.DETECTING_FACE -> vibrantBlue
         LivenessState.WAITING_FOR_LIVENESS -> vibrantYellow
+        LivenessState.LOW_LIGHT -> vibrantYellow
         LivenessState.LIVENESS_DETECTED -> vibrantGreen // Langsung hijau saat liveness terdeteksi
         LivenessState.VERIFYING_FACE -> vibrantOrange
         LivenessState.SUCCESS -> vibrantGreen
@@ -144,7 +145,8 @@ fun FaceBoundingBox(
                 vibrantRed.copy(alpha = 0.7f)
             }
 
-            LivenessState.WAITING_FOR_LIVENESS -> {
+            LivenessState.WAITING_FOR_LIVENESS,
+            LivenessState.LOW_LIGHT -> {
                 vibrantYellow.copy(alpha = 0.8f)
             }
 
@@ -155,7 +157,8 @@ fun FaceBoundingBox(
         animationSpec = infiniteRepeatable(
             animation = tween(
                 durationMillis = when (livenessState) {
-                    LivenessState.WAITING_FOR_LIVENESS -> 800 // Faster pulse for waiting
+                    LivenessState.WAITING_FOR_LIVENESS,
+                    LivenessState.LOW_LIGHT -> 800 // Faster pulse for waiting/guidance
                     LivenessState.LIVENESS_DETECTED -> 400 // Very fast for success feedback
                     else -> 1500
                 },

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceLightingQuality.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceLightingQuality.kt
@@ -1,0 +1,46 @@
+package com.example.infinite_track.presentation.screen.attendance.face
+
+internal enum class LightingQuality {
+    ACCEPTABLE,
+    LOW_LIGHT
+}
+
+internal object FaceLightingQuality {
+    private const val MIN_AVERAGE_LUMINANCE = 55.0
+    private const val MIN_BRIGHT_PIXEL_RATIO = 0.12
+    private const val BRIGHT_PIXEL_LUMINANCE = 72.0
+
+    fun evaluate(pixels: IntArray): LightingQuality {
+        if (pixels.isEmpty()) return LightingQuality.ACCEPTABLE
+
+        var totalLuminance = 0.0
+        var brightPixels = 0
+
+        pixels.forEach { color ->
+            val luminance = color.luminance()
+            totalLuminance += luminance
+            if (luminance >= BRIGHT_PIXEL_LUMINANCE) {
+                brightPixels += 1
+            }
+        }
+
+        val averageLuminance = totalLuminance / pixels.size
+        val brightPixelRatio = brightPixels.toDouble() / pixels.size
+
+        return if (
+            averageLuminance < MIN_AVERAGE_LUMINANCE &&
+            brightPixelRatio < MIN_BRIGHT_PIXEL_RATIO
+        ) {
+            LightingQuality.LOW_LIGHT
+        } else {
+            LightingQuality.ACCEPTABLE
+        }
+    }
+
+    private fun Int.luminance(): Double {
+        val red = this shr 16 and 0xFF
+        val green = this shr 8 and 0xFF
+        val blue = this and 0xFF
+        return 0.299 * red + 0.587 * green + 0.114 * blue
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerScreen.kt
@@ -102,6 +102,18 @@ fun FaceScannerScreen(
     // Camera executor
     val cameraExecutor = remember { Executors.newSingleThreadExecutor() }
 
+    var hasPublishedResult by remember { mutableStateOf(false) }
+
+    fun publishResultOnce(result: FaceVerificationResult) {
+        if (hasPublishedResult) return
+        hasPublishedResult = true
+        navController.finishFaceScanner(result)
+    }
+
+    fun publishExitStateOnce(state: LivenessState) {
+        publishResultOnce(FaceVerificationResult.fromScannerExitState(state))
+    }
+
     // KUNCI PERBAIKAN: Reset scanner setiap kali screen muncul
     // Ini akan memastikan ViewModel selalu dalam state fresh
     LaunchedEffect(Unit) {
@@ -111,14 +123,14 @@ fun FaceScannerScreen(
     }
 
     BackHandler {
-        navController.finishFaceScanner(uiState.livenessState)
+        publishExitStateOnce(uiState.livenessState)
     }
 
     // Handle navigation based on verification result
     LaunchedEffect(uiState.livenessState) {
         when (uiState.livenessState) {
             LivenessState.SUCCESS -> {
-                navController.finishFaceScanner(FaceVerificationResult.SUCCESS)
+                publishResultOnce(FaceVerificationResult.SUCCESS)
             }
 
             // FAILURE and TIMEOUT stay on screen to allow explicit retry or close
@@ -154,7 +166,7 @@ fun FaceScannerScreen(
                         viewModel.resetScanner()
                     },
                     onCloseClick = {
-                        navController.finishFaceScanner(uiState.livenessState)
+                        publishExitStateOnce(uiState.livenessState)
                     }
                 )
             }
@@ -166,7 +178,7 @@ fun FaceScannerScreen(
                         cameraPermissionState.launchPermissionRequest()
                     },
                     onCloseClick = {
-                        navController.finishFaceScanner(uiState.livenessState)
+                        publishExitStateOnce(uiState.livenessState)
                     }
                 )
             }
@@ -178,7 +190,7 @@ fun FaceScannerScreen(
                         cameraPermissionState.launchPermissionRequest()
                     },
                     onCloseClick = {
-                        navController.finishFaceScanner(uiState.livenessState)
+                        publishExitStateOnce(uiState.livenessState)
                     }
                 )
             }
@@ -417,13 +429,15 @@ private fun InstructionSection(
                 }
 
                 LivenessState.SUCCESS -> Icons.Default.SentimentSatisfied
+                LivenessState.LOW_LIGHT -> Icons.Default.Visibility
                 else -> Icons.Default.Visibility
             }
 
             val iconColor = when (uiState.livenessState) {
                 LivenessState.SUCCESS -> Color(0xFF00FFC2)
                 LivenessState.FAILURE, LivenessState.TIMEOUT -> Color(0xFFFF3B30)
-                LivenessState.WAITING_FOR_LIVENESS -> Color(0xFFFFD60A)
+                LivenessState.WAITING_FOR_LIVENESS,
+                LivenessState.LOW_LIGHT -> Color(0xFFFFD60A)
                 else -> Color(0xFF00A3FF)
             }
 
@@ -469,7 +483,11 @@ private fun InstructionSection(
                 Text(
                     text = errorMessage,
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFFFF3B30),
+                    color = if (uiState.livenessState == LivenessState.LOW_LIGHT) {
+                        Color(0xFFFFD60A)
+                    } else {
+                        Color(0xFFFF3B30)
+                    },
                     textAlign = TextAlign.Center
                 )
             }
@@ -731,6 +749,25 @@ fun PreviewFaceScannerCheckOutWaiting() {
                 showCountdown = true,
                 progress = 0.6f,
                 timeRemaining = 4
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Low Light State")
+@Composable
+fun PreviewFaceScannerLowLight() {
+    MaterialTheme {
+        FaceScannerScreenPreview(
+            action = "checkin",
+            state = FaceScannerState(
+                livenessState = LivenessState.LOW_LIGHT,
+                instructionText = "Pencahayaan kurang. Pindah ke area lebih terang sebelum verifikasi dilanjutkan.",
+                errorMessage = "Wajah sudah terdeteksi, tetapi pencahayaan belum cukup untuk verifikasi.",
+                isProcessing = false,
+                showCountdown = true,
+                progress = 0.35f,
+                timeRemaining = 13
             )
         )
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/face/FaceScannerViewModel.kt
@@ -33,6 +33,7 @@ enum class LivenessState {
     IDLE,
     DETECTING_FACE,
     WAITING_FOR_LIVENESS,
+    LOW_LIGHT,
     LIVENESS_DETECTED,
     VERIFYING_FACE,
     SUCCESS,
@@ -139,8 +140,13 @@ class FaceScannerViewModel @Inject constructor(
         val currentState = _uiState.value.livenessState
         val isProcessing = _uiState.value.isProcessing
 
-        // Hanya blokir jika benar-benar sedang processing atau sudah final success
-        if (isProcessing || currentState == LivenessState.SUCCESS) {
+        // Hanya blokir jika sedang processing atau scanner sudah berada di state final
+        if (
+            isProcessing ||
+            currentState == LivenessState.SUCCESS ||
+            currentState == LivenessState.FAILURE ||
+            currentState == LivenessState.TIMEOUT
+        ) {
             imageProxy.close()
             return
         }
@@ -150,7 +156,7 @@ class FaceScannerViewModel @Inject constructor(
         // Panggil FaceDetectorHelper untuk mendeteksi wajah
         faceDetectorHelper.detect(imageProxy) { result ->
             result.onSuccess { face ->
-                handleFaceDetected(face, imageBitmap.width, imageBitmap.height)
+                handleFaceDetected(face, imageBitmap)
             }.onFailure { exception ->
                 handleFaceDetectionError(exception.message ?: "Error mendeteksi wajah")
             }
@@ -160,8 +166,10 @@ class FaceScannerViewModel @Inject constructor(
     /**
      * Handle ketika wajah berhasil terdeteksi
      */
-    private fun handleFaceDetected(face: Face, imageWidth: Int, imageHeight: Int) {
+    private fun handleFaceDetected(face: Face, imageBitmap: Bitmap) {
         currentDetectedFace = face
+        val imageWidth = imageBitmap.width
+        val imageHeight = imageBitmap.height
 
         // Convert android.graphics.Rect to androidx.compose.ui.geometry.Rect
         val androidRect = face.boundingBox
@@ -185,9 +193,32 @@ class FaceScannerViewModel @Inject constructor(
         if (!faceDetectorHelper.isFaceWellPositioned(face, imageWidth, imageHeight)) {
             _uiState.value = _uiState.value.copy(
                 livenessState = LivenessState.DETECTING_FACE,
-                instructionText = "Posisikan wajah Anda lebih dekat dan di tengah frame"
+                instructionText = "Posisikan wajah Anda lebih dekat dan di tengah frame",
+                errorMessage = null
             )
             return
+        }
+
+        if (isLowLight(imageBitmap = imageBitmap, face = face)) {
+            livenessJob?.cancel()
+            _uiState.value = _uiState.value.copy(
+                livenessState = LivenessState.LOW_LIGHT,
+                instructionText = "Pencahayaan kurang. Pindah ke area lebih terang sebelum verifikasi dilanjutkan.",
+                errorMessage = "Wajah sudah terdeteksi, tetapi pencahayaan belum cukup untuk verifikasi.",
+                isProcessing = false
+            )
+            return
+        }
+
+        if (_uiState.value.livenessState == LivenessState.LOW_LIGHT) {
+            _uiState.value = _uiState.value.copy(
+                livenessState = LivenessState.WAITING_FOR_LIVENESS,
+                errorMessage = null,
+                instructionText = when (_uiState.value.currentChallenge) {
+                    LivenessChallenge.BLINK -> "Pencahayaan membaik. Sekarang kedipkan mata Anda"
+                    LivenessChallenge.SMILE -> "Pencahayaan membaik. Sekarang tersenyum"
+                }
+            )
         }
 
         // Wajah sudah di posisi yang baik, lanjut ke pengecekan liveness
@@ -211,6 +242,26 @@ class FaceScannerViewModel @Inject constructor(
             else -> {
                 // State lain tidak perlu di-handle di sini
             }
+        }
+    }
+
+    private fun isLowLight(imageBitmap: Bitmap, face: Face): Boolean {
+        if (imageBitmap.width <= 1 || imageBitmap.height <= 1) return false
+
+        val boundingBox = face.boundingBox
+        val left = boundingBox.left.coerceIn(0, imageBitmap.width - 1)
+        val top = boundingBox.top.coerceIn(0, imageBitmap.height - 1)
+        val right = boundingBox.right.coerceIn(left + 1, imageBitmap.width)
+        val bottom = boundingBox.bottom.coerceIn(top + 1, imageBitmap.height)
+        val width = right - left
+        val height = bottom - top
+        val pixels = IntArray(width * height)
+
+        return try {
+            imageBitmap.getPixels(pixels, 0, width, left, top, width, height)
+            FaceLightingQuality.evaluate(pixels) == LightingQuality.LOW_LIGHT
+        } catch (exception: IllegalArgumentException) {
+            false
         }
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/FaceVerificationResultContractTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/FaceVerificationResultContractTest.kt
@@ -52,6 +52,10 @@ class FaceVerificationResultContractTest {
             FaceVerificationResult.CANCELLED,
             FaceVerificationResult.fromScannerExitState(LivenessState.VERIFYING_FACE)
         )
+        assertEquals(
+            FaceVerificationResult.CANCELLED,
+            FaceVerificationResult.fromScannerExitState(LivenessState.LOW_LIGHT)
+        )
     }
 
     @Test

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/face/FaceLightingQualityTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/face/FaceLightingQualityTest.kt
@@ -1,0 +1,43 @@
+package com.example.infinite_track.presentation.screen.attendance.face
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FaceLightingQualityTest {
+
+    @Test
+    fun evaluate_returnsLowLightForDarkFacePixels() {
+        val darkPixels = IntArray(100) { rgb(18, 18, 18) }
+
+        assertEquals(
+            LightingQuality.LOW_LIGHT,
+            FaceLightingQuality.evaluate(darkPixels)
+        )
+    }
+
+    @Test
+    fun evaluate_returnsAcceptableForBrightFacePixels() {
+        val brightPixels = IntArray(100) { rgb(140, 140, 140) }
+
+        assertEquals(
+            LightingQuality.ACCEPTABLE,
+            FaceLightingQuality.evaluate(brightPixels)
+        )
+    }
+
+    @Test
+    fun evaluate_returnsAcceptableWhenEnoughPixelsAreBright() {
+        val mixedPixels = IntArray(100) { index ->
+            if (index < 20) rgb(120, 120, 120) else rgb(25, 25, 25)
+        }
+
+        assertEquals(
+            LightingQuality.ACCEPTABLE,
+            FaceLightingQuality.evaluate(mixedPixels)
+        )
+    }
+
+    private fun rgb(red: Int, green: Int, blue: Int): Int {
+        return (red shl 16) or (green shl 8) or blue
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-layer4-face-verification-flow.md
+++ b/docs/superpowers/plans/2026-07-09-layer4-face-verification-flow.md
@@ -1,0 +1,66 @@
+# 2026-07-09 — Layer 4 Face Verification Flow
+
+## Scope
+
+Layer 4 Face Verification hardening for Android attendance flow:
+
+- scanner result handoff is guarded so a final result is published once from the scanner screen
+- final scanner result contract remains explicit: success, failed, timeout, cancelled
+- low-light is introduced as scanner runtime guidance, not as a final attendance result
+- low-light blocks liveness/matching until lighting improves
+- face verification success returns Attendance to submitting; backend check-in/check-out remains the final attendance authority
+
+## Contract notes
+
+`FaceVerificationResult.SUCCESS` is the only scanner result that permits attendance submission. It does not mean attendance succeeded. Attendance success is only shown after the backend check-in/check-out use case succeeds.
+
+`FaceVerificationResult.FAILED` and `FaceVerificationResult.TIMEOUT` stay retryable and do not submit attendance.
+
+`LOW_LIGHT` is intentionally kept inside `LivenessState`. If the user closes the scanner while low-light guidance is visible, the scanner exit maps to `FaceVerificationResult.CANCELLED`, not failed or timeout.
+
+## Runtime flow
+
+```text
+Attendance Ready
+→ VerifyingFace
+→ FaceScanner
+→ face detected and positioned
+→ lighting gate
+  - low light: guide user, no matching, no backend submit
+  - acceptable: continue liveness/matching
+→ scanner success
+→ Attendance Submitting
+→ backend check-in/check-out
+→ backend success/failure state
+```
+
+## Non-goals
+
+- no backend endpoint changes
+- no backend validation authority changes
+- no full Attendance screen redesign
+- no full FaceScanner redesign
+- no geofence architecture changes
+
+## Verification status
+
+Gradle verification passes when run through PowerShell with the project Java/Android SDK environment configured for this machine:
+
+```powershell
+$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
+$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
+$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
+$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
+Set-Location "C:\Users\Febriyadi\.claude\worktrees\android-layer4-face-verification-flow"
+```
+
+Commands run:
+
+```powershell
+.\gradlew.bat --no-daemon app:assembleDebug
+.\gradlew.bat --no-daemon app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.FaceVerificationResultContractTest" --tests "com.example.infinite_track.presentation.screen.attendance.face.FaceLightingQualityTest"
+.\gradlew.bat --no-daemon app:test
+.\gradlew.bat --no-daemon app:lint
+```
+
+Runtime/emulator evidence is still needed for scanner camera behavior, low-light guidance, success-to-submitting handoff, timeout, failure, and cancellation paths.


### PR DESCRIPTION
## Summary
- Harden FaceScanner result handoff so final scanner result is published once.
- Add low-light quality gate as scanner runtime guidance before liveness/matching.
- Keep final scanner contract explicit: success, failed, timeout, cancelled.
- Preserve AttendanceActionState handoff: face success returns to Submitting, then backend check-in/check-out remains final attendance authority.

## Scope / non-goals
- No backend endpoint changes.
- No backend validation authority changes.
- No full Attendance redesign.
- No full FaceScanner redesign.
- No geofence architecture rewrite.

## Verification
PowerShell environment used:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
Set-Location "C:\Users\Febriyadi\.claude\worktrees\android-layer4-face-verification-flow"
```

Passed:
- `.\gradlew.bat --no-daemon app:assembleDebug`
- `.\gradlew.bat --no-daemon app:testDebugUnitTest --tests "com.example.infinite_track.presentation.screen.attendance.FaceVerificationResultContractTest" --tests "com.example.infinite_track.presentation.screen.attendance.face.FaceLightingQualityTest"`
- `.\gradlew.bat --no-daemon app:test`
- `.\gradlew.bat --no-daemon app:lint`
- `git diff --check`

## Needs Verification
Runtime/emulator validation is still required on develop/human device:
- Ready Check-in / Ready Checkout states
- Blocked inline alert
- VerifyingFace transition / scanner open
- Low-light state
- Improved lighting -> verification continues
- Submitting after face success
- Backend check-in/check-out success/failure
- Timeout, failed match, and cancel paths

## Notes
- Low-light remains internal scanner runtime state and maps to cancelled if the scanner is closed; it is not a final attendance failure.
- Backend remains the only final authority for attendance success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)