### PR TITLE
fix(splash): INF-241 polish double splash, brand text, duration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Infinite_Track">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/main/MainActivity.kt
@@ -53,11 +53,17 @@ class MainActivity : ComponentActivity() {
 	@ExperimentalGetImage
 	override fun onCreate(savedInstanceState: Bundle?) {
 		// Install splash screen BEFORE super.onCreate()
+		// MainActivity theme must be Theme.App.Starting (see AndroidManifest).
 		val splashScreen = installSplashScreen()
 
 		// Release native splash once Compose content is ready.
 		// Do NOT hold through full session bootstrap Loading.
 		splashScreen.setKeepOnScreenCondition { !isComposeReady }
+
+		// Remove the default fade-out so users don't perceive a second splash transition.
+		splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
+			splashScreenViewProvider.remove()
+		}
 
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/splash/SplashScreen.kt
@@ -1,5 +1,8 @@
 package com.example.infinite_track.presentation.screen.splash
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Button
@@ -21,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -32,8 +37,10 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.example.infinite_track.R
 import com.example.infinite_track.presentation.core.headline1
+import com.example.infinite_track.presentation.core.headline2
 import com.example.infinite_track.presentation.navigation.Screen
 import com.example.infinite_track.presentation.theme.Blue_500
+import kotlinx.coroutines.delay
 
 /**
  * Transparent branded splash presentation gate.
@@ -53,18 +60,38 @@ fun SplashScreen(
         spec = LottieCompositionSpec.RawRes(R.raw.infinite_track_splash)
     )
     val composition by compositionResult
-    // Play once; hold final frame after completion (progress stays at 1f).
+    // Play once, sped up so branded splash stays short (~1.9s for the 3.77s asset).
+    // Hold final frame after completion (progress stays at 1f).
     val progress by animateLottieCompositionAsState(
         composition = composition,
         iterations = 1,
         isPlaying = true,
-        restartOnPlay = false
+        restartOnPlay = false,
+        speed = 2f
     )
     // Failure must not trap the user; treat load failure as finished so destination can navigate.
     val isAnimationFinished = compositionResult.isFailure || (composition != null && progress >= 1f)
 
     val navigationState by splashViewModel.navigationState.collectAsState()
     var hasNavigated by remember { mutableStateOf(false) }
+
+    // Brand title fade/slide-in using existing theme typography + color tokens.
+    var brandVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        // Small delay so Lottie paints first, then text enters.
+        delay(120)
+        brandVisible = true
+    }
+    val brandAlpha by animateFloatAsState(
+        targetValue = if (brandVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing),
+        label = "splash_brand_alpha"
+    )
+    val brandOffsetY by animateFloatAsState(
+        targetValue = if (brandVisible) 0f else 12f,
+        animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing),
+        label = "splash_brand_offset"
+    )
 
     // One-shot navigation: only after animation completion AND destination resolved.
     // Fast session resolution waits for animation; slow resolution waits on final frame.
@@ -115,6 +142,21 @@ fun SplashScreen(
                     .aspectRatio(184f / 93f)
                     .semantics {
                         contentDescription = "Infinite Track splash animation"
+                    }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Infinite Track",
+                style = headline2,
+                color = Blue_500,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .alpha(brandAlpha)
+                    .offset(y = brandOffsetY.dp)
+                    .semantics {
+                        contentDescription = "Infinite Track"
                     }
             )
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,12 +3,15 @@
 
     <style name="Theme.Infinite_Track" parent="android:Theme.Material.Light.NoActionBar" />
 
-    <!-- Splash Screen Theme.
-         Native splash cannot be literally transparent; use soft tone + transparent
-         icon so handoff into Compose branded splash is less abrupt. -->
+    <!--
+      Native splash must be Theme.SplashScreen and applied on MainActivity.
+      Keep it visually close to the first Compose frame so handoff is a single continuous splash,
+      not a system default splash followed by a branded Compose splash.
+    -->
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
+        <item name="windowSplashScreenAnimationDuration">0</item>
         <item name="postSplashScreenTheme">@style/Theme.Infinite_Track</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- **Fix double splash:** `MainActivity` now uses `Theme.App.Starting` (was `Theme.Infinite_Track`), so Android system splash and Compose branded splash are one continuous handoff.
- **Instant native exit:** `setOnExitAnimationListener { remove() }` + `windowSplashScreenAnimationDuration=0` remove the default fade that felt like a second splash.
- **Shorter duration:** Lottie `speed = 2f` (~1.9s instead of ~3.77s) while still playing once and holding final frame.
- **Brand text:** animated \"Infinite Track\" using existing `headline2` + `Blue_500` theme tokens.

## Root cause
1. Manifest activity theme was still the normal app theme → Android default splash appearance, then Compose branded splash.
2. Full-speed Lottie (~3.77s) felt too long when session already resolved.
3. Brand title was missing after removing \"Sync Profile\".

## Test plan
- [x] `./gradlew --no-daemon app:compileDebugKotlin` PASS
- [ ] Cold start: no obvious system-default splash before branded splash
- [ ] Cold start valid session → short branded animation + \"Infinite Track\" text → Home
- [ ] Cold start invalid session → same → Login
- [ ] TemporaryFailure still shows Retry/Login after animation
- [ ] Transparent global BaseLayout still visible behind splash

Related: INF-241 follow-up polish