### PR TITLE
fix: redesign home report summary and timeline surfaces

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,8 +22,10 @@ import com.example.infinite_track.domain.model.attendance.AttendanceReportStatus
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
-import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.utils.UiState
 
 @Composable
@@ -57,57 +60,59 @@ fun InfiniteAttendanceTimelineSection(
 
             is UiState.Success -> {
                 if (attendanceState.data.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            EmptyListAnimation(modifier = Modifier.size(150.dp))
+                    InfiniteGlassReportCard {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            EmptyListAnimation(modifier = Modifier.size(120.dp))
                             Text(
                                 text = "No attendance records found",
-                                style = headline4,
+                                style = body2,
+                                color = Purple_300
                             )
                         }
                     }
                 } else {
                     val timelineItems = attendanceState.data.take(maxItems)
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        timelineItems.forEachIndexed { index, attendance ->
-                            val status = attendance.toReportStatus()
-                            InfiniteAttendanceTimelineCard(
-                                dateLabel = attendance.toReportDateLabel(),
-                                modeLabel = attendance.toReportWorkModeLabel(),
-                                timeRange = attendance.toReportTimeRangeLabel(),
-                                statusLabel = status.label,
-                                statusVariant = status.kind.toTimelineVariant(),
-                                connectorPosition = connectorPositionFor(index, timelineItems.size),
-                                workHourLabel = attendance.toReportWorkHourLabel(),
-                                locationLabel = attendance.location,
-                                showModeLabel = showModeLabel,
-                                modeKey = attendance.modeKey ?: attendance.modeLabel
-                            )
+                    InfiniteGlassReportCard {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            timelineItems.forEachIndexed { index, attendance ->
+                                val status = attendance.toReportStatus()
+                                InfiniteAttendanceTimelineCard(
+                                    dateLabel = attendance.toReportDateLabel(),
+                                    modeLabel = attendance.toReportWorkModeLabel(),
+                                    timeRange = attendance.toReportTimeRangeLabel(),
+                                    statusLabel = status.label,
+                                    statusVariant = status.kind.toTimelineVariant(),
+                                    connectorPosition = connectorPositionFor(index, timelineItems.size),
+                                    workHourLabel = attendance.toReportWorkHourLabel(),
+                                    locationLabel = attendance.location,
+                                    showModeLabel = showModeLabel,
+                                    modeKey = attendance.modeKey ?: attendance.modeLabel
+                                )
+                                if (index != timelineItems.lastIndex) {
+                                    HorizontalDivider(
+                                        color = InfiniteColors.AttendanceReportGlassBorder
+                                    )
+                                }
+                            }
                         }
                     }
                 }
             }
 
             is UiState.Error -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 24.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        EmptyListAnimation(modifier = Modifier.size(150.dp))
+                InfiniteGlassReportCard {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        EmptyListAnimation(modifier = Modifier.size(120.dp))
                         Text(
                             text = attendanceState.errorMessage,
-                            style = headline4,
+                            style = body2,
+                            color = Purple_300
                         )
                     }
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
@@ -1,26 +1,22 @@
 package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,12 +24,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 
 enum class TimelineConnectorPosition {
     None,
@@ -54,13 +54,13 @@ fun InfiniteTimelineRow(
     connectorPosition: TimelineConnectorPosition = TimelineConnectorPosition.None,
     onClick: (() -> Unit)? = null,
     supportingText: String? = null,
-    supportingColor: Color = InfiniteColors.AttendanceReportMutedText,
+    supportingColor: Color = Purple_300,
     supportingMaxLines: Int = 1,
     supportingOverflow: TextOverflow = TextOverflow.Ellipsis,
     showModeLabel: Boolean = false,
     modeAccentColor: Color? = null
 ) {
-    val accentColor = modeAccentColor ?: timelineAccentColor(statusVariant)
+    val accentColor = modeAccentColor ?: InfiniteColors.Primary
     val primaryLine = if (showModeLabel && modeLabel.isNotBlank()) {
         "$dateLabel · $modeLabel · $timeRange"
     } else {
@@ -70,123 +70,99 @@ fun InfiniteTimelineRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 2.dp),
+            .height(64.dp)
+            .padding(horizontal = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        TimelineMarker(
+        TimelineRail(
             connectorPosition = connectorPosition,
-            leadingIcon = leadingIcon,
-            accentColor = accentColor
+            accentColor = accentColor,
+            leadingIcon = leadingIcon
         )
+
         Spacer(modifier = Modifier.width(12.dp))
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(22.dp),
-            color = InfiniteColors.Surface.copy(alpha = 0.58f),
-            border = BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder.copy(alpha = 0.92f))
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                leadingIcon?.let {
-                    Surface(
-                        modifier = Modifier.size(38.dp),
-                        shape = RoundedCornerShape(14.dp),
-                        color = accentColor.copy(alpha = 0.12f),
-                        border = BorderStroke(1.dp, accentColor.copy(alpha = 0.18f))
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = it,
-                                contentDescription = null,
-                                tint = accentColor,
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
-                    }
-                }
-
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
-                    Text(
-                        text = primaryLine,
-                        color = InfiniteColors.Text,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    supportingText?.let {
-                        Text(
-                            text = it,
-                            color = supportingColor,
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = supportingMaxLines,
-                            overflow = supportingOverflow
-                        )
-                    }
-                }
-
-                InfiniteStatusPill(
-                    label = statusLabel,
-                    variant = statusVariant,
-                    useSharedRequestPalette = true
+            Text(
+                text = primaryLine,
+                style = body1,
+                color = Purple_500,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            supportingText?.let {
+                Text(
+                    text = it,
+                    style = body2,
+                    color = supportingColor,
+                    maxLines = supportingMaxLines,
+                    overflow = supportingOverflow
                 )
             }
         }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        InfiniteStatusPill(
+            label = statusLabel,
+            variant = statusVariant,
+            size = InfiniteSize.Small,
+            useSharedRequestPalette = true
+        )
     }
 }
 
 @Composable
-private fun TimelineMarker(
+private fun TimelineRail(
     connectorPosition: TimelineConnectorPosition,
-    leadingIcon: ImageVector?,
-    accentColor: Color
+    accentColor: Color,
+    leadingIcon: ImageVector?
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Canvas(modifier = Modifier.size(2.dp, 16.dp)) {
-            if (connectorPosition == TimelineConnectorPosition.Middle || connectorPosition == TimelineConnectorPosition.Last) {
+    Box(
+        modifier = Modifier
+            .width(28.dp)
+            .fillMaxHeight(),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxHeight().width(2.dp)) {
+            val x = size.width / 2f
+            val showTop = connectorPosition == TimelineConnectorPosition.Middle ||
+                connectorPosition == TimelineConnectorPosition.Last
+            val showBottom = connectorPosition == TimelineConnectorPosition.Middle ||
+                connectorPosition == TimelineConnectorPosition.First
+            if (showTop) {
                 drawLine(
-                    accentColor.copy(alpha = 0.55f),
-                    Offset(size.width / 2, 0f),
-                    Offset(size.width / 2, size.height),
+                    color = accentColor.copy(alpha = 0.45f),
+                    start = Offset(x, 0f),
+                    end = Offset(x, size.height / 2f),
+                    strokeWidth = size.width
+                )
+            }
+            if (showBottom) {
+                drawLine(
+                    color = accentColor.copy(alpha = 0.45f),
+                    start = Offset(x, size.height / 2f),
+                    end = Offset(x, size.height),
                     strokeWidth = size.width
                 )
             }
         }
+
         Box(
             modifier = Modifier
-                .size(12.dp)
-                .background(InfiniteColors.Surface, CircleShape)
-                .padding(1.dp)
+                .size(28.dp)
+                .background(accentColor.copy(alpha = 0.12f), CircleShape),
+            contentAlignment = Alignment.Center
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(accentColor, CircleShape)
+            Icon(
+                imageVector = leadingIcon ?: Icons.Rounded.CalendarMonth,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(15.dp)
             )
         }
-        Canvas(modifier = Modifier.size(2.dp, 16.dp)) {
-            if (connectorPosition == TimelineConnectorPosition.Middle || connectorPosition == TimelineConnectorPosition.First) {
-                drawLine(
-                    accentColor.copy(alpha = 0.55f),
-                    Offset(size.width / 2, 0f),
-                    Offset(size.width / 2, size.height),
-                    strokeWidth = size.width
-                )
-            }
-        }
     }
-}
-
-private fun timelineAccentColor(variant: InfiniteStatusVariant): Color = when (variant) {
-    InfiniteStatusVariant.Active -> InfiniteColors.Primary
-    InfiniteStatusVariant.OnTime -> InfiniteColors.Accent
-    InfiniteStatusVariant.Late -> InfiniteColors.Secondary
-    InfiniteStatusVariant.Alpha -> InfiniteColors.Error
-    else -> InfiniteColors.Primary
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -3,13 +3,14 @@ package com.example.infinite_track.presentation.screen.history
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -241,26 +242,35 @@ fun HistoryScreen(
                         )
                     }
 
-                    if (uiState.records.isEmpty()) {
-                        item {
+                    item {
+                        if (uiState.records.isEmpty()) {
                             InfiniteGlassReportCard {
                                 InfiniteEmptyState(
                                     title = "No attendance records found",
                                     message = "Backend did not return attendance records for this period."
                                 )
                             }
-                        }
-                    } else {
-                        itemsIndexed(uiState.records) { index, record ->
-                            ReportTimelineRow(
-                                record = record,
-                                connectorPosition = when {
-                                    uiState.records.size == 1 -> TimelineConnectorPosition.None
-                                    index == 0 -> TimelineConnectorPosition.First
-                                    index == uiState.records.lastIndex -> TimelineConnectorPosition.Last
-                                    else -> TimelineConnectorPosition.Middle
+                        } else {
+                            InfiniteGlassReportCard {
+                                Column {
+                                    uiState.records.forEachIndexed { index, record ->
+                                        ReportTimelineRow(
+                                            record = record,
+                                            connectorPosition = when {
+                                                uiState.records.size == 1 -> TimelineConnectorPosition.None
+                                                index == 0 -> TimelineConnectorPosition.First
+                                                index == uiState.records.lastIndex -> TimelineConnectorPosition.Last
+                                                else -> TimelineConnectorPosition.Middle
+                                            }
+                                        )
+                                        if (index != uiState.records.lastIndex) {
+                                            HorizontalDivider(
+                                                color = InfiniteColors.AttendanceReportGlassBorder
+                                            )
+                                        }
+                                    }
                                 }
-                            )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
@@ -1,13 +1,19 @@
 package com.example.infinite_track.presentation.screen.home.content
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.AccessTime
@@ -15,20 +21,29 @@ import androidx.compose.material.icons.outlined.PersonOutline
 import androidx.compose.material.icons.outlined.QueryStats
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.rounded.BarChart
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.data.InfiniteGlassReportCard
-import com.example.infinite_track.presentation.design.components.data.InfiniteMetricCard
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Orange_500
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Status_Approved
+import com.example.infinite_track.presentation.theme.Status_Rejected
 import com.example.infinite_track.utils.UiState
 
 @Composable
@@ -43,7 +58,7 @@ fun HomeAttendanceReportSummaryCard(
             .fillMaxWidth()
             .clickable(onClick = onViewReportClick)
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -52,90 +67,110 @@ fun HomeAttendanceReportSummaryCard(
                 Icon(
                     imageVector = Icons.Rounded.BarChart,
                     contentDescription = null,
-                    tint = InfiniteColors.Primary
+                    tint = Purple_500,
+                    modifier = Modifier.size(22.dp)
                 )
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "My Attendance Report",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = InfiniteColors.Text,
-                        fontWeight = FontWeight.SemiBold
+                        style = headline4,
+                        color = Purple_500
                     )
                     Text(
                         text = periodInfo?.label ?: "This Month",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = InfiniteColors.AttendanceReportMutedText
+                        style = body2,
+                        color = Purple_300
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(14.dp))
 
             when (summaryState) {
                 is UiState.Loading -> {
                     Text(
                         text = "Loading attendance summary...",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = InfiniteColors.AttendanceReportMutedText
+                        style = body2,
+                        color = Purple_300
                     )
                 }
 
                 is UiState.Error -> {
                     Text(
                         text = summaryState.errorMessage,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = InfiniteColors.Error
+                        style = body2,
+                        color = Status_Rejected
                     )
                 }
 
                 is UiState.Success -> {
                     val summary = summaryState.data
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        InfiniteMetricCard(
-                            title = "Attendance Rate",
-                            value = summary.attendanceRateLabel ?: "—",
-                            subtitle = null,
-                            icon = Icons.Outlined.QueryStats,
-                            semantic = InfiniteSemantic.Primary,
-                            modifier = Modifier.weight(1f)
-                        )
-                        InfiniteMetricCard(
-                            title = "Late",
-                            value = "${summary.totalLate} times",
-                            subtitle = null,
-                            icon = Icons.Outlined.Schedule,
-                            semantic = InfiniteSemantic.Warning,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        InfiniteMetricCard(
-                            title = "Alpha",
-                            value = "${summary.totalAlpha} day",
-                            subtitle = null,
-                            icon = Icons.Outlined.PersonOutline,
-                            semantic = InfiniteSemantic.Error,
-                            modifier = Modifier.weight(1f)
-                        )
-                        InfiniteMetricCard(
-                            title = "Work Hours",
-                            value = summary.totalWorkHoursLabel ?: "—",
-                            subtitle = null,
-                            icon = Icons.Outlined.AccessTime,
-                            semantic = InfiniteSemantic.Info,
-                            modifier = Modifier.weight(1f)
-                        )
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(78.dp)
+                        ) {
+                            SummaryMetricCell(
+                                title = "Attendance Rate",
+                                value = summary.attendanceRateLabel ?: "—",
+                                icon = Icons.Outlined.QueryStats,
+                                accent = Purple_500,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .width(1.dp)
+                                    .fillMaxHeight()
+                                    .background(InfiniteColors.AttendanceReportGlassBorder)
+                            )
+                            SummaryMetricCell(
+                                title = "Late",
+                                value = "${summary.totalLate} times",
+                                icon = Icons.Outlined.Schedule,
+                                accent = Orange_500,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+
+                        HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(78.dp)
+                        ) {
+                            SummaryMetricCell(
+                                title = "Alpha",
+                                value = "${summary.totalAlpha} day",
+                                icon = Icons.Outlined.PersonOutline,
+                                accent = Status_Rejected,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .width(1.dp)
+                                    .fillMaxHeight()
+                                    .background(InfiniteColors.AttendanceReportGlassBorder)
+                            )
+                            SummaryMetricCell(
+                                title = "Work Hours",
+                                value = summary.totalWorkHoursLabel ?: "—",
+                                icon = Icons.Outlined.AccessTime,
+                                accent = Status_Approved,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
                     }
                 }
 
                 is UiState.Idle -> Unit
             }
 
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.height(12.dp))
+            HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
+            Spacer(modifier = Modifier.height(10.dp))
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -143,16 +178,62 @@ fun HomeAttendanceReportSummaryCard(
             ) {
                 Text(
                     text = "View Report",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = InfiniteColors.Primary,
-                    fontWeight = FontWeight.SemiBold
+                    style = body1,
+                    color = Blue_500
                 )
                 Icon(
                     imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                     contentDescription = null,
-                    tint = InfiniteColors.Primary
+                    tint = Blue_500,
+                    modifier = Modifier.size(18.dp)
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SummaryMetricCell(
+    title: String,
+    value: String,
+    icon: ImageVector,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(accent.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(15.dp)
+                )
+            }
+            Text(
+                text = title,
+                style = body2,
+                color = Purple_300
+            )
+        }
+        Text(
+            text = value,
+            style = headline4,
+            color = accent
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Redesign Home My Attendance Report metrics into a single card separated by dividers instead of four nested cards.
- Redesign Attendance Timeline into one card with divider-separated rows.
- Connect the timeline rail to calendar icons and remove the outer pill feel.
- Use existing app typography (`headline4`, `body1`, `body2`) and theme colors.
- Shrink status badges to the existing small pill size.

## Scope notes
- Presentation-only redesign for Home/History timeline surfaces.
- No backend/auth/session changes.
- Keeps existing data attributes and routing behavior.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- My Attendance Report shows one divided card
- Timeline items are in one card separated by dividers
- Timeline line connects through calendar icons
- Badge size/font/color feel consistent with existing theme
- Home and History still show max 3 latest items

🤖 Generated with [Claude Code](https://claude.com/claude-code)