### PR TITLE
INF-223: split geofence reminder and active monitoring

### DIFF
--- a/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/data/mapper/booking/BookingMapper.kt
@@ -56,7 +56,11 @@ fun BookingItem.toDomain(): BookingHistoryItem {
         createdAtRaw = rawCreatedAt,
         createdAt = formatDateTimeId(rawCreatedAt),
         processedAtRaw = processedAt,
-        processedAt = displayProcessedAt
+        processedAt = displayProcessedAt,
+        locationId = location?.locationId,
+        latitude = location?.latitude,
+        longitude = location?.longitude,
+        radiusMeters = location?.radius
     )
 }
 

--- a/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -218,9 +218,14 @@ class AttendanceRepositoryImpl @Inject constructor(
         when {
             activeAttendanceId != null && activeAttendanceId > 0 -> {
                 attendancePreference.saveActiveAttendanceId(activeAttendanceId)
+                attendancePreference.saveAttendanceSessionStateKey(status.attendanceSessionState?.key)
             }
             activeAttendanceId == null && status.attendanceSessionState?.key in CLEAR_EMPTY_ATTENDANCE_STATES -> {
                 attendancePreference.clearActiveAttendanceId()
+                attendancePreference.saveAttendanceSessionStateKey(status.attendanceSessionState?.key)
+            }
+            else -> {
+                attendancePreference.saveAttendanceSessionStateKey(status.attendanceSessionState?.key)
             }
         }
     }

--- a/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRuntimeCleanerImpl.kt
+++ b/app/src/main/java/com/example/infinite_track/data/repository/auth/AuthRuntimeCleanerImpl.kt
@@ -33,8 +33,8 @@ class AuthRuntimeCleanerImpl @Inject constructor(
         runBestEffort("attendancePreference.clearAttendanceRuntimeState", failures) {
             attendancePreference.clearAttendanceRuntimeState()
         }
-        runBestEffort("geofenceManager.removeAllGeofencesAwait", failures) {
-            geofenceManager.removeAllGeofencesAwait()
+        runBestEffort("geofenceManager.removeAllGeofencesForLogoutOnlyAwait", failures) {
+            geofenceManager.removeAllGeofencesForLogoutOnlyAwait()
         }
 
         if (failures.isNotEmpty()) {

--- a/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreference.kt
+++ b/app/src/main/java/com/example/infinite_track/data/soucre/local/preferences/AttendancePreference.kt
@@ -30,11 +30,13 @@ class AttendancePreference internal constructor(
 	companion object {
 		private val ACTIVE_ATTENDANCE_ID_KEY = intPreferencesKey("active_attendance_id")
 		private val IS_INSIDE_GEOFENCE_KEY = booleanPreferencesKey("is_inside_geofence")
+		private val ATTENDANCE_SESSION_STATE_KEY = stringPreferencesKey("attendance_session_state_key")
 		private val LAST_GEOFENCE_REQUEST_ID_KEY = stringPreferencesKey("last_geofence_request_id")
 		private val LAST_GEOFENCE_LAT_KEY = floatPreferencesKey("last_geofence_lat")
 		private val LAST_GEOFENCE_LNG_KEY = floatPreferencesKey("last_geofence_lng")
 		private val LAST_GEOFENCE_RADIUS_KEY = floatPreferencesKey("last_geofence_radius")
 		private val REMINDER_GEOFENCES_KEY = stringSetPreferencesKey("reminder_geofences")
+		private val NOTIFICATION_COOLDOWNS_KEY = stringSetPreferencesKey("notification_cooldowns")
 	}
 
 	/**
@@ -52,6 +54,22 @@ class AttendancePreference internal constructor(
 	fun getActiveAttendanceId(): Flow<Int?> {
 		return dataStore.data.map { preferences ->
 			preferences[ACTIVE_ATTENDANCE_ID_KEY]
+		}
+	}
+
+	suspend fun saveAttendanceSessionStateKey(key: String?) {
+		dataStore.edit { preferences ->
+			if (key.isNullOrBlank()) {
+				preferences.remove(ATTENDANCE_SESSION_STATE_KEY)
+			} else {
+				preferences[ATTENDANCE_SESSION_STATE_KEY] = key
+			}
+		}
+	}
+
+	fun getAttendanceSessionStateKey(): Flow<String?> {
+		return dataStore.data.map { preferences ->
+			preferences[ATTENDANCE_SESSION_STATE_KEY]
 		}
 	}
 
@@ -185,15 +203,40 @@ class AttendancePreference internal constructor(
 		}
 	}
 
+	suspend fun canNotifyWithCooldown(key: String, nowMillis: Long, cooldownMillis: Long): Boolean {
+		var allowed = false
+		dataStore.edit { preferences ->
+			val current = preferences[NOTIFICATION_COOLDOWNS_KEY].orEmpty()
+			val existing = current.firstOrNull { it.startsWith("$key|") }
+			val lastShownAt = existing?.substringAfter("|")?.toLongOrNull()
+			allowed = lastShownAt == null || nowMillis - lastShownAt >= cooldownMillis
+			if (allowed) {
+				preferences[NOTIFICATION_COOLDOWNS_KEY] = current
+					.filterNot { it.startsWith("$key|") }
+					.plus("$key|$nowMillis")
+					.toSet()
+			}
+		}
+		return allowed
+	}
+
+	suspend fun clearNotificationCooldowns() {
+		dataStore.edit { preferences ->
+			preferences.remove(NOTIFICATION_COOLDOWNS_KEY)
+		}
+	}
+
 	suspend fun clearAttendanceRuntimeState() {
 		dataStore.edit { preferences ->
 			preferences.remove(ACTIVE_ATTENDANCE_ID_KEY)
 			preferences.remove(IS_INSIDE_GEOFENCE_KEY)
+			preferences.remove(ATTENDANCE_SESSION_STATE_KEY)
 			preferences.remove(LAST_GEOFENCE_REQUEST_ID_KEY)
 			preferences.remove(LAST_GEOFENCE_LAT_KEY)
 			preferences.remove(LAST_GEOFENCE_LNG_KEY)
 			preferences.remove(LAST_GEOFENCE_RADIUS_KEY)
 			preferences.remove(REMINDER_GEOFENCES_KEY)
+			preferences.remove(NOTIFICATION_COOLDOWNS_KEY)
 		}
 	}
 }

--- a/app/src/main/java/com/example/infinite_track/data/worker/LocationEventWorker.kt
+++ b/app/src/main/java/com/example/infinite_track/data/worker/LocationEventWorker.kt
@@ -9,6 +9,8 @@ import com.example.infinite_track.data.soucre.network.request.LocationEventReque
 import com.example.infinite_track.domain.repository.AttendanceRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import java.time.Duration
+import java.time.Instant
 /**
  * Worker for sending location events to backend
  * This worker handles the background task of sending geofence events (ENTER/EXIT) to the server
@@ -28,6 +30,10 @@ class LocationEventWorker @AssistedInject constructor(
         const val KEY_EVENT_TYPE = "event_type"
         const val KEY_LOCATION_ID = "location_id" // now String
         const val KEY_EVENT_TIMESTAMP = "event_timestamp"
+        const val KEY_ACTIVE_ATTENDANCE_ID = "active_attendance_id"
+
+        private const val MAX_RETRY_ATTEMPTS = 3
+        private val MAX_EVENT_AGE = Duration.ofHours(6)
     }
 
     override suspend fun doWork(): Result {
@@ -38,14 +44,20 @@ class LocationEventWorker @AssistedInject constructor(
             val eventType = inputData.getString(KEY_EVENT_TYPE)
             val locationId = inputData.getString(KEY_LOCATION_ID)
             val eventTimestamp = inputData.getString(KEY_EVENT_TIMESTAMP)
+            val activeAttendanceId = inputData.getInt(KEY_ACTIVE_ATTENDANCE_ID, -1)
 
             // Validate input data
-            if (eventType.isNullOrBlank() || locationId.isNullOrBlank() || eventTimestamp.isNullOrBlank()) {
+            if (eventType.isNullOrBlank() || locationId.isNullOrBlank() || eventTimestamp.isNullOrBlank() || activeAttendanceId <= 0) {
                 Log.e(
                     TAG,
-                    "Invalid input data: eventType=$eventType, locationId=$locationId, timestamp=$eventTimestamp"
+                    "Invalid input data: eventType=$eventType, locationId=$locationId, timestamp=$eventTimestamp, activeAttendanceId=$activeAttendanceId"
                 )
                 return Result.failure()
+            }
+
+            if (isStale(eventTimestamp)) {
+                Log.w(TAG, "Dropping stale location event: $eventType for $locationId at $eventTimestamp")
+                return Result.success()
             }
 
             // Create request object
@@ -62,13 +74,32 @@ class LocationEventWorker @AssistedInject constructor(
                 Log.d(TAG, "Location event sent successfully: $eventType for location $locationId")
                 Result.success()
             } else {
-                Log.e(TAG, "Failed to send location event: ${result.exceptionOrNull()?.message}")
-                // Retry the work if it fails
-                Result.retry()
+                val message = result.exceptionOrNull()?.message.orEmpty()
+                Log.e(TAG, "Failed to send location event: $message")
+                if (shouldRetry(message)) Result.retry() else Result.failure()
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error in LocationEventWorker", e)
-            Result.retry()
+            if (shouldRetry(e.message.orEmpty())) Result.retry() else Result.failure()
         }
+    }
+
+    private fun isStale(eventTimestamp: String): Boolean {
+        return try {
+            val eventInstant = Instant.parse(eventTimestamp)
+            Duration.between(eventInstant, Instant.now()) > MAX_EVENT_AGE
+        } catch (exception: Exception) {
+            Log.w(TAG, "Invalid event timestamp format, treating as permanent failure: $eventTimestamp", exception)
+            true
+        }
+    }
+
+    private fun shouldRetry(message: String): Boolean {
+        if (runAttemptCount >= MAX_RETRY_ATTEMPTS) return false
+        val lower = message.lowercase()
+        if (lower.contains("400") || lower.contains("401") || lower.contains("403") || lower.contains("404") || lower.contains("422")) {
+            return false
+        }
+        return true
     }
 }

--- a/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/infinite_track/di/UseCaseModule.kt
@@ -30,6 +30,7 @@ import com.example.infinite_track.domain.use_case.auth.ValidateForegroundSession
 import com.example.infinite_track.domain.use_case.auth.VerifyFaceUseCase
 import com.example.infinite_track.domain.use_case.booking.GetBookingHistoryUseCase
 import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.booking.SubmitWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.contact.GetContactsUseCase
 import com.example.infinite_track.domain.use_case.history.ExportAttendanceReportPdfUseCase
@@ -220,6 +221,13 @@ object UseCaseModule {
         bookingRepository: BookingRepository
     ): ResolveTodayApprovedWfaBookingIdUseCase {
         return ResolveTodayApprovedWfaBookingIdUseCase(bookingRepository)
+    }
+
+    @Provides
+    fun provideResolveTodayApprovedWfaBookingUseCase(
+        bookingRepository: BookingRepository
+    ): ResolveTodayApprovedWfaBookingUseCase {
+        return ResolveTodayApprovedWfaBookingUseCase(bookingRepository)
     }
 
     // Provide the Check In Use Case

--- a/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/model/booking/BookingHistoryItem.kt
@@ -16,5 +16,9 @@ data class BookingHistoryItem(
     val createdAtRaw: String = "",
     val createdAt: String = "-",
     val processedAtRaw: String? = null,
-    val processedAt: String = "Not processed yet"
+    val processedAt: String = "Not processed yet",
+    val locationId: Int? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val radiusMeters: Float? = null
 )

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckInUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckInUseCase.kt
@@ -55,27 +55,15 @@ class CheckInUseCase @Inject constructor(
             // Step 4: If check-in successful, setup geofence monitoring using provided target location
             if (checkInResult.isSuccess) {
                 try {
-                    // Clean up reminder geofences to avoid double notifications during active session
-                    geofenceManager.removeAllGeofences()
-
-                    val requestId = if (targetLocation.locationId != 0) {
-                        targetLocation.locationId.toString()
-                    } else {
-                        // WFA: build a stable id from coordinates
-                        val lat = String.format("%.6f", targetLocation.latitude)
-                        val lng = String.format("%.6f", targetLocation.longitude)
-                        "wfa:$lat,$lng"
-                    }
-
-                    geofenceManager.addGeofence(
-                        id = requestId,
-                        latitude = targetLocation.latitude,
-                        longitude = targetLocation.longitude,
-                        radius = targetLocation.radius.toFloat()
+                    val activeAttendanceId = checkInResult.getOrThrow().idAttendance
+                    attendancePreference.saveAttendanceSessionStateKey("active")
+                    geofenceManager.registerActiveMonitoringGeofence(
+                        location = targetLocation,
+                        activeAttendanceId = activeAttendanceId
                     )
                     android.util.Log.d(
                         "CheckInUseCase",
-                        "Geofence monitoring started for requestId $requestId"
+                        "Active monitoring geofence requested for attendance $activeAttendanceId"
                     )
                 } catch (e: Exception) {
                     android.util.Log.e("CheckInUseCase", "Failed to setup geofence monitoring", e)

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckOutUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/attendance/CheckOutUseCase.kt
@@ -5,7 +5,6 @@ import com.example.infinite_track.domain.model.attendance.ActiveAttendanceSessio
 import com.example.infinite_track.domain.repository.AttendanceRepository
 import com.example.infinite_track.domain.use_case.location.GetCurrentCoordinatesUseCase
 import com.example.infinite_track.presentation.geofencing.GeofenceManager
-import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
 /**
@@ -52,22 +51,15 @@ class CheckOutUseCase @Inject constructor(
             // 4. If check-out successful, remove geofence using stored request ID
             if (checkOutResult.isSuccess) {
                 try {
-                    val lastRequestId = attendancePreference.getLastGeofenceRequestId().firstOrNull()
-                    if (lastRequestId != null) {
-                        geofenceManager.removeGeofence(lastRequestId)
-                    } else {
-                        geofenceManager.removeAllGeofences()
-                    }
+                    geofenceManager.removeActiveMonitoringGeofence()
+                    attendancePreference.saveAttendanceSessionStateKey("completed")
                     android.util.Log.d(
                         "CheckOutUseCase",
-                        "Geofence removed using stored request ID: ${lastRequestId ?: "ALL"}"
+                        "Active monitoring geofence removed after checkout"
                     )
 
-                    // Re-register reminder geofences (WFO/WFH) so reminders work after checkout
-                    val reminders = attendancePreference.getReminderGeofences().firstOrNull().orEmpty()
-                    reminders.forEach { r ->
-                        geofenceManager.addReminderGeofence(r.id, r.latitude, r.longitude, r.radiusMeters)
-                    }
+                    // Re-register only the persisted reminder geofences. Receiver still gates notification by can-check-in/session truth.
+                    geofenceManager.restoreReminderGeofences()
                 } catch (e: Exception) {
                     android.util.Log.e("CheckOutUseCase", "Failed to remove geofence", e)
                     // Don't fail the entire check-out process if geofence removal fails

--- a/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCase.kt
+++ b/app/src/main/java/com/example/infinite_track/domain/use_case/booking/ResolveTodayApprovedWfaBookingUseCase.kt
@@ -1,0 +1,37 @@
+package com.example.infinite_track.domain.use_case.booking
+
+import com.example.infinite_track.domain.model.booking.BookingHistoryItem
+import com.example.infinite_track.domain.repository.BookingRepository
+import javax.inject.Inject
+
+class ResolveTodayApprovedWfaBookingUseCase @Inject constructor(
+    private val bookingRepository: BookingRepository
+) {
+    suspend operator fun invoke(scheduleDateIso: String): Result<BookingHistoryItem> {
+        var page = 1
+
+        while (true) {
+            val bookingPage = bookingRepository.getBookingHistory(
+                status = "approved",
+                page = page,
+                limit = 50
+            ).getOrElse { error -> return Result.failure(error) }
+
+            val approvedBooking = bookingPage.bookings.firstOrNull { booking ->
+                booking.statusRaw.equals("approved", ignoreCase = true) &&
+                    booking.scheduleDateRaw == scheduleDateIso
+            }
+
+            if (approvedBooking != null) {
+                return Result.success(approvedBooking)
+            }
+
+            if (!bookingPage.hasNextPage) break
+            page += 1
+        }
+
+        return Result.failure(
+            IllegalStateException("Approved WFA booking for $scheduleDateIso was not found.")
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/BootCompletedReceiver.kt
@@ -35,20 +35,27 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
+                val activeAttendanceId = attendancePreference.getActiveAttendanceId().firstOrNull()
+                val sessionStateKey = attendancePreference.getAttendanceSessionStateKey().firstOrNull()
                 val params = attendancePreference.getLastGeofenceParams().firstOrNull()
-                if (params != null) {
+                if (activeAttendanceId != null && sessionStateKey == "active" && params != null) {
                     val (requestId, latLng, radius) = params
                     val (lat, lng) = latLng
-                    Log.d("BootCompletedReceiver", "Re-registering monitoring geofence after boot: $requestId")
+                    Log.d("BootCompletedReceiver", "Re-registering active monitoring geofence after boot: $requestId")
                     geofenceManager.addGeofence(requestId, lat, lng, radius.toFloat())
                 } else {
-                    Log.d("BootCompletedReceiver", "No monitoring geofence to restore.")
+                    Log.d(
+                        "BootCompletedReceiver",
+                        "Skipping active monitoring restore: attendanceId=$activeAttendanceId, state=$sessionStateKey, hasParams=${params != null}"
+                    )
                 }
 
-                val reminders = attendancePreference.getReminderGeofences().firstOrNull().orEmpty()
-                reminders.forEach { r ->
-                    Log.d("BootCompletedReceiver", "Re-registering reminder geofence after boot: ${r.id}")
-                    geofenceManager.addReminderGeofence(r.id, r.latitude, r.longitude, r.radiusMeters)
+                if (sessionStateKey != "completed" && activeAttendanceId == null) {
+                    val reminders = attendancePreference.getReminderGeofences().firstOrNull().orEmpty()
+                    reminders.forEach { r ->
+                        Log.d("BootCompletedReceiver", "Re-registering reminder geofence after boot: ${r.id}")
+                        geofenceManager.addReminderGeofence(r.id, r.latitude, r.longitude, r.radiusMeters)
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("BootCompletedReceiver", "Failed to re-register geofence after boot", e)

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceBroadcastReceiver.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceBroadcastReceiver.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.NetworkType
+import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.example.infinite_track.data.soucre.local.preferences.AttendancePreference
@@ -35,6 +36,9 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
     companion object {
         private const val TAG = "GeofenceReceiver"
+        private const val ACTIVE_SESSION_STATE = "active"
+        private const val REMINDER_COOLDOWN_MILLIS = 45 * 60 * 1000L
+        private const val ACTIVE_ALERT_COOLDOWN_MILLIS = 7 * 60 * 1000L
     }
 
     @EntryPoint
@@ -75,18 +79,31 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val activeAttendanceId = attendancePreference.getActiveAttendanceId().first()
+                val sessionStateKey = attendancePreference.getAttendanceSessionStateKey().first()
+                val hasActiveSessionTruth = activeAttendanceId != null && sessionStateKey == ACTIVE_SESSION_STATE
 
-                if (activeAttendanceId == null) {
-                    Log.d(TAG, "No active session. Handling as reminder mode for event: $eventType")
+                if (!hasActiveSessionTruth) {
+                    Log.d(
+                        TAG,
+                        "No active session truth. Handling as reminder mode for event=$eventType, attendanceId=$activeAttendanceId, state=$sessionStateKey"
+                    )
 
-                    if (eventType == "ENTER") {
+                    if (eventType == "ENTER" && sessionStateKey != "completed") {
                         triggeringGeofences.forEach { geofence ->
                             val locationId = geofence.requestId
-                            val friendlyLabel = when {
-                                locationId.startsWith("wfa:") -> "Lokasi WFA"
-                                else -> locationId
+                            if (!locationId.startsWith("reminder:")) return@forEach
+                            val friendlyLabel = reminderLabel(locationId)
+                            val cooldownKey = "reminder:$locationId"
+                            val canNotify = attendancePreference.canNotifyWithCooldown(
+                                key = cooldownKey,
+                                nowMillis = System.currentTimeMillis(),
+                                cooldownMillis = REMINDER_COOLDOWN_MILLIS
+                            )
+                            if (canNotify) {
+                                NotificationHelper.showCheckInReminderNotification(context, friendlyLabel)
+                            } else {
+                                Log.d(TAG, "Reminder notification skipped by cooldown: $locationId")
                             }
-                            NotificationHelper.showCheckInReminderNotification(context, friendlyLabel)
                         }
                     }
                     return@launch
@@ -94,7 +111,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
                 Log.d(
                     TAG,
-                    "Active session found (ID: $activeAttendanceId). Processing geofence event: $eventType"
+                    "Active session truth found (ID: $activeAttendanceId, state=$sessionStateKey). Processing geofence event: $eventType"
                 )
 
                 when (eventType) {
@@ -108,7 +125,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                         Log.d(TAG, "Ignoring reminder geofence during active session: $requestId")
                         return@forEach
                     }
-                    processGeofenceEvent(context, geofence, eventType)
+                    processGeofenceEvent(context, geofence, eventType, activeAttendanceId!!)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error processing geofence event", e)
@@ -118,7 +135,12 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun processGeofenceEvent(context: Context, geofence: Geofence, eventType: String) {
+    private suspend fun processGeofenceEvent(
+        context: Context,
+        geofence: Geofence,
+        eventType: String,
+        activeAttendanceId: Int
+    ) {
         try {
             val locationId = geofence.requestId // String: supports numeric and WFA ids
 
@@ -132,12 +154,26 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 locationId.startsWith("wfa:") -> "Lokasi WFA"
                 else -> locationId
             }
-            NotificationHelper.showGeofenceNotification(context, eventType, friendlyLabel)
+            val cooldownKey = "active:$activeAttendanceId:$eventType:$locationId"
+            val canNotify = EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                GeofenceReceiverEntryPoint::class.java
+            ).attendancePreference().canNotifyWithCooldown(
+                key = cooldownKey,
+                nowMillis = System.currentTimeMillis(),
+                cooldownMillis = ACTIVE_ALERT_COOLDOWN_MILLIS
+            )
+            if (canNotify) {
+                NotificationHelper.showGeofenceNotification(context, eventType, friendlyLabel)
+            } else {
+                Log.d(TAG, "Active monitoring notification skipped by cooldown: $cooldownKey")
+            }
 
             val workData = Data.Builder()
                 .putString(LocationEventWorker.KEY_EVENT_TYPE, eventType)
                 .putString(LocationEventWorker.KEY_LOCATION_ID, locationId)
                 .putString(LocationEventWorker.KEY_EVENT_TIMESTAMP, timestamp)
+                .putInt(LocationEventWorker.KEY_ACTIVE_ATTENDANCE_ID, activeAttendanceId)
                 .build()
 
             val constraints = androidx.work.Constraints.Builder()
@@ -150,11 +186,25 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 .addTag("location_event_$locationId")
                 .build()
 
-            WorkManager.getInstance(context).enqueue(workRequest)
+            val uniqueWorkName = "location_event_${activeAttendanceId}_${locationId}_${eventType}"
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                uniqueWorkName,
+                ExistingWorkPolicy.REPLACE,
+                workRequest
+            )
 
-            Log.d(TAG, "Location event enqueued: $eventType for $locationId at $timestamp")
+            Log.d(TAG, "Location event enqueued uniquely: $uniqueWorkName at $timestamp")
         } catch (e: Exception) {
             Log.e(TAG, "Error processing geofence event for ${geofence.requestId}", e)
+        }
+    }
+
+    private fun reminderLabel(requestId: String): String {
+        return when {
+            requestId.startsWith("reminder:wfh:") -> "Lokasi WFH"
+            requestId.startsWith("reminder:wfa:") -> "Lokasi WFA"
+            requestId.startsWith("reminder:primary:") -> "Lokasi utama attendance"
+            else -> requestId.removePrefix("reminder:")
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/GeofenceManager.kt
@@ -94,13 +94,12 @@ class GeofenceManager @Inject constructor(
     }
 
     /**
-     * Remove all geofences registered by this application.
-     * Existing fire-and-forget callers keep their non-blocking behavior.
+     * Full geofence teardown. Keep this for logout/auth runtime cleanup only.
      */
-    fun removeAllGeofences() {
+    fun removeAllGeofencesForLogoutOnly() {
         ioScope.launch {
             try {
-                removeAllGeofencesAwait()
+                removeAllGeofencesForLogoutOnlyAwait()
             } catch (e: CancellationException) {
                 throw e
             } catch (exception: Exception) {
@@ -110,15 +109,21 @@ class GeofenceManager @Inject constructor(
     }
 
     /**
+     * Backward-compatible alias. New normal mode switches must use typed lifecycle APIs.
+     */
+    fun removeAllGeofences() = removeAllGeofencesForLogoutOnly()
+
+    /**
      * Awaitable geofence cleanup for auth/runtime teardown semantics.
      */
-    suspend fun removeAllGeofencesAwait() {
+    suspend fun removeAllGeofencesForLogoutOnlyAwait() {
         try {
             geofencingClient.removeGeofences(geofencePendingIntent).awaitTask()
-            Log.d(TAG, "Semua geofence berhasil dihapus")
+            Log.d(TAG, "Semua geofence berhasil dihapus untuk logout/full teardown")
             attendancePreference.clearLastGeofenceRequestId()
             attendancePreference.clearLastGeofenceParams()
             attendancePreference.clearReminderGeofences()
+            attendancePreference.clearNotificationCooldowns()
         } catch (e: CancellationException) {
             throw e
         } catch (exception: Exception) {
@@ -126,6 +131,8 @@ class GeofenceManager @Inject constructor(
             throw exception
         }
     }
+
+    suspend fun removeAllGeofencesAwait() = removeAllGeofencesForLogoutOnlyAwait()
 
     @SuppressLint("MissingPermission")
     fun addGeofence(
@@ -166,51 +173,34 @@ class GeofenceManager @Inject constructor(
 
         settingsClient.checkLocationSettings(settingsRequest)
             .addOnSuccessListener {
-                // STEP 1: Always remove all existing geofences first (clean slate approach)
-                Log.d(TAG, "Membersihkan semua geofence sebelum menambah yang baru...")
+                val requestId = id
+                val geofence = Geofence.Builder()
+                    .setRequestId(requestId)
+                    .setCircularRegion(latitude, longitude, safeRadius)
+                    .setExpirationDuration(Geofence.NEVER_EXPIRE)
+                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
+                    .build()
 
-                geofencingClient.removeGeofences(geofencePendingIntent).run {
+                val geofencingRequest = GeofencingRequest.Builder()
+                    .setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER)
+                    .addGeofence(geofence)
+                    .build()
+
+                geofencingClient.addGeofences(geofencingRequest, geofencePendingIntent).run {
                     addOnSuccessListener {
-                        Log.d(TAG, "Semua geofence berhasil dihapus, sekarang menambah geofence baru...")
-
-                        // STEP 2: Create and add the new geofence ONLY after removal is successful
-                        val requestId = id
-                        val geofence = Geofence.Builder()
-                            .setRequestId(requestId)
-                            .setCircularRegion(latitude, longitude, safeRadius)
-                            .setExpirationDuration(Geofence.NEVER_EXPIRE)
-                            .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
-                            .build()
-
-                        val geofencingRequest = GeofencingRequest.Builder()
-                            .setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER)
-                            .addGeofence(geofence)
-                            .build()
-
-                        geofencingClient.addGeofences(geofencingRequest, geofencePendingIntent).run {
-                            addOnSuccessListener {
-                                Log.d(
-                                    TAG,
-                                    "Geofence berhasil ditambahkan: $requestId (lat: $latitude, lng: $longitude, radius: ${safeRadius}m)"
-                                )
-                                ioScope.launch {
-                                    attendancePreference.saveLastGeofenceRequestId(requestId)
-                                    attendancePreference.saveLastGeofenceParams(requestId, latitude, longitude, safeRadius)
-                                }
-                            }
-                            addOnFailureListener { exception ->
-                                val status = (exception as? ApiException)?.statusCode
-                                val statusText = status?.let { GeofenceStatusCodes.getStatusCodeString(it) }
-                                Log.e(TAG, "Gagal menambahkan geofence: $requestId (${status ?: "?"}: ${statusText ?: exception.message})", exception)
-                            }
+                        Log.d(
+                            TAG,
+                            "Active geofence berhasil ditambahkan: $requestId (lat: $latitude, lng: $longitude, radius: ${safeRadius}m)"
+                        )
+                        ioScope.launch {
+                            attendancePreference.saveLastGeofenceRequestId(requestId)
+                            attendancePreference.saveLastGeofenceParams(requestId, latitude, longitude, safeRadius)
                         }
                     }
                     addOnFailureListener { exception ->
-                        Log.e(
-                            TAG,
-                            "Gagal menghapus semua geofence, geofence baru tidak akan ditambahkan",
-                            exception
-                        )
+                        val status = (exception as? ApiException)?.statusCode
+                        val statusText = status?.let { GeofenceStatusCodes.getStatusCodeString(it) }
+                        Log.e(TAG, "Gagal menambahkan active geofence: $requestId (${status ?: "?"}: ${statusText ?: exception.message})", exception)
                     }
                 }
             }
@@ -289,6 +279,87 @@ class GeofenceManager @Inject constructor(
         }
     }
 
+    fun registerReminderGeofences(candidates: List<ReminderGeofenceCandidate>) {
+        if (candidates.isEmpty()) {
+            Log.d(TAG, "Tidak ada reminder geofence candidate untuk diregister")
+            return
+        }
+        Log.d(
+            TAG,
+            "Registering reminder candidates: " + candidates.joinToString { "${it.id}:${it.source}" }
+        )
+        candidates.forEach { candidate ->
+            addReminderGeofence(
+                id = candidate.id,
+                latitude = candidate.latitude,
+                longitude = candidate.longitude,
+                radius = candidate.radiusMeters
+            )
+        }
+    }
+
+    fun removeReminderGeofences() {
+        ioScope.launch {
+            val reminders = attendancePreference.getReminderGeofences().first()
+            if (reminders.isEmpty()) {
+                Log.d(TAG, "Tidak ada reminder geofence untuk dihapus")
+                return@launch
+            }
+            geofencingClient.removeGeofences(reminders.map { it.id }).run {
+                addOnSuccessListener {
+                    Log.d(TAG, "Reminder geofences dilepas dari Play Services: ${reminders.map { it.id }}")
+                }
+                addOnFailureListener { Log.e(TAG, "Gagal menghapus reminder geofences", it) }
+            }
+        }
+    }
+
+    fun restoreReminderGeofences() {
+        ioScope.launch {
+            val reminders = attendancePreference.getReminderGeofences().first()
+            reminders.forEach { reminder ->
+                addReminderGeofence(reminder.id, reminder.latitude, reminder.longitude, reminder.radiusMeters)
+            }
+            Log.d(TAG, "Reminder geofences restored: ${reminders.map { it.id }}")
+        }
+    }
+
+    fun registerActiveMonitoringGeofence(
+        location: com.example.infinite_track.domain.model.attendance.Location,
+        activeAttendanceId: Int
+    ) {
+        removeReminderGeofences()
+        val requestId = buildActiveMonitoringRequestId(location, activeAttendanceId)
+        addGeofence(
+            id = requestId,
+            latitude = location.latitude,
+            longitude = location.longitude,
+            radius = location.radius.toFloat()
+        )
+        Log.d(TAG, "Active monitoring geofence requested: $requestId for attendance=$activeAttendanceId")
+    }
+
+    fun removeActiveMonitoringGeofence() {
+        ioScope.launch {
+            val lastRequestId = attendancePreference.getLastGeofenceRequestId().first()
+            if (lastRequestId == null) {
+                Log.d(TAG, "Tidak ada active monitoring geofence untuk dihapus")
+                return@launch
+            }
+            geofencingClient.removeGeofences(listOf(lastRequestId)).run {
+                addOnSuccessListener {
+                    Log.d(TAG, "Active monitoring geofence dihapus: $lastRequestId")
+                    ioScope.launch {
+                        attendancePreference.clearLastGeofenceRequestId()
+                        attendancePreference.clearLastGeofenceParams()
+                        attendancePreference.setUserInsideGeofence(false)
+                    }
+                }
+                addOnFailureListener { Log.e(TAG, "Gagal menghapus active monitoring geofence: $lastRequestId", it) }
+            }
+        }
+    }
+
     fun removeReminderGeofence(id: String) {
         geofencingClient.removeGeofences(listOf(id)).run {
             addOnSuccessListener {
@@ -296,6 +367,19 @@ class GeofenceManager @Inject constructor(
                 ioScope.launch { attendancePreference.removeReminderGeofence(id) }
             }
             addOnFailureListener { Log.e(TAG, "Gagal menghapus reminder geofence: $id", it) }
+        }
+    }
+
+    private fun buildActiveMonitoringRequestId(
+        location: com.example.infinite_track.domain.model.attendance.Location,
+        activeAttendanceId: Int
+    ): String {
+        return if (location.locationId != 0) {
+            "active:$activeAttendanceId:${location.locationId}"
+        } else {
+            val lat = String.format("%.6f", location.latitude)
+            val lng = String.format("%.6f", location.longitude)
+            "active:$activeAttendanceId:wfa:$lat,$lng"
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/geofencing/ReminderGeofenceCandidate.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/geofencing/ReminderGeofenceCandidate.kt
@@ -1,0 +1,11 @@
+package com.example.infinite_track.presentation.geofencing
+
+data class ReminderGeofenceCandidate(
+    val id: String,
+    val modeKey: String,
+    val label: String,
+    val latitude: Double,
+    val longitude: Double,
+    val radiusMeters: Float,
+    val source: String
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceViewModel.kt
@@ -17,11 +17,13 @@ import com.example.infinite_track.domain.use_case.attendance.GetTodayStatusUseCa
 import com.example.infinite_track.domain.use_case.attendance.ResolveSelectedTargetLocationUseCase
 import com.example.infinite_track.domain.use_case.auth.GetLoggedInUserUseCase
 import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingIdUseCase
+import com.example.infinite_track.domain.use_case.booking.ResolveTodayApprovedWfaBookingUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentAddressUseCase
 import com.example.infinite_track.domain.use_case.location.GetCurrentCoordinatesUseCase
 import com.example.infinite_track.domain.use_case.location.ReverseGeocodeUseCase
 import com.example.infinite_track.domain.use_case.wfa.GetWfaRecommendationsUseCase
 import com.example.infinite_track.presentation.geofencing.GeofenceManager
+import com.example.infinite_track.presentation.geofencing.ReminderGeofenceCandidate
 import com.example.infinite_track.presentation.navigation.Screen
 import com.example.infinite_track.utils.LocationPermissionHelper
 import com.example.infinite_track.utils.UiState
@@ -80,6 +82,7 @@ class AttendanceViewModel @Inject constructor(
     private val geofenceManager: GeofenceManager,
     private val getLoggedInUserUseCase: GetLoggedInUserUseCase,
     private val resolveTodayApprovedWfaBookingIdUseCase: ResolveTodayApprovedWfaBookingIdUseCase,
+    private val resolveTodayApprovedWfaBookingUseCase: ResolveTodayApprovedWfaBookingUseCase,
     private val resolveSelectedTargetLocationUseCase: ResolveSelectedTargetLocationUseCase,
     private val evaluateWorkModeEligibilityUseCase: EvaluateWorkModeEligibilityUseCase,
     // Add UseCase dependencies for attendance operations
@@ -97,6 +100,8 @@ class AttendanceViewModel @Inject constructor(
     companion object {
         private const val TAG = "AttendanceViewModel"
         private const val DISPLAY_UPDATE_INTERVAL = 10000L // 10 seconds for UI updates
+        private const val SESSION_STATE_ACTIVE = "active"
+        private const val SESSION_STATE_NOT_STARTED = "not_started"
     }
 
     init {
@@ -144,23 +149,7 @@ class AttendanceViewModel @Inject constructor(
                 fetchUserHomeLocation()
 
                 // Don't start location updates automatically - let UI control this
-                // Register reminder geofences for WFO/WFH if available (prefix with reminder:)
-                _uiState.value.wfoLocation?.let { loc ->
-                    geofenceManager.addReminderGeofence(
-                        id = "reminder:" + loc.locationId,
-                        latitude = loc.latitude,
-                        longitude = loc.longitude,
-                        radius = loc.radius.toFloat()
-                    )
-                }
-                _uiState.value.wfhLocation?.let { loc ->
-                    geofenceManager.addReminderGeofence(
-                        id = "reminder:wfh:" + loc.locationId,
-                        latitude = loc.latitude,
-                        longitude = loc.longitude,
-                        radius = loc.radius.toFloat()
-                    )
-                }
+                refreshReminderGeofencesIfNeeded()
 
             } catch (e: Exception) {
                 Log.e(TAG, "Error initializing data", e)
@@ -203,27 +192,7 @@ class AttendanceViewModel @Inject constructor(
                     "Attendance action state updated: ${_uiState.value.actionState}"
                 )
 
-                // Register/refresh reminder geofences (WFO/WFH) after fetching status
-                try {
-                    todayStatus.activeLocation?.let { loc ->
-                        geofenceManager.addReminderGeofence(
-                            id = "reminder:" + loc.locationId,
-                            latitude = loc.latitude,
-                            longitude = loc.longitude,
-                            radius = loc.radius.toFloat()
-                        )
-                    }
-                    _uiState.value.wfhLocation?.let { loc ->
-                        geofenceManager.addReminderGeofence(
-                            id = "reminder:wfh:" + loc.locationId,
-                            latitude = loc.latitude,
-                            longitude = loc.longitude,
-                            radius = loc.radius.toFloat()
-                        )
-                    }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to add reminder geofences", e)
-                }
+                refreshReminderGeofencesIfNeeded()
 
             }.onFailure { exception ->
                 Log.e(TAG, "Failed to fetch today status", exception)
@@ -312,11 +281,100 @@ class AttendanceViewModel @Inject constructor(
                 }
 
                 Log.d(TAG, "WFH location updated: $wfhLocation")
+                refreshReminderGeofencesIfNeeded()
             }
         } catch (e: Exception) {
             Log.w(TAG, "Unexpected error in fetchUserHomeLocation", e)
             // Continue without WFH location
         }
+    }
+
+    private fun refreshReminderGeofencesIfNeeded() {
+        viewModelScope.launch {
+            val state = _uiState.value
+            val todayStatus = state.todayStatus ?: return@launch
+            val sessionKey = todayStatus.attendanceSessionState?.key
+            val shouldRegisterReminders = todayStatus.activeAttendanceId == null &&
+                sessionKey == SESSION_STATE_NOT_STARTED &&
+                todayStatus.canCheckIn
+
+            attendancePreference.saveAttendanceSessionStateKey(sessionKey)
+
+            if (!shouldRegisterReminders) {
+                Log.d(
+                    TAG,
+                    "Reminder geofence skipped: attendanceId=${todayStatus.activeAttendanceId}, state=$sessionKey, canCheckIn=${todayStatus.canCheckIn}"
+                )
+                return@launch
+            }
+
+            val candidates = buildReminderCandidates(todayStatus, state.wfhLocation)
+            Log.d(
+                TAG,
+                "Reminder candidates built: " + candidates.joinToString { "${it.id}:${it.modeKey}:${it.source}" }
+            )
+            geofenceManager.registerReminderGeofences(candidates)
+        }
+    }
+
+    private suspend fun buildReminderCandidates(
+        todayStatus: TodayStatus,
+        wfhLocation: Location?
+    ): List<ReminderGeofenceCandidate> {
+        val candidates = mutableListOf<ReminderGeofenceCandidate>()
+
+        todayStatus.activeLocation?.let { primary ->
+            candidates += ReminderGeofenceCandidate(
+                id = "reminder:primary:${primary.locationId}",
+                modeKey = WorkMode.fromRaw(todayStatus.activeMode)?.shortLabel?.lowercase() ?: WorkMode.WFO.shortLabel.lowercase(),
+                label = primary.description,
+                latitude = primary.latitude,
+                longitude = primary.longitude,
+                radiusMeters = primary.radius.toFloat(),
+                source = "status-today.active_location"
+            )
+        }
+
+        wfhLocation?.let { home ->
+            candidates += ReminderGeofenceCandidate(
+                id = "reminder:wfh:user_home:${home.locationId}",
+                modeKey = WorkMode.WFH.shortLabel.lowercase(),
+                label = home.description,
+                latitude = home.latitude,
+                longitude = home.longitude,
+                radiusMeters = home.radius.toFloat(),
+                source = "/me"
+            )
+        }
+
+        val todayDate = todayStatus.todayDate
+        if (todayDate.isNotBlank()) {
+            resolveTodayApprovedWfaBookingUseCase(todayDate).onSuccess { booking ->
+                val latitude = booking.latitude
+                val longitude = booking.longitude
+                if (latitude != null && longitude != null && !isDuplicateWithPrimary(todayStatus.activeLocation, latitude, longitude)) {
+                    candidates += ReminderGeofenceCandidate(
+                        id = "reminder:wfa:${booking.bookingId}:${booking.locationId ?: 0}",
+                        modeKey = WorkMode.WFA.shortLabel.lowercase(),
+                        label = booking.locationDescription,
+                        latitude = latitude,
+                        longitude = longitude,
+                        radiusMeters = booking.radiusMeters ?: 100f,
+                        source = "approved-wfa-booking"
+                    )
+                }
+            }.onFailure { exception ->
+                Log.d(TAG, "No approved WFA reminder candidate: ${exception.message}")
+            }
+        }
+
+        return candidates.distinctBy { it.id }
+    }
+
+    private fun isDuplicateWithPrimary(primary: Location?, latitude: Double, longitude: Double): Boolean {
+        if (primary == null) return false
+        return kotlin.math.abs(primary.latitude - latitude) < 0.00001 &&
+            kotlin.math.abs(primary.longitude - longitude) < 0.00001
     }
 
     /**

--- a/app/src/main/java/com/example/infinite_track/utils/NotificationHelper.kt
+++ b/app/src/main/java/com/example/infinite_track/utils/NotificationHelper.kt
@@ -1,31 +1,55 @@
 package com.example.infinite_track.utils
 
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import com.example.infinite_track.R
 import com.example.infinite_track.presentation.main.MainActivity
 
 object NotificationHelper {
 
-    private const val CHANNEL_ID = "geofence_channel_01"
-    private const val CHANNEL_NAME = "Geofence Notifications"
+    private const val TAG = "NotificationHelper"
+    private const val REMINDER_CHANNEL_ID = "attendance_reminder_channel"
+    private const val SESSION_ALERT_CHANNEL_ID = "attendance_session_alert_channel"
+    private const val EVIDENCE_SYNC_CHANNEL_ID = "attendance_evidence_sync_channel"
 
     fun createNotificationChannel(context: Context) {
-        val channel = NotificationChannel(
-            CHANNEL_ID,
-            CHANNEL_NAME,
-            NotificationManager.IMPORTANCE_HIGH
-        )
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(channel)
+        notificationManager.createNotificationChannels(
+            listOf(
+                NotificationChannel(
+                    REMINDER_CHANNEL_ID,
+                    "Attendance Reminder",
+                    NotificationManager.IMPORTANCE_HIGH
+                ),
+                NotificationChannel(
+                    SESSION_ALERT_CHANNEL_ID,
+                    "Attendance Session Alert",
+                    NotificationManager.IMPORTANCE_HIGH
+                ),
+                NotificationChannel(
+                    EVIDENCE_SYNC_CHANNEL_ID,
+                    "Attendance Evidence Sync",
+                    NotificationManager.IMPORTANCE_LOW
+                )
+            )
+        )
     }
 
     fun showGeofenceNotification(context: Context, eventType: String, locationName: String) {
+        if (!canPostNotifications(context)) {
+            Log.w(TAG, "Session alert notification skipped because POST_NOTIFICATIONS is not granted")
+            return
+        }
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -46,7 +70,7 @@ object NotificationHelper {
             context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(context, SESSION_ALERT_CHANNEL_ID)
             .setSmallIcon(R.drawable.notifications_24px)
             .setContentTitle("Pemberitahuan Area Presensi")
             .setContentText(message)
@@ -59,6 +83,10 @@ object NotificationHelper {
     }
 
     fun showCheckInReminderNotification(context: Context, locationName: String) {
+        if (!canPostNotifications(context)) {
+            Log.w(TAG, "Reminder notification skipped because POST_NOTIFICATIONS is not granted")
+            return
+        }
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -70,7 +98,7 @@ object NotificationHelper {
             context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(context, REMINDER_CHANNEL_ID)
             .setSmallIcon(R.drawable.notifications_24px)
             .setContentTitle("Pengingat Check-in")
             .setContentText("Anda berada di area: $locationName. Jangan lupa check-in.")
@@ -80,5 +108,13 @@ object NotificationHelper {
             .build()
 
         notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+    }
+
+    private fun canPostNotifications(context: Context): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
     }
 }

--- a/docs/superpowers/plans/2026-07-09-inf-223-geofence-reminder-active-monitoring.md
+++ b/docs/superpowers/plans/2026-07-09-inf-223-geofence-reminder-active-monitoring.md
@@ -1,0 +1,85 @@
+# INF-223 / INF-74 / INF-75 / INF-76 / INF-77 / INF-96 — Android Geofence Reminder vs Active Monitoring
+
+## Scope
+
+This implementation separates Android-owned local geofence registration into two runtime modes:
+
+- Reminder geofences before check-in.
+- Active monitoring geofence after backend-confirmed check-in.
+
+Backend remains authoritative for attendance outcome, active attendance truth, booking approval, and final validation. Android only registers local geofences, shows local notifications when allowed, tracks local inside/outside state, and optionally syncs location events.
+
+## Runtime contract
+
+### Reminder mode
+
+Condition:
+
+```text
+active_attendance_id == null
+attendance_session_state.key == not_started
+can_check_in == true
+```
+
+Android builds reminder candidates from:
+
+1. `status-today.active_location` as the primary attendance target.
+2. `/me` cached user home location for WFH when latitude/longitude exist.
+3. Approved WFA booking from booking history when location coordinates exist and are not duplicate with the primary target.
+
+Reminder notification is local-only and does not trigger backend check-in.
+
+### Active monitoring mode
+
+Condition:
+
+```text
+active_attendance_id != null
+attendance_session_state.key == active
+```
+
+Only one active monitoring geofence is registered. Reminder geofences are detached from Play Services while preserving their persisted candidates for later restore.
+
+### Completed / checkout mode
+
+Checkout removes the active monitoring geofence, marks local session state completed, and restores persisted reminder geofences. The receiver suppresses reminder notifications when local state is completed.
+
+## Lifecycle API split
+
+New GeofenceManager intent APIs:
+
+- `registerReminderGeofences(candidates)`
+- `removeReminderGeofences()`
+- `registerActiveMonitoringGeofence(location, activeAttendanceId)`
+- `removeActiveMonitoringGeofence()`
+- `restoreReminderGeofences()`
+- `removeAllGeofencesForLogoutOnly()` / await variant
+
+`removeAllGeofences()` remains only as a backward-compatible alias for full teardown semantics; normal mode switching should not use it.
+
+## Duplicate and retry policy
+
+- Geofence receiver gates active events by both active attendance ID and `attendance_session_state.key == active`.
+- Active location event work uses unique work names per `activeAttendanceId + locationId + eventType` with `ExistingWorkPolicy.REPLACE`.
+- Worker drops stale events older than six hours.
+- Worker retries transient failures up to three attempts and treats common permanent HTTP client/auth failures as non-retryable.
+
+## Permissions and notifications
+
+- Geofence registration still requires foreground + background location permission.
+- Attendance map rendering is foreground-only; background permission remains optional/degraded for geofencing.
+- Notification channels are split into Attendance Reminder, Attendance Session Alert, and Attendance Evidence Sync.
+- If `POST_NOTIFICATIONS` is denied, geofence registration is still allowed; local notification calls are skipped with logs.
+
+## Verification status
+
+- Static diff whitespace check: `git diff --check` passed.
+- Debug build passed with the supported Windows/PowerShell Gradle environment:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command '$env:JAVA_HOME="D:\Java_Home\java 1.8.2"; $env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"; $env:ANDROID_SDK_ROOT=$env:ANDROID_HOME; $env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"; Set-Location "C:\Users\Febriyadi\.claude\worktrees\android-geofence-reminder-active-monitoring"; .\gradlew.bat --no-daemon app:assembleDebug'
+```
+
+Result: `BUILD SUCCESSFUL in 1m 52s`.
+
+- Runtime/geofence/device evidence remains `Needs Verification` on emulator/device with Google Play Services.


### PR DESCRIPTION
## Summary

- Split Android geofence runtime into reminder mode and active monitoring mode.
- Build reminder candidates from `status-today.active_location`, `/me` WFH/home location, and approved WFA booking location.
- Gate active monitoring on backend-confirmed `active_attendance_id` plus `attendance_session_state.key == active`.
- Add lifecycle APIs to avoid destructive `removeAllGeofences()` for normal mode switches.
- Add duplicate-safe WorkManager enqueue for location events and harden stale/retry behavior.
- Split notification channels and treat denied notification permission as degraded/non-blocking.
- Keep backend as final attendance validator; no backend contract change.

## Files / Areas Affected

- Geofence lifecycle and receiver behavior
- Attendance check-in/check-out geofence mode switching
- Reminder candidate composition
- Approved WFA booking location mapping
- Location event worker enqueue/retry semantics
- Notification channel and permission handling
- Implementation note under `docs/superpowers/plans/`

## Verification

- `git diff --check` passed.
- Debug build passed using supported local Windows/PowerShell Gradle env:

```powershell
powershell.exe -NoProfile -ExecutionPolicy Bypass -Command '$env:JAVA_HOME="D:\Java_Home\java 1.8.2"; $env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"; $env:ANDROID_SDK_ROOT=$env:ANDROID_HOME; $env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"; Set-Location "C:\Users\Febriyadi\.claude\worktrees\android-geofence-reminder-active-monitoring"; .\gradlew.bat --no-daemon app:assembleDebug'
```

Result: `BUILD SUCCESSFUL in 1m 52s`.

## Needs Verification

Runtime/device verification remains required on `develop` after merge:

- Reminder candidates are built from status-today + `/me` + approved WFA booking.
- WFO/WFH/WFA reminder geofences register before check-in.
- Reminder ENTER shows local notification only before check-in and respects cooldown.
- Notification denied state is degraded/non-blocking.
- Active monitoring starts only after backend-confirmed active attendance ID and active session state.
- Active EXIT updates local inside/outside state or enqueues location event.
- Checkout removes active monitoring and restores reminder flow without misleading completed-state reminder.
- Foreground-only map/manual attendance remains usable when background location is denied.

## Docs / ADR Note

This changes geofence/background location-event behavior. Added focused implementation note:

- `docs/superpowers/plans/2026-07-09-inf-223-geofence-reminder-active-monitoring.md`

A formal ADR can be added separately if release governance requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
