### PR TITLE
feat: redesign attendance timeline and home report card

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.attendanceModeColor
 
 @Composable
 fun InfiniteAttendanceModeDistributionCard(
@@ -41,14 +42,14 @@ fun InfiniteAttendanceModeDistributionCard(
                 label = "WFO",
                 count = wfoCount,
                 total = totalKnown,
-                color = InfiniteColors.Primary,
+                color = attendanceModeColor("wfo"),
                 unitLabel = "days"
             )
             InfiniteAttendanceModeDistributionRow(
                 label = "WFA",
                 count = wfaCount,
                 total = totalKnown,
-                color = InfiniteColors.Accent,
+                color = attendanceModeColor("wfa"),
                 unitLabel = "days"
             )
             wfhCount?.let { count ->
@@ -56,7 +57,7 @@ fun InfiniteAttendanceModeDistributionCard(
                     label = "WFH",
                     count = count,
                     total = totalKnown,
-                    color = InfiniteColors.Secondary,
+                    color = attendanceModeColor("wfh"),
                     unitLabel = "days"
                 )
             } ?: unavailableModeMessage?.let { message ->

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendancePeriodFilter.kt
@@ -10,8 +10,7 @@ import com.example.infinite_track.domain.model.attendance.AttendancePeriod
 val attendanceReportPeriodOptions = listOf(
     InfiniteFilterOption(AttendancePeriod.DAILY, "Daily"),
     InfiniteFilterOption(AttendancePeriod.WEEKLY, "Weekly"),
-    InfiniteFilterOption(AttendancePeriod.MONTHLY, "Monthly"),
-    InfiniteFilterOption(AttendancePeriod.CUSTOM, "Custom")
+    InfiniteFilterOption(AttendancePeriod.MONTHLY, "Monthly")
 )
 
 @Composable

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.attendanceModeColor
 
 @Composable
 fun InfiniteAttendanceTimelineCard(
@@ -16,7 +17,9 @@ fun InfiniteAttendanceTimelineCard(
     modifier: Modifier = Modifier,
     connectorPosition: TimelineConnectorPosition = TimelineConnectorPosition.None,
     workHourLabel: String? = null,
-    locationLabel: String? = null
+    locationLabel: String? = null,
+    showModeLabel: Boolean = false,
+    modeKey: String? = null
 ) {
     InfiniteTimelineRow(
         dateLabel = dateLabel,
@@ -29,6 +32,8 @@ fun InfiniteAttendanceTimelineCard(
         supportingText = locationLabel?.takeIf { it.isNotBlank() } ?: workHourLabel,
         supportingMaxLines = 1,
         supportingOverflow = TextOverflow.Ellipsis,
-        supportingColor = InfiniteColors.AttendanceReportMutedText
+        supportingColor = InfiniteColors.AttendanceReportMutedText,
+        showModeLabel = showModeLabel,
+        modeAccentColor = attendanceModeColor(modeKey ?: modeLabel)
     )
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
@@ -30,8 +30,9 @@ fun InfiniteAttendanceTimelineSection(
     attendanceState: UiState<List<AttendanceRecord>>,
     onSeeAllClick: () -> Unit,
     modifier: Modifier = Modifier,
-    title: String = "Attendance TimeLine",
-    maxItems: Int = 3
+    title: String = "Attendance Timeline",
+    maxItems: Int = 3,
+    showModeLabel: Boolean = false
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -86,7 +87,9 @@ fun InfiniteAttendanceTimelineSection(
                                 statusVariant = status.kind.toTimelineVariant(),
                                 connectorPosition = connectorPositionFor(index, timelineItems.size),
                                 workHourLabel = attendance.toReportWorkHourLabel(),
-                                locationLabel = attendance.location
+                                locationLabel = attendance.location,
+                                showModeLabel = showModeLabel,
+                                modeKey = attendance.modeKey ?: attendance.modeLabel
                             )
                         }
                     }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
@@ -56,9 +56,16 @@ fun InfiniteTimelineRow(
     supportingText: String? = null,
     supportingColor: Color = InfiniteColors.AttendanceReportMutedText,
     supportingMaxLines: Int = 1,
-    supportingOverflow: TextOverflow = TextOverflow.Ellipsis
+    supportingOverflow: TextOverflow = TextOverflow.Ellipsis,
+    showModeLabel: Boolean = false,
+    modeAccentColor: Color? = null
 ) {
-    val accentColor = timelineAccentColor(statusVariant)
+    val accentColor = modeAccentColor ?: timelineAccentColor(statusVariant)
+    val primaryLine = if (showModeLabel && modeLabel.isNotBlank()) {
+        "$dateLabel · $modeLabel · $timeRange"
+    } else {
+        "$dateLabel · $timeRange"
+    }
 
     Row(
         modifier = modifier
@@ -74,9 +81,9 @@ fun InfiniteTimelineRow(
         Spacer(modifier = Modifier.width(12.dp))
         Surface(
             modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(20.dp),
-            color = InfiniteColors.Surface.copy(alpha = 0.64f),
-            border = BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder)
+            shape = RoundedCornerShape(22.dp),
+            color = InfiniteColors.Surface.copy(alpha = 0.58f),
+            border = BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder.copy(alpha = 0.92f))
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
@@ -85,9 +92,9 @@ fun InfiniteTimelineRow(
             ) {
                 leadingIcon?.let {
                     Surface(
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier.size(38.dp),
                         shape = RoundedCornerShape(14.dp),
-                        color = InfiniteColors.Surface.copy(alpha = 0.85f),
+                        color = accentColor.copy(alpha = 0.12f),
                         border = BorderStroke(1.dp, accentColor.copy(alpha = 0.18f))
                     ) {
                         Box(contentAlignment = Alignment.Center) {
@@ -95,7 +102,7 @@ fun InfiniteTimelineRow(
                                 imageVector = it,
                                 contentDescription = null,
                                 tint = accentColor,
-                                modifier = Modifier.size(22.dp)
+                                modifier = Modifier.size(20.dp)
                             )
                         }
                     }
@@ -103,13 +110,13 @@ fun InfiniteTimelineRow(
 
                 Column(
                     modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
                 ) {
                     Text(
-                        text = "$dateLabel · $modeLabel · $timeRange",
+                        text = primaryLine,
                         color = InfiniteColors.Text,
                         style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
+                        fontWeight = FontWeight.SemiBold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -126,7 +133,8 @@ fun InfiniteTimelineRow(
 
                 InfiniteStatusPill(
                     label = statusLabel,
-                    variant = statusVariant
+                    variant = statusVariant,
+                    useSharedRequestPalette = true
                 )
             }
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
@@ -12,12 +12,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
+import com.example.infinite_track.presentation.theme.toAttendanceBadgeColor
 
 enum class InfiniteStatusVariant {
     Active,
@@ -49,10 +51,37 @@ fun InfiniteStatusPill(
     modifier: Modifier = Modifier,
     size: InfiniteSize = InfiniteSize.Medium,
     leadingIcon: ImageVector? = null,
-    selected: Boolean = false
+    selected: Boolean = false,
+    /**
+     * When true, reuse the same badge palette as WFA request status pills
+     * (Status_Approved / Status_Pending / Status_Rejected / Status_Default).
+     */
+    useSharedRequestPalette: Boolean = false,
+    colorOverride: Color? = null
 ) {
+    val sharedColor = colorOverride ?: variant.toAttendanceBadgeColor()
     val semantic = variant.toSemantic()
-    val colors = infiniteSemanticColors(semantic)
+    val semanticColors = infiniteSemanticColors(semantic)
+    val containerColor = if (useSharedRequestPalette || colorOverride != null) {
+        sharedColor.copy(alpha = 0.13f)
+    } else {
+        semanticColors.container
+    }
+    val contentColor = if (useSharedRequestPalette || colorOverride != null) {
+        sharedColor
+    } else {
+        semanticColors.content
+    }
+    val borderColor = if (useSharedRequestPalette || colorOverride != null) {
+        sharedColor.copy(alpha = 0.35f)
+    } else {
+        semanticColors.border
+    }
+    val iconTint = if (useSharedRequestPalette || colorOverride != null) {
+        sharedColor
+    } else {
+        semanticColors.accent
+    }
     val horizontal = when (size) {
         InfiniteSize.Small -> 8.dp
         InfiniteSize.Medium -> 10.dp
@@ -66,9 +95,9 @@ fun InfiniteStatusPill(
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(999.dp),
-        color = colors.container,
-        contentColor = colors.content,
-        border = BorderStroke(if (selected) 1.5.dp else 1.dp, colors.border)
+        color = containerColor,
+        contentColor = contentColor,
+        border = BorderStroke(if (selected) 1.5.dp else 1.dp, borderColor)
     ) {
         Row(
             modifier = Modifier.padding(horizontal = horizontal, vertical = vertical),
@@ -76,9 +105,12 @@ fun InfiniteStatusPill(
             verticalAlignment = Alignment.CenterVertically
         ) {
             leadingIcon?.let {
-                Icon(imageVector = it, contentDescription = null, tint = colors.accent, modifier = Modifier.size(14.dp))
+                Icon(imageVector = it, contentDescription = null, tint = iconTint, modifier = Modifier.size(14.dp))
             }
-            Text(text = label)
+            Text(
+                text = label,
+                fontWeight = if (useSharedRequestPalette || colorOverride != null) FontWeight.Bold else FontWeight.Normal
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/MainContentNavGraph.kt
@@ -49,7 +49,7 @@ fun NavGraphBuilder.mainContentNavGraph(
             viewModel = homeViewModel,
             navigateAttendance = { navController.safeNavigate(Screen.AttendancePermissionReadiness.route) },
             navigateTimeOffRequest = { navController.safeNavigate(Screen.TimeOffRequest.route) },
-            navigateListMyAttendance = { navController.safeNavigate(Screen.DetailMyAttendance.route) },
+            navigateListMyAttendance = { navController.safeNavigate(Screen.History.route) },
             navigateServiceComingSoon = { navController.safeNavigate(Screen.CompanyServiceComingSoon.route) }
         )
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -157,15 +157,6 @@ fun HistoryScreen(
                 )
             }
 
-            if (uiState.selectedPeriod == AttendancePeriod.CUSTOM) {
-                item {
-                    InfiniteAttendanceReportNoticeCard(
-                        title = "Custom range needs verification",
-                        message = "Date range picker is not available in this branch yet. The Custom filter is visible for the report contract, but runtime date-range behavior still needs verification."
-                    )
-                }
-            }
-
             if (uiState.isRefreshing) {
                 item {
                     InfiniteGlassReportCard {
@@ -175,17 +166,6 @@ fun HistoryScreen(
             }
 
             when {
-                uiState.selectedPeriod == AttendancePeriod.CUSTOM -> {
-                    item {
-                        InfiniteGlassReportCard {
-                            InfiniteEmptyState(
-                                title = "Custom report not available yet",
-                                message = "Choose Daily, Weekly, or Monthly to load backend report data while Custom range support is awaiting verification."
-                            )
-                        }
-                    }
-                }
-
                 uiState.isLoading && uiState.records.isEmpty() -> {
                     item {
                         InfiniteGlassReportCard {
@@ -284,14 +264,6 @@ fun HistoryScreen(
                         }
                     }
 
-                    if (uiState.isLoadingMore) {
-                        item {
-                            InfiniteGlassReportCard {
-                                InfiniteLoadingState(message = "Loading more attendance records...")
-                            }
-                        }
-                    }
-
                     if (uiState.error != null && uiState.records.isNotEmpty()) {
                         item {
                             InfiniteAttendanceReportNoticeCard(
@@ -320,7 +292,9 @@ private fun ReportTimelineRow(
         statusVariant = status.kind.toInfiniteStatusVariant(),
         connectorPosition = connectorPosition,
         workHourLabel = record.toReportWorkHourLabel(),
-        locationLabel = record.location
+        locationLabel = record.location,
+        showModeLabel = false,
+        modeKey = record.modeKey ?: record.modeLabel
     )
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
@@ -33,7 +33,7 @@ data class HistoryScreenState(
     val summary: AttendanceSummaryInfo? = null,
     val records: List<AttendanceRecord> = emptyList(),
     val currentPage: Int = 1,
-    val pageSize: Int = 10
+    val pageSize: Int = 3
 )
 
 @HiltViewModel
@@ -59,6 +59,7 @@ class HistoryViewModel @Inject constructor(
      * @param newPeriod The new period to filter by (e.g., "daily", "weekly", "monthly")
      */
     fun onFilterChanged(newPeriod: String) {
+        if (newPeriod == AttendancePeriod.CUSTOM) return
         if (newPeriod != uiState.value.selectedPeriod) {
             loadingJob?.cancel()
 
@@ -68,33 +69,23 @@ class HistoryViewModel @Inject constructor(
                 periodInfo = null,
                 summary = null,
                 currentPage = 1,
-                canLoadMore = newPeriod != AttendancePeriod.CUSTOM,
+                canLoadMore = false,
                 isLoading = false,
                 isRefreshing = false,
                 isLoadingMore = false,
                 error = null
             )}
 
-            // Custom range is visible for the report contract, but it needs a date range picker
-            // before it can request backend data honestly.
-            if (newPeriod != AttendancePeriod.CUSTOM) {
-                loadHistory(isRefresh = true)
-            }
+            loadHistory(isRefresh = true)
         }
     }
 
     /**
-     * Load the next page of attendance history
+     * History interface intentionally shows only the latest 3 records.
+     * Pagination is disabled for this screen.
      */
     fun loadNextPage() {
-        val currentState = uiState.value
-
-        if (!currentState.isLoadingMore && currentState.canLoadMore) {
-            _uiState.update { it.copy(
-                currentPage = it.currentPage + 1
-            )}
-            loadHistory(isRefresh = false)
-        }
+        // no-op: max 3 items on history interface
     }
 
     /**
@@ -198,14 +189,20 @@ class HistoryViewModel @Inject constructor(
 
                 // Update state with the loaded data
                 _uiState.update { currentState ->
+                    val mergedRecords = if (isRefresh) {
+                        historyPage.records
+                    } else {
+                        currentState.records + historyPage.records
+                    }
                     currentState.copy(
                         isLoading = false,
                         isRefreshing = false,
                         isLoadingMore = false,
                         periodInfo = historyPage.period,
                         summary = historyPage.summary,
-                        records = if (isRefresh) historyPage.records else currentState.records + historyPage.records,
-                        canLoadMore = historyPage.pagination.hasNextPage
+                        // History interface intentionally keeps only the latest 3 records.
+                        records = mergedRecords.take(3),
+                        canLoadMore = false
                     )
                 }
             }.onFailure { error ->

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeScreen.kt
@@ -42,6 +42,8 @@ fun HomeScreen(
 ) {
     val userProfile by viewModel.userProfileState.collectAsState()
     val attendanceState by viewModel.topAttendanceHistoryState.collectAsState()
+    val attendanceSummaryState by viewModel.topAttendanceSummaryState.collectAsState()
+    val attendancePeriodInfo by viewModel.topAttendancePeriodInfo.collectAsState()
     val currentLocation by viewModel.currentAddressState.collectAsState()
     val todayStatusState by viewModel.todayStatusState.collectAsState()
 
@@ -109,6 +111,8 @@ fun HomeScreen(
                                     user = userProfile,
                                     currentLocation = currentLocation,
                                     attendanceState = attendanceState,
+                                    attendanceSummaryState = attendanceSummaryState,
+                                    attendancePeriodInfo = attendancePeriodInfo,
                                     todayStatusState = todayStatusState,
                                     navigateToListMyAttendance = navigateListMyAttendance
                                 )
@@ -118,6 +122,8 @@ fun HomeScreen(
                                 EmployeeAndManagerComponent(
                                     user = userProfile,
                                     attendanceState = attendanceState,
+                                    attendanceSummaryState = attendanceSummaryState,
+                                    attendancePeriodInfo = attendancePeriodInfo,
                                     todayStatusState = todayStatusState,
                                     currentLocation = currentLocation,
                                     isLoading = isLoading,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/HomeViewModel.kt
@@ -3,7 +3,9 @@ package com.example.infinite_track.presentation.screen.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.infinite_track.domain.model.attendance.AttendancePeriod
+import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
 import com.example.infinite_track.domain.model.attendance.TodayStatus
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.domain.model.booking.BookingHistoryItem
@@ -43,6 +45,14 @@ class HomeViewModel @Inject constructor(
 		MutableStateFlow<UiState<List<AttendanceRecord>>>(UiState.Loading)
 	val topAttendanceHistoryState: StateFlow<UiState<List<AttendanceRecord>>> =
 		_topAttendanceHistoryState
+
+	private val _topAttendanceSummaryState =
+		MutableStateFlow<UiState<AttendanceSummaryInfo>>(UiState.Loading)
+	val topAttendanceSummaryState: StateFlow<UiState<AttendanceSummaryInfo>> =
+		_topAttendanceSummaryState
+
+	private val _topAttendancePeriodInfo = MutableStateFlow<AttendancePeriodInfo?>(null)
+	val topAttendancePeriodInfo: StateFlow<AttendancePeriodInfo?> = _topAttendancePeriodInfo
 
 	// Location state
 	private val _currentAddressState = MutableStateFlow("Loading...")
@@ -86,16 +96,20 @@ class HomeViewModel @Inject constructor(
 	private fun fetchTopAttendanceHistory() {
 		viewModelScope.launch {
 			_topAttendanceHistoryState.value = UiState.Loading
+			_topAttendanceSummaryState.value = UiState.Loading
 
 			getAttendanceHistoryUseCase(
 				period = AttendancePeriod.MONTHLY,
 				page = 1,
-				limit = 5
+				limit = 3
 			).onSuccess { historyPage ->
-				_topAttendanceHistoryState.value = UiState.Success(historyPage.records)
+				_topAttendanceHistoryState.value = UiState.Success(historyPage.records.take(3))
+				_topAttendanceSummaryState.value = UiState.Success(historyPage.summary)
+				_topAttendancePeriodInfo.value = historyPage.period
 			}.onFailure { error ->
-				_topAttendanceHistoryState.value =
-					UiState.Error(error.message ?: "Unknown error occurred")
+				val message = error.message ?: "Unknown error occurred"
+				_topAttendanceHistoryState.value = UiState.Error(message)
+				_topAttendanceSummaryState.value = UiState.Error(message)
 			}
 		}
 	}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
 import com.example.infinite_track.presentation.components.tittle.Location
@@ -28,6 +30,8 @@ fun EmployeeAndManagerComponent(
     modifier: Modifier = Modifier,
     user: UserModel?,
     attendanceState: UiState<List<AttendanceRecord>>,
+    attendanceSummaryState: UiState<AttendanceSummaryInfo>,
+    attendancePeriodInfo: AttendancePeriodInfo?,
     todayStatusState: HomeTodayStatusUiState,
     currentLocation: String,
     isLoading: Boolean = false,
@@ -78,6 +82,14 @@ fun EmployeeAndManagerComponent(
 
                 Spacer(modifier.height(14.dp))
 
+                HomeAttendanceReportSummaryCard(
+                    summaryState = attendanceSummaryState,
+                    periodInfo = attendancePeriodInfo,
+                    onViewReportClick = navigateListMyAttendance
+                )
+
+                Spacer(modifier.height(14.dp))
+
                 if (isLoading) {
                     Box(
                         modifier = Modifier
@@ -90,7 +102,8 @@ fun EmployeeAndManagerComponent(
                 } else {
                     InfiniteAttendanceTimelineSection(
                         attendanceState = attendanceState,
-                        maxItems = 5,
+                        maxItems = 3,
+                        showModeLabel = false,
                         onSeeAllClick = navigateListMyAttendance
                     )
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
@@ -1,0 +1,158 @@
+package com.example.infinite_track.presentation.screen.home.content
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material.icons.outlined.QueryStats
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.rounded.BarChart
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
+import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
+import com.example.infinite_track.presentation.design.components.data.InfiniteGlassReportCard
+import com.example.infinite_track.presentation.design.components.data.InfiniteMetricCard
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.utils.UiState
+
+@Composable
+fun HomeAttendanceReportSummaryCard(
+    summaryState: UiState<AttendanceSummaryInfo>,
+    periodInfo: AttendancePeriodInfo?,
+    onViewReportClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    InfiniteGlassReportCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onViewReportClick)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.BarChart,
+                    contentDescription = null,
+                    tint = InfiniteColors.Primary
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "My Attendance Report",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = InfiniteColors.Text,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = periodInfo?.label ?: "This Month",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = InfiniteColors.AttendanceReportMutedText
+                    )
+                }
+            }
+
+            when (summaryState) {
+                is UiState.Loading -> {
+                    Text(
+                        text = "Loading attendance summary...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = InfiniteColors.AttendanceReportMutedText
+                    )
+                }
+
+                is UiState.Error -> {
+                    Text(
+                        text = summaryState.errorMessage,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = InfiniteColors.Error
+                    )
+                }
+
+                is UiState.Success -> {
+                    val summary = summaryState.data
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        InfiniteMetricCard(
+                            title = "Attendance Rate",
+                            value = summary.attendanceRateLabel ?: "—",
+                            subtitle = null,
+                            icon = Icons.Outlined.QueryStats,
+                            semantic = InfiniteSemantic.Primary,
+                            modifier = Modifier.weight(1f)
+                        )
+                        InfiniteMetricCard(
+                            title = "Late",
+                            value = "${summary.totalLate} times",
+                            subtitle = null,
+                            icon = Icons.Outlined.Schedule,
+                            semantic = InfiniteSemantic.Warning,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        InfiniteMetricCard(
+                            title = "Alpha",
+                            value = "${summary.totalAlpha} day",
+                            subtitle = null,
+                            icon = Icons.Outlined.PersonOutline,
+                            semantic = InfiniteSemantic.Error,
+                            modifier = Modifier.weight(1f)
+                        )
+                        InfiniteMetricCard(
+                            title = "Work Hours",
+                            value = summary.totalWorkHoursLabel ?: "—",
+                            subtitle = null,
+                            icon = Icons.Outlined.AccessTime,
+                            semantic = InfiniteSemantic.Info,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+
+                is UiState.Idle -> Unit
+            }
+
+            Spacer(modifier = Modifier.height(2.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "View Report",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = InfiniteColors.Primary,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = InfiniteColors.Primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceRecord
+import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
 import com.example.infinite_track.domain.model.auth.UserModel
 import com.example.infinite_track.presentation.components.tittle.Location
 import com.example.infinite_track.presentation.components.tittle.nameCards
@@ -25,6 +27,8 @@ fun InternshipContent(
     user: UserModel?,
     currentLocation: String,
     attendanceState: UiState<List<AttendanceRecord>>,
+    attendanceSummaryState: UiState<AttendanceSummaryInfo>,
+    attendancePeriodInfo: AttendancePeriodInfo?,
     todayStatusState: HomeTodayStatusUiState,
     navigateToListMyAttendance: () -> Unit
 ) {
@@ -63,9 +67,18 @@ fun InternshipContent(
 
             Spacer(modifier = Modifier.height(14.dp))
 
+            HomeAttendanceReportSummaryCard(
+                summaryState = attendanceSummaryState,
+                periodInfo = attendancePeriodInfo,
+                onViewReportClick = navigateToListMyAttendance
+            )
+
+            Spacer(modifier = Modifier.height(14.dp))
+
             InfiniteAttendanceTimelineSection(
                 attendanceState = attendanceState,
                 maxItems = 3,
+                showModeLabel = false,
                 onSeeAllClick = navigateToListMyAttendance
             )
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/details/DetailsMyAttendance.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/details/DetailsMyAttendance.kt
@@ -95,23 +95,6 @@ fun DetailsMyAttendance(
 
 				// Display loading, error, or content based on UI state
 				when {
-					uiState.selectedPeriod == AttendancePeriod.CUSTOM -> {
-						Box(
-							modifier = Modifier.fillMaxSize(),
-							contentAlignment = Alignment.Center
-						) {
-							Column(
-								horizontalAlignment = Alignment.CenterHorizontally,
-							) {
-								EmptyListAnimation(modifier = Modifier.size(150.dp))
-								Text(
-									text = "Custom attendance range is not available yet.",
-									style = headline4,
-								)
-							}
-						}
-					}
-
 					uiState.isLoading && uiState.records.isEmpty() -> {
 						Box(
 							modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
@@ -177,6 +177,7 @@ fun WfaRequestCard(
 
 @Composable
 private fun StatusPill(label: String, color: Color) {
+    // Keep the same visual contract as InfiniteStatusPill shared request palette.
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(50.dp))

--- a/app/src/main/java/com/example/infinite_track/presentation/theme/StatusColors.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/theme/StatusColors.kt
@@ -1,8 +1,13 @@
 package com.example.infinite_track.presentation.theme
 
 import androidx.compose.ui.graphics.Color
+import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import java.util.Locale
 
+/**
+ * Shared status color for WFA request badges and other request-like statuses.
+ */
 fun requestStatusColor(statusKey: String?): Color {
     return when (statusKey.orEmpty().lowercase(Locale.getDefault())) {
         "approved" -> Status_Approved
@@ -10,4 +15,75 @@ fun requestStatusColor(statusKey: String?): Color {
         "pending" -> Status_Pending
         else -> Status_Default
     }
+}
+
+/**
+ * Shared attendance mode colors for mode bars + timeline markers/icons.
+ * Keep WFO/WFA/WFH mapping in one place only.
+ */
+fun attendanceModeColor(mode: String?): Color {
+    val normalized = mode.orEmpty().lowercase(Locale.getDefault())
+    return when {
+        normalized.contains("wfh") || normalized.contains("home") -> InfiniteColors.Secondary
+        normalized.contains("wfa") || normalized.contains("anywhere") -> InfiniteColors.Accent
+        normalized.contains("wfo") || normalized.contains("office") -> InfiniteColors.Primary
+        else -> InfiniteColors.Primary
+    }
+}
+
+/**
+ * Shared attendance status badge color, aligned with WFA request badge palette.
+ */
+fun attendanceStatusColor(statusKey: String?): Color {
+    val normalized = statusKey.orEmpty().lowercase(Locale.getDefault())
+    return when {
+        normalized.contains("ontime") ||
+            normalized.contains("on_time") ||
+            normalized.contains("on-time") ||
+            normalized.contains("on time") ||
+            normalized.contains("completed") ||
+            normalized.contains("approved") -> Status_Approved
+
+        normalized.contains("late") ||
+            normalized.contains("early") ||
+            normalized.contains("pending") ||
+            normalized.contains("needs") -> Status_Pending
+
+        normalized.contains("alpha") ||
+            normalized.contains("absent") ||
+            normalized.contains("reject") ||
+            normalized.contains("error") -> Status_Rejected
+
+        normalized.contains("active") -> Status_Default
+        else -> Status_Default
+    }
+}
+
+/**
+ * Shared badge color for InfiniteStatusVariant, reusing WFA request badge palette.
+ */
+fun InfiniteStatusVariant.toAttendanceBadgeColor(): Color = when (this) {
+    InfiniteStatusVariant.OnTime,
+    InfiniteStatusVariant.Completed,
+    InfiniteStatusVariant.Approved,
+    InfiniteStatusVariant.Excellent,
+    InfiniteStatusVariant.PdfReady -> Status_Approved
+
+    InfiniteStatusVariant.Late,
+    InfiniteStatusVariant.Early,
+    InfiniteStatusVariant.Pending,
+    InfiniteStatusVariant.NeedsReview -> Status_Pending
+
+    InfiniteStatusVariant.Alpha,
+    InfiniteStatusVariant.Rejected,
+    InfiniteStatusVariant.Outside -> Status_Rejected
+
+    InfiniteStatusVariant.Active,
+    InfiniteStatusVariant.Recommended,
+    InfiniteStatusVariant.Good,
+    InfiniteStatusVariant.Inside,
+    InfiniteStatusVariant.NotStarted,
+    InfiniteStatusVariant.Unavailable,
+    InfiniteStatusVariant.Unknown,
+    InfiniteStatusVariant.Neutral -> Status_Default
 }


### PR DESCRIPTION
## Summary
- Redesign Attendance Timeline for Home/History to match the denser reference layout without forcing unsupported glass effects.
- Remove WFO/WFA/WFH text from timeline content and represent mode through shared accent colors.
- Reuse shared status badge palette for timeline badges, aligned with WFA request badge colors.
- Add Home "My Attendance Report" summary card above the timeline using existing report components.
- Route See More / View Report to History tab and limit Home/History lists to the latest 3 items.
- Remove Custom period filter from History interface.

## Scope notes
- No backend/auth/session changes.
- No PDF export logic changes.
- Focused on presentation/timeline/home report surface consistency.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Timeline rows no longer show WFO/WFA/WFH text
- Mode colors match Attendance Mode bars
- Status badges match WFA request badge palette
- Home shows report summary card above timeline
- Home timeline max 3 items
- History timeline max 3 items
- Custom filter removed from History
- See More / View Report navigates to History

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “My Attendance Report” card to the home screen with attendance rate, lateness, absence, and work-hour summaries.
  * Attendance visuals now use consistent colors for work modes and statuses.
  * Timeline entries can display attendance mode labels when enabled.
* **Changes**
  * History now shows only the latest three records; custom date ranges and pagination are no longer available.
  * Improved timeline and status badge styling.
  * Home report navigation now opens the History screen.
  * Corrected the “Attendance Timeline” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->