### PR TITLE
INF-240: Harden attendance submit layer

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -164,6 +164,10 @@ class AttendanceRepositoryImpl @Inject constructor(
             } else {
                 Result.failure(Exception(response.message))
             }
+        } catch (e: HttpException) {
+            Log.e(TAG, "HTTP Error during check-out", e)
+            val errorMessage = extractErrorMessage(e)
+            Result.failure(Exception(errorMessage))
         } catch (e: Exception) {
             Log.e(TAG, "Error during check-out", e)
             Result.failure(e)

--- a/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/network/retrofit/ApiService.kt
@@ -54,9 +54,9 @@ interface ApiService {
         @Body request: AttendanceRequest
     ): AttendanceResponse
 
-    @POST("api/attendance/checkout/{id_attendance}")
+    @POST("api/attendance/checkout/{id}")
     suspend fun checkOut(
-        @Path("id_attendance") attendanceId: Int,
+        @Path("id") attendanceId: Int,
         @Body request: CheckOutRequestDto
     ): AttendanceResponse
 

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckOutUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckOutUseCase.kt
@@ -23,11 +23,13 @@ class CheckOutUseCase @Inject constructor(
      * No parameters needed - gets all required data from repository and current location
      * @return Result containing ActiveAttendanceSession on success or exception on failure
      */
-    suspend operator fun invoke(): Result<ActiveAttendanceSession> {
+    suspend operator fun invoke(attendanceId: Int? = null): Result<ActiveAttendanceSession> {
         return try {
-            // 1. Get active attendance ID
-            val attendanceId = attendanceRepository.getActiveAttendanceId()
-                ?: return Result.failure(Exception("No active attendance session found"))
+            // 1. Prefer the active attendance ID from caller status, refresh status if needed, then fallback to preference
+            val resolvedAttendanceId = attendanceId
+                ?: attendanceRepository.getTodayStatus(forceRefresh = true).getOrNull()?.activeAttendanceId
+                ?: attendanceRepository.getActiveAttendanceId()
+                ?: return Result.failure(Exception("No active attendance session found. Please refresh attendance status and try again."))
 
             // 2. Get current real-time GPS coordinates (strict, no DB fallback)
             val coordinatesResult = getCurrentCoordinatesUseCase(useRealTimeGPS = true)
@@ -42,7 +44,7 @@ class CheckOutUseCase @Inject constructor(
             // 3. Call repository to perform check-out
             // Backend will handle location validation
             val checkOutResult = attendanceRepository.checkOut(
-                attendanceId = attendanceId,
+                attendanceId = resolvedAttendanceId,
                 latitude = currentCoordinates.first,
                 longitude = currentCoordinates.second
             )

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -192,9 +193,7 @@ class AttendanceViewModel @Inject constructor(
                     isWfaModeActive = selectedMode == WorkMode.WFA,
                     uiState = UiState.Success(Unit)
                 )
-                _uiState.value = nextState.withActionState(
-                    AttendanceActionResolver.resolve(nextState)
-                )
+                _uiState.value = nextState.withResolvedActionStatePreservingInFlightSubmit()
 
                 resolveAndApplyTargetForMode(selectedMode)
 
@@ -265,10 +264,20 @@ class AttendanceViewModel @Inject constructor(
         )
     }
 
+    private fun AttendanceScreenState.withResolvedActionStatePreservingInFlightSubmit(): AttendanceScreenState {
+        val currentActionState = _uiState.value.actionState
+        val inFlightState = currentActionState as? AttendanceActionState.VerifyingFace
+            ?: currentActionState as? AttendanceActionState.Submitting
+
+        return if (inFlightState != null) {
+            withActionState(inFlightState)
+        } else {
+            withActionState(AttendanceActionResolver.resolve(this))
+        }
+    }
+
     private fun refreshResolvedActionState() {
-        _uiState.value = _uiState.value.withActionState(
-            AttendanceActionResolver.resolve(_uiState.value)
-        )
+        _uiState.value = _uiState.value.withResolvedActionStatePreservingInFlightSubmit()
     }
 
     /**
@@ -416,9 +425,7 @@ class AttendanceViewModel @Inject constructor(
                 workModeEligibility = eligibility,
                 isEvaluatingWorkMode = false
             )
-            _uiState.value = nextState.withActionState(
-                AttendanceActionResolver.resolve(nextState)
-            )
+            _uiState.value = nextState.withResolvedActionStatePreservingInFlightSubmit()
 
             target.location?.let { animateMapToTarget(it) }
         }
@@ -637,6 +644,11 @@ class AttendanceViewModel @Inject constructor(
     fun onFaceVerificationResult(result: FaceVerificationResult) {
         Log.d(TAG, "Face verification result: $result")
 
+        if (_uiState.value.actionState is AttendanceActionState.Submitting) {
+            Log.d(TAG, "Ignoring face verification result because attendance submit is already in flight")
+            return
+        }
+
         val intent = (_uiState.value.actionState as? AttendanceActionState.VerifyingFace)?.intent
             ?: _uiState.value.takeIf { it.isButtonEnabled }?.let { state ->
                 (state.actionState as? AttendanceActionState.Ready)?.intent
@@ -713,6 +725,12 @@ class AttendanceViewModel @Inject constructor(
             try {
                 Log.d(TAG, "Proceeding with check-in after face verification")
 
+                val initialSubmittingState = _uiState.value.actionState as? AttendanceActionState.Submitting
+                if (initialSubmittingState?.intent != intent) {
+                    Log.w(TAG, "Check-in submit blocked because action state is not Submitting($intent): ${_uiState.value.actionState}")
+                    return@launch
+                }
+
                 // Clear any previous error
                 _uiState.value = _uiState.value.copy(activeDialog = null)
 
@@ -753,27 +771,43 @@ class AttendanceViewModel @Inject constructor(
                     return@launch
                 }
 
-                // Get user info for the request
-                getLoggedInUserUseCase().collect { user ->
-                    if (user == null) {
-                        val message = "User information not available. Please try again."
-                        _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Error(message)
-                        ).withActionState(
-                            AttendanceActionState.RetryableFailure(
-                                intent = intent,
-                                title = "Check-in gagal",
-                                message = message
-                            )
+                // Get user info once for this mutation; long-running collection can replay submit.
+                val user = getLoggedInUserUseCase().firstOrNull()
+                if (user == null) {
+                    val message = "User information not available. Please try again."
+                    _uiState.value = _uiState.value.copy(
+                        activeDialog = DialogState.Error(message)
+                    ).withActionState(
+                        AttendanceActionState.RetryableFailure(
+                            intent = intent,
+                            title = "Check-in gagal",
+                            message = message
                         )
-                        return@collect
-                    }
+                    )
+                    return@launch
+                }
 
-                    val bookingId = if (selectedMode == WorkMode.WFA) {
-                        eligibility.approvedWfaBookingId ?: run {
-                            val scheduleDateIso = _uiState.value.todayStatus?.todayDate
-                            if (scheduleDateIso.isNullOrBlank()) {
-                                val message = "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
+                val bookingId = if (selectedMode == WorkMode.WFA) {
+                    eligibility.approvedWfaBookingId ?: run {
+                        val scheduleDateIso = _uiState.value.todayStatus?.todayDate
+                        if (scheduleDateIso.isNullOrBlank()) {
+                            val message = "Tanggal attendance hari ini tidak tersedia untuk memvalidasi booking WFA."
+                            _uiState.value = _uiState.value.copy(
+                                activeDialog = DialogState.Error(message)
+                            ).withActionState(
+                                AttendanceActionState.RetryableFailure(
+                                    intent = intent,
+                                    title = "Booking WFA belum disetujui",
+                                    message = message
+                                )
+                            )
+                            return@launch
+                        }
+
+                        resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
+                            .getOrElse { exception ->
+                                val message = exception.message
+                                    ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
                                 _uiState.value = _uiState.value.copy(
                                     activeDialog = DialogState.Error(message)
                                 ).withActionState(
@@ -783,81 +817,70 @@ class AttendanceViewModel @Inject constructor(
                                         message = message
                                     )
                                 )
-                                return@collect
+                                return@launch
                             }
-
-                            resolveTodayApprovedWfaBookingIdUseCase(scheduleDateIso)
-                                .getOrElse { exception ->
-                                    val message = exception.message
-                                        ?: "Booking WFA yang sudah disetujui untuk hari ini tidak ditemukan."
-                                    _uiState.value = _uiState.value.copy(
-                                        activeDialog = DialogState.Error(message)
-                                    ).withActionState(
-                                        AttendanceActionState.RetryableFailure(
-                                            intent = intent,
-                                            title = "Booking WFA belum disetujui",
-                                            message = message
-                                        )
-                                    )
-                                    return@collect
-                                }
-                        }
-                    } else {
-                        null
                     }
+                } else {
+                    null
+                }
 
-                    val attendanceRequest = try {
-                        AttendanceCheckInRequestFactory.create(
-                            workMode = selectedMode,
-                            bookingId = bookingId
+                val attendanceRequest = try {
+                    AttendanceCheckInRequestFactory.create(
+                        workMode = selectedMode,
+                        bookingId = bookingId
+                    )
+                } catch (exception: IllegalArgumentException) {
+                    val message = exception.message ?: "Payload check-in WFA tidak valid."
+                    _uiState.value = _uiState.value.copy(
+                        activeDialog = DialogState.Error(message)
+                    ).withActionState(
+                        AttendanceActionState.RetryableFailure(
+                            intent = intent,
+                            title = "Check-in gagal",
+                            message = message
                         )
-                    } catch (exception: IllegalArgumentException) {
-                        val message = exception.message ?: "Payload check-in WFA tidak valid."
-                        _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Error(message)
-                        ).withActionState(
-                            AttendanceActionState.RetryableFailure(
-                                intent = intent,
-                                title = "Check-in gagal",
-                                message = message
-                            )
+                    )
+                    return@launch
+                }
+
+                val submittingState = _uiState.value.actionState as? AttendanceActionState.Submitting
+                if (submittingState?.intent != intent) {
+                    Log.w(TAG, "Check-in submit blocked because action state is not Submitting($intent): ${_uiState.value.actionState}")
+                    return@launch
+                }
+
+                // Call CheckInUseCase with both request and target location
+                checkInUseCase(attendanceRequest, targetLocation).onSuccess { activeSession ->
+                    Log.d(TAG, "Check-in successful: $activeSession")
+
+                    // Refresh today's status from backend after mutation invalidates local cache.
+                    fetchTodayStatus(forceRefresh = true)
+
+                    val successMessage = "Check-in berhasil! Selamat bekerja hari ini."
+                    _uiState.value = _uiState.value.copy(
+                        activeDialog = DialogState.Success(successMessage)
+                    ).withActionState(
+                        AttendanceActionState.Success(
+                            intent = intent,
+                            message = successMessage
                         )
-                        return@collect
-                    }
+                    )
 
-                    // Call CheckInUseCase with both request and target location
-                    checkInUseCase(attendanceRequest, targetLocation).onSuccess { activeSession ->
-                        Log.d(TAG, "Check-in successful: $activeSession")
+                }.onFailure { exception ->
+                    Log.e(TAG, "Check-in failed: ${exception.message}", exception)
 
-                        // Refresh today's status from backend after mutation invalidates local cache.
-                        fetchTodayStatus(forceRefresh = true)
+                    // Extract the actual error message from the exception
+                    val errorMessage = exception.message ?: "Check-in gagal. Silakan coba lagi."
 
-                        val successMessage = "Check-in berhasil! Selamat bekerja hari ini."
-                        _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Success(successMessage)
-                        ).withActionState(
-                            AttendanceActionState.Success(
-                                intent = intent,
-                                message = successMessage
-                            )
+                    _uiState.value = _uiState.value.copy(
+                        activeDialog = DialogState.Error(errorMessage)
+                    ).withActionState(
+                        AttendanceActionState.RetryableFailure(
+                            intent = intent,
+                            title = "Check-in gagal",
+                            message = errorMessage
                         )
-
-                    }.onFailure { exception ->
-                        Log.e(TAG, "Check-in failed: ${exception.message}", exception)
-
-                        // Extract the actual error message from the exception
-                        val errorMessage = exception.message ?: "Check-in gagal. Silakan coba lagi."
-
-                        _uiState.value = _uiState.value.copy(
-                            activeDialog = DialogState.Error(errorMessage)
-                        ).withActionState(
-                            AttendanceActionState.RetryableFailure(
-                                intent = intent,
-                                title = "Check-in gagal",
-                                message = errorMessage
-                            )
-                        )
-                    }
+                    )
                 }
 
             } catch (e: Exception) {
@@ -885,11 +908,19 @@ class AttendanceViewModel @Inject constructor(
             try {
                 Log.d(TAG, "Proceeding with check-out after face verification")
 
+                val submittingState = _uiState.value.actionState as? AttendanceActionState.Submitting
+                if (submittingState?.intent != intent) {
+                    Log.w(TAG, "Check-out submit blocked because action state is not Submitting($intent): ${_uiState.value.actionState}")
+                    return@launch
+                }
+
                 // Clear any previous error
                 _uiState.value = _uiState.value.copy(activeDialog = null)
 
-                // Call CheckOutUseCase - it will handle everything internally
-                checkOutUseCase().onSuccess { activeSession ->
+                val attendanceId = _uiState.value.todayStatus?.activeAttendanceId
+
+                // Call CheckOutUseCase - it will refresh status if needed, get real-time GPS, and fallback to preference
+                checkOutUseCase(attendanceId).onSuccess { activeSession ->
                     Log.d(TAG, "Check-out successful: $activeSession")
 
                     // Refresh today's status from backend after mutation invalidates local cache.

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/AttendanceActionStateTest.kt
@@ -45,6 +45,18 @@ class AttendanceActionStateTest {
     }
 
     @Test
+    fun submitting_exposesLoadingCopyAndDisablesRetrySubmit() {
+        val state = AttendanceActionState.Submitting(
+            intent = AttendanceActionIntent.CHECK_IN,
+            message = "Mengirim check-in..."
+        )
+
+        assertEquals("Mengirim check-in...", state.ctaLabel)
+        assertFalse(state.isCtaEnabled)
+        assertTrue(state.legacyIsCheckInMode)
+    }
+
+    @Test
     fun completed_exposesHonestDisabledCompletedCopy() {
         val state = AttendanceActionState.Completed
 


### PR DESCRIPTION
## Summary
- Align Layer 5 attendance submit with the INF-239 AttendanceActionState contract.
- Keep face verification success as a gate to backend submit, not attendance success.
- Set and preserve AttendanceActionState.Submitting before check-in/checkout backend mutations.
- Block duplicate submit/duplicate face results while Submitting.
- Make check-in submit user/session read one-shot via firstOrNull instead of long-running collect.
- Prefer checkout activeAttendanceId from today status/caller, then fresh status, then preference fallback.
- Align checkout HttpException error-body extraction with check-in.
- Clarify Retrofit checkout placeholder to {id}; backend route semantics unchanged.

## Verification
- [x] powershell env + ./gradlew.bat --no-daemon app:assembleDebug
- [x] targeted attendance unit tests: AttendanceActionStateTest, AttendanceCheckInRequestFactoryTest, AttendanceActionResolverTest
- [x] powershell env + ./gradlew.bat --no-daemon app:test
- [x] powershell env + ./gradlew.bat --no-daemon --max-workers=2 app:lint
- [x] git diff --check

## Needs Verification
- Emulator/device runtime smoke remains pending because no adb device was attached during this session.
- Check-in success: face success -> Submitting -> backend success -> Success.
- Checkout success: face success -> Submitting -> backend success -> Success.
- Backend check-in failure -> RetryableFailure.
- Backend checkout failure -> RetryableFailure.
- Duplicate submit/duplicate face result does not create a second backend mutation.
- Geofence active monitoring timing remains post-backend-success.

## Docs / ADR
- No ADR added. PR documents the Layer 5 contract: attendance success only happens after backend check-in/check-out success; face verification success only transitions to Submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout error handling so network/API failures show clearer messages instead of generic errors.
  * Fixed checkout flow reliability by using the correct attendance ID and reducing duplicate submissions during in-progress actions.
  * Prevented repeated face-verification or submit actions from causing inconsistent attendance states.

* **Tests**
  * Added coverage for submitting states to ensure the UI shows loading behavior and disables retry while a submission is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->