### PR TITLE
fix: polish recent attendance card and shared report summary

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -2,22 +2,30 @@ package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.WorkOutline
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.presentation.theme.attendanceModeColor
 
 @Composable
@@ -27,17 +35,39 @@ fun InfiniteAttendanceModeDistributionCard(
     modifier: Modifier = Modifier,
     wfhCount: Int? = null,
     title: String = "Attendance Mode",
-    subtitle: String? = "WFO and WFA distribution from backend summary",
-    unavailableModeMessage: String? = "WFH is not shown because total_wfh is not available in the current Android model."
+    subtitle: String? = null,
+    unavailableModeMessage: String? = null
 ) {
     val totalKnown = wfoCount + wfaCount + (wfhCount ?: 0)
 
     InfiniteGlassReportCard(modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteSectionHeader(
-                title = title,
-                subtitle = subtitle
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = title,
+                    style = headline4,
+                    color = Purple_500
+                )
+                Icon(
+                    imageVector = Icons.Outlined.WorkOutline,
+                    contentDescription = null,
+                    tint = Purple_500,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            subtitle?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    text = it,
+                    style = body2,
+                    color = Purple_300
+                )
+            }
+
             InfiniteAttendanceModeDistributionRow(
                 label = "WFO",
                 count = wfoCount,
@@ -63,8 +93,8 @@ fun InfiniteAttendanceModeDistributionCard(
             } ?: unavailableModeMessage?.let { message ->
                 Text(
                     text = message,
-                    color = InfiniteColors.AttendanceReportMutedText,
-                    style = MaterialTheme.typography.bodySmall
+                    color = Purple_300,
+                    style = body2
                 )
             }
         }
@@ -83,7 +113,7 @@ fun InfiniteAttendanceModeDistributionRow(
     val progress = if (total > 0) count.toFloat() / total.toFloat() else 0f
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -92,24 +122,30 @@ fun InfiniteAttendanceModeDistributionRow(
         ) {
             Text(
                 text = label,
-                color = InfiniteColors.Text,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium
+                color = Purple_500,
+                style = body1
             )
             Text(
                 text = "$count $unitLabel",
-                color = InfiniteColors.AttendanceReportMutedText,
-                style = MaterialTheme.typography.bodySmall
+                color = Purple_300,
+                style = body2
             )
         }
-        LinearProgressIndicator(
-            progress = { progress },
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(10.dp)
-                .background(InfiniteColors.Surface.copy(alpha = 0.62f), RoundedCornerShape(999.dp)),
-            color = color,
-            trackColor = color.copy(alpha = 0.12f)
-        )
+                .clip(RoundedCornerShape(999.dp))
+                .background(InfiniteColors.Surface.copy(alpha = 0.72f))
+        ) {
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp),
+                color = color,
+                trackColor = Color.Transparent
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummaryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummaryCard.kt
@@ -1,0 +1,248 @@
+package com.example.infinite_track.presentation.design.components.data
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.PersonOutline
+import androidx.compose.material.icons.outlined.QueryStats
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.rounded.BarChart
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
+import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Orange_500
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
+import com.example.infinite_track.presentation.theme.Status_Approved
+import com.example.infinite_track.presentation.theme.Status_Rejected
+import com.example.infinite_track.utils.UiState
+
+@Composable
+fun InfiniteAttendanceReportSummaryCard(
+    summaryState: UiState<AttendanceSummaryInfo>,
+    periodInfo: AttendancePeriodInfo?,
+    modifier: Modifier = Modifier,
+    title: String = "My Attendance Report",
+    showViewReportAction: Boolean = true,
+    onViewReportClick: (() -> Unit)? = null
+) {
+    val clickableModifier = if (showViewReportAction && onViewReportClick != null) {
+        Modifier.clickable(onClick = onViewReportClick)
+    } else {
+        Modifier
+    }
+
+    InfiniteGlassReportCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(clickableModifier)
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.BarChart,
+                    contentDescription = null,
+                    tint = Purple_500,
+                    modifier = Modifier.size(22.dp)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = headline4,
+                        color = Purple_500
+                    )
+                    Text(
+                        text = periodInfo?.label ?: "This Month",
+                        style = body2,
+                        color = Purple_300
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            when (summaryState) {
+                is UiState.Loading -> {
+                    Text(
+                        text = "Loading attendance summary...",
+                        style = body2,
+                        color = Purple_300
+                    )
+                }
+
+                is UiState.Error -> {
+                    Text(
+                        text = summaryState.errorMessage,
+                        style = body2,
+                        color = Status_Rejected
+                    )
+                }
+
+                is UiState.Success -> {
+                    val summary = summaryState.data
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(72.dp)
+                        ) {
+                            SummaryMetricCell(
+                                title = "Attendance Rate",
+                                value = summary.attendanceRateLabel ?: "—",
+                                icon = Icons.Outlined.QueryStats,
+                                accent = Purple_500,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .width(1.dp)
+                                    .fillMaxHeight()
+                                    .background(InfiniteColors.AttendanceReportGlassBorder)
+                            )
+                            SummaryMetricCell(
+                                title = "Late",
+                                value = "${summary.totalLate} times",
+                                icon = Icons.Outlined.Schedule,
+                                accent = Orange_500,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+
+                        HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(72.dp)
+                        ) {
+                            SummaryMetricCell(
+                                title = "Alpha",
+                                value = "${summary.totalAlpha} day",
+                                icon = Icons.Outlined.PersonOutline,
+                                accent = Status_Rejected,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .width(1.dp)
+                                    .fillMaxHeight()
+                                    .background(InfiniteColors.AttendanceReportGlassBorder)
+                            )
+                            SummaryMetricCell(
+                                title = "Work Hours",
+                                value = summary.totalWorkHoursLabel ?: "—",
+                                icon = Icons.Outlined.AccessTime,
+                                accent = Status_Approved,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                    }
+                }
+
+                is UiState.Idle -> Unit
+            }
+
+            if (showViewReportAction) {
+                Spacer(modifier = Modifier.height(10.dp))
+                HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "View Report",
+                        style = body1,
+                        color = Blue_500
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = Blue_500,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SummaryMetricCell(
+    title: String,
+    value: String,
+    icon: ImageVector,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(26.dp)
+                    .clip(CircleShape)
+                    .background(accent.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+            Text(
+                text = title,
+                style = body2,
+                color = Purple_300
+            )
+        }
+        Text(
+            text = value,
+            style = headline4,
+            color = accent
+        )
+    }
+}

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceTimelineSection.kt
@@ -1,12 +1,19 @@
 package com.example.infinite_track.presentation.design.components.data
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,10 +29,14 @@ import com.example.infinite_track.domain.model.attendance.AttendanceReportStatus
 import com.example.infinite_track.presentation.components.button.SeeAllButton
 import com.example.infinite_track.presentation.components.empty.EmptyListAnimation
 import com.example.infinite_track.presentation.components.loading.LoadingAnimation
+import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.utils.UiState
 
 @Composable
@@ -33,25 +44,29 @@ fun InfiniteAttendanceTimelineSection(
     attendanceState: UiState<List<AttendanceRecord>>,
     onSeeAllClick: () -> Unit,
     modifier: Modifier = Modifier,
-    title: String = "Attendance Timeline",
+    title: String = "Recent Attendance",
     maxItems: Int = 3,
-    showModeLabel: Boolean = false
+    showModeLabel: Boolean = false,
+    showExternalHeader: Boolean = false,
+    showSeeAllAction: Boolean = true
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        SeeAllButton(
-            label = title,
-            onClickButton = onSeeAllClick
-        )
+        if (showExternalHeader) {
+            SeeAllButton(
+                label = title,
+                onClickButton = onSeeAllClick
+            )
+        }
 
         when (attendanceState) {
             is UiState.Loading -> {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 24.dp),
+                        .padding(vertical = 20.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     LoadingAnimation()
@@ -61,22 +76,41 @@ fun InfiniteAttendanceTimelineSection(
             is UiState.Success -> {
                 if (attendanceState.data.isEmpty()) {
                     InfiniteGlassReportCard {
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            EmptyListAnimation(modifier = Modifier.size(120.dp))
-                            Text(
-                                text = "No attendance records found",
-                                style = body2,
-                                color = Purple_300
-                            )
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            if (!showExternalHeader) {
+                                TimelineCardHeader(
+                                    title = title,
+                                    showSeeAllAction = showSeeAllAction,
+                                    onSeeAllClick = onSeeAllClick
+                                )
+                                Spacer(modifier = Modifier.height(10.dp))
+                            }
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                EmptyListAnimation(modifier = Modifier.size(120.dp))
+                                Text(
+                                    text = "No attendance records found",
+                                    style = body2,
+                                    color = Purple_300
+                                )
+                            }
                         }
                     }
                 } else {
                     val timelineItems = attendanceState.data.take(maxItems)
                     InfiniteGlassReportCard {
                         Column(modifier = Modifier.fillMaxWidth()) {
+                            if (!showExternalHeader) {
+                                TimelineCardHeader(
+                                    title = title,
+                                    showSeeAllAction = showSeeAllAction,
+                                    onSeeAllClick = onSeeAllClick
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
+                            }
                             timelineItems.forEachIndexed { index, attendance ->
                                 val status = attendance.toReportStatus()
                                 InfiniteAttendanceTimelineCard(
@@ -104,21 +138,65 @@ fun InfiniteAttendanceTimelineSection(
 
             is UiState.Error -> {
                 InfiniteGlassReportCard {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        EmptyListAnimation(modifier = Modifier.size(120.dp))
-                        Text(
-                            text = attendanceState.errorMessage,
-                            style = body2,
-                            color = Purple_300
-                        )
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        if (!showExternalHeader) {
+                            TimelineCardHeader(
+                                title = title,
+                                showSeeAllAction = showSeeAllAction,
+                                onSeeAllClick = onSeeAllClick
+                            )
+                            Spacer(modifier = Modifier.height(10.dp))
+                        }
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            EmptyListAnimation(modifier = Modifier.size(120.dp))
+                            Text(
+                                text = attendanceState.errorMessage,
+                                style = body2,
+                                color = Purple_300
+                            )
+                        }
                     }
                 }
             }
 
             is UiState.Idle -> Unit
+        }
+    }
+}
+
+@Composable
+private fun TimelineCardHeader(
+    title: String,
+    showSeeAllAction: Boolean,
+    onSeeAllClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.CalendarMonth,
+            contentDescription = null,
+            tint = Purple_500,
+            modifier = Modifier.size(20.dp)
+        )
+        Text(
+            text = title,
+            style = headline4,
+            color = Purple_500,
+            modifier = Modifier.weight(1f)
+        )
+        if (showSeeAllAction) {
+            Text(
+                text = "See More",
+                style = body1,
+                color = Blue_500,
+                modifier = Modifier.clickable(onClick = onSeeAllClick)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteTimelineRow.kt
@@ -70,8 +70,8 @@ fun InfiniteTimelineRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(64.dp)
-            .padding(horizontal = 12.dp),
+            .height(56.dp)
+            .padding(horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         TimelineRail(
@@ -80,11 +80,11 @@ fun InfiniteTimelineRow(
             leadingIcon = leadingIcon
         )
 
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(10.dp))
 
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
+            verticalArrangement = Arrangement.spacedBy(1.dp)
         ) {
             Text(
                 text = primaryLine,
@@ -123,7 +123,7 @@ private fun TimelineRail(
 ) {
     Box(
         modifier = Modifier
-            .width(28.dp)
+            .width(26.dp)
             .fillMaxHeight(),
         contentAlignment = Alignment.Center
     ) {
@@ -153,7 +153,7 @@ private fun TimelineRail(
 
         Box(
             modifier = Modifier
-                .size(28.dp)
+                .size(26.dp)
                 .background(accentColor.copy(alpha = 0.12f), CircleShape),
             contentAlignment = Alignment.Center
         ) {
@@ -161,7 +161,7 @@ private fun TimelineRail(
                 imageVector = leadingIcon ?: Icons.Rounded.CalendarMonth,
                 contentDescription = null,
                 tint = accentColor,
-                modifier = Modifier.size(15.dp)
+                modifier = Modifier.size(14.dp)
             )
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
@@ -16,6 +16,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.body3
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
 import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
@@ -83,14 +86,19 @@ fun InfiniteStatusPill(
         semanticColors.accent
     }
     val horizontal = when (size) {
-        InfiniteSize.Small -> 8.dp
+        InfiniteSize.Small -> 6.dp
         InfiniteSize.Medium -> 10.dp
         InfiniteSize.Large -> 12.dp
     }
     val vertical = when (size) {
-        InfiniteSize.Small -> 4.dp
+        InfiniteSize.Small -> 2.dp
         InfiniteSize.Medium -> 6.dp
         InfiniteSize.Large -> 8.dp
+    }
+    val textStyle = when (size) {
+        InfiniteSize.Small -> body3
+        InfiniteSize.Medium -> body2
+        InfiniteSize.Large -> body1
     }
     Surface(
         modifier = modifier,
@@ -101,15 +109,21 @@ fun InfiniteStatusPill(
     ) {
         Row(
             modifier = Modifier.padding(horizontal = horizontal, vertical = vertical),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             leadingIcon?.let {
-                Icon(imageVector = it, contentDescription = null, tint = iconTint, modifier = Modifier.size(14.dp))
+                Icon(
+                    imageVector = it,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(if (size == InfiniteSize.Small) 11.dp else 14.dp)
+                )
             }
             Text(
                 text = label,
-                fontWeight = if (useSharedRequestPalette || colorOverride != null) FontWeight.Bold else FontWeight.Normal
+                style = textStyle,
+                fontWeight = if (useSharedRequestPalette || colorOverride != null) FontWeight.SemiBold else FontWeight.Medium
             )
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -3,14 +3,12 @@ package com.example.infinite_track.presentation.screen.history
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,29 +25,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.example.infinite_track.data.mapper.attendance.toReportDateLabel
-import com.example.infinite_track.data.mapper.attendance.toReportStatus
-import com.example.infinite_track.data.mapper.attendance.toReportTimeRangeLabel
-import com.example.infinite_track.data.mapper.attendance.toReportTotalWorkHoursLabel
-import com.example.infinite_track.data.mapper.attendance.toReportWorkHourLabel
-import com.example.infinite_track.data.mapper.attendance.toReportWorkModeLabel
-import com.example.infinite_track.domain.model.attendance.AttendancePeriod
-import com.example.infinite_track.domain.model.attendance.AttendanceRecord
-import com.example.infinite_track.domain.model.attendance.AttendanceReportStatusKind
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceModeDistributionCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendancePeriodFilterCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportActionsCard
 import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportNoticeCard
-import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportSummarySection
-import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceTimelineCard
+import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportSummaryCard
+import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceTimelineSection
 import com.example.infinite_track.presentation.design.components.data.InfiniteGlassReportCard
-import com.example.infinite_track.presentation.design.components.data.InfiniteSectionHeader
-import com.example.infinite_track.presentation.design.components.data.TimelineConnectorPosition
 import com.example.infinite_track.presentation.design.components.state.InfiniteEmptyState
 import com.example.infinite_track.presentation.design.components.state.InfiniteErrorState
 import com.example.infinite_track.presentation.design.components.state.InfiniteLoadingState
-import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
+import com.example.infinite_track.utils.UiState
 
 private enum class ReportAction {
     Preview,
@@ -188,14 +175,10 @@ fun HistoryScreen(
 
                 else -> {
                     item {
-                        InfiniteAttendanceReportSummarySection(
-                            attendanceRateValue = uiState.summary?.attendanceRateLabel ?: "—",
-                            workHoursValue = remember(uiState.records, uiState.summary?.totalWorkHoursLabel) {
-                                uiState.records.toReportTotalWorkHoursLabel(uiState.summary?.totalWorkHoursLabel)
-                            },
-                            lateCount = uiState.summary?.totalLate ?: 0,
-                            alphaCount = uiState.summary?.totalAlpha ?: 0,
-                            subtitle = uiState.periodInfo?.label
+                        InfiniteAttendanceReportSummaryCard(
+                            summaryState = uiState.summary?.let { UiState.Success(it) } ?: UiState.Loading,
+                            periodInfo = uiState.periodInfo,
+                            showViewReportAction = false
                         )
                     }
 
@@ -236,42 +219,15 @@ fun HistoryScreen(
                     }
 
                     item {
-                        InfiniteSectionHeader(
+                        InfiniteAttendanceTimelineSection(
+                            attendanceState = UiState.Success(uiState.records),
+                            onSeeAllClick = {},
                             title = "Attendance Timeline",
-                            subtitle = null
+                            maxItems = 3,
+                            showModeLabel = false,
+                            showExternalHeader = false,
+                            showSeeAllAction = false
                         )
-                    }
-
-                    item {
-                        if (uiState.records.isEmpty()) {
-                            InfiniteGlassReportCard {
-                                InfiniteEmptyState(
-                                    title = "No attendance records found",
-                                    message = "Backend did not return attendance records for this period."
-                                )
-                            }
-                        } else {
-                            InfiniteGlassReportCard {
-                                Column {
-                                    uiState.records.forEachIndexed { index, record ->
-                                        ReportTimelineRow(
-                                            record = record,
-                                            connectorPosition = when {
-                                                uiState.records.size == 1 -> TimelineConnectorPosition.None
-                                                index == 0 -> TimelineConnectorPosition.First
-                                                index == uiState.records.lastIndex -> TimelineConnectorPosition.Last
-                                                else -> TimelineConnectorPosition.Middle
-                                            }
-                                        )
-                                        if (index != uiState.records.lastIndex) {
-                                            HorizontalDivider(
-                                                color = InfiniteColors.AttendanceReportGlassBorder
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
                     }
 
                     if (uiState.error != null && uiState.records.isNotEmpty()) {
@@ -286,35 +242,6 @@ fun HistoryScreen(
             }
         }
     }
-}
-
-@Composable
-private fun ReportTimelineRow(
-    record: AttendanceRecord,
-    connectorPosition: TimelineConnectorPosition
-) {
-    val status = record.toReportStatus()
-    InfiniteAttendanceTimelineCard(
-        dateLabel = record.toReportDateLabel(),
-        modeLabel = record.toReportWorkModeLabel(),
-        timeRange = record.toReportTimeRangeLabel(),
-        statusLabel = status.label,
-        statusVariant = status.kind.toInfiniteStatusVariant(),
-        connectorPosition = connectorPosition,
-        workHourLabel = record.toReportWorkHourLabel(),
-        locationLabel = record.location,
-        showModeLabel = false,
-        modeKey = record.modeKey ?: record.modeLabel
-    )
-}
-
-private fun AttendanceReportStatusKind.toInfiniteStatusVariant(): InfiniteStatusVariant = when (this) {
-    AttendanceReportStatusKind.ActiveSession -> InfiniteStatusVariant.Active
-    AttendanceReportStatusKind.OnTime -> InfiniteStatusVariant.OnTime
-    AttendanceReportStatusKind.Late -> InfiniteStatusVariant.Late
-    AttendanceReportStatusKind.Alpha -> InfiniteStatusVariant.Alpha
-    AttendanceReportStatusKind.Unknown -> InfiniteStatusVariant.Unknown
-    AttendanceReportStatusKind.Neutral -> InfiniteStatusVariant.Neutral
 }
 
 private const val PullToRefreshThresholdPx = 160f

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -104,6 +104,9 @@ fun EmployeeAndManagerComponent(
                         attendanceState = attendanceState,
                         maxItems = 3,
                         showModeLabel = false,
+                        title = "Recent Attendance",
+                        showExternalHeader = false,
+                        showSeeAllAction = true,
                         onSeeAllClick = navigateListMyAttendance
                     )
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeAttendanceReportSummaryCard.kt
@@ -1,51 +1,16 @@
 package com.example.infinite_track.presentation.screen.home.content
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
-import androidx.compose.material.icons.outlined.AccessTime
-import androidx.compose.material.icons.outlined.PersonOutline
-import androidx.compose.material.icons.outlined.QueryStats
-import androidx.compose.material.icons.outlined.Schedule
-import androidx.compose.material.icons.rounded.BarChart
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.attendance.AttendancePeriodInfo
 import com.example.infinite_track.domain.model.attendance.AttendanceSummaryInfo
-import com.example.infinite_track.presentation.core.body1
-import com.example.infinite_track.presentation.core.body2
-import com.example.infinite_track.presentation.core.headline4
-import com.example.infinite_track.presentation.design.components.data.InfiniteGlassReportCard
-import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.theme.Blue_500
-import com.example.infinite_track.presentation.theme.Orange_500
-import com.example.infinite_track.presentation.theme.Purple_300
-import com.example.infinite_track.presentation.theme.Purple_500
-import com.example.infinite_track.presentation.theme.Status_Approved
-import com.example.infinite_track.presentation.theme.Status_Rejected
+import com.example.infinite_track.presentation.design.components.data.InfiniteAttendanceReportSummaryCard
 import com.example.infinite_track.utils.UiState
 
+/**
+ * Home-facing wrapper so existing call sites stay stable while the shared
+ * report summary component lives in the global design/components package.
+ */
 @Composable
 fun HomeAttendanceReportSummaryCard(
     summaryState: UiState<AttendanceSummaryInfo>,
@@ -53,187 +18,11 @@ fun HomeAttendanceReportSummaryCard(
     onViewReportClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    InfiniteGlassReportCard(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onViewReportClick)
-    ) {
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.BarChart,
-                    contentDescription = null,
-                    tint = Purple_500,
-                    modifier = Modifier.size(22.dp)
-                )
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = "My Attendance Report",
-                        style = headline4,
-                        color = Purple_500
-                    )
-                    Text(
-                        text = periodInfo?.label ?: "This Month",
-                        style = body2,
-                        color = Purple_300
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(14.dp))
-
-            when (summaryState) {
-                is UiState.Loading -> {
-                    Text(
-                        text = "Loading attendance summary...",
-                        style = body2,
-                        color = Purple_300
-                    )
-                }
-
-                is UiState.Error -> {
-                    Text(
-                        text = summaryState.errorMessage,
-                        style = body2,
-                        color = Status_Rejected
-                    )
-                }
-
-                is UiState.Success -> {
-                    val summary = summaryState.data
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(78.dp)
-                        ) {
-                            SummaryMetricCell(
-                                title = "Attendance Rate",
-                                value = summary.attendanceRateLabel ?: "—",
-                                icon = Icons.Outlined.QueryStats,
-                                accent = Purple_500,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Box(
-                                modifier = Modifier
-                                    .width(1.dp)
-                                    .fillMaxHeight()
-                                    .background(InfiniteColors.AttendanceReportGlassBorder)
-                            )
-                            SummaryMetricCell(
-                                title = "Late",
-                                value = "${summary.totalLate} times",
-                                icon = Icons.Outlined.Schedule,
-                                accent = Orange_500,
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-
-                        HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
-
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(78.dp)
-                        ) {
-                            SummaryMetricCell(
-                                title = "Alpha",
-                                value = "${summary.totalAlpha} day",
-                                icon = Icons.Outlined.PersonOutline,
-                                accent = Status_Rejected,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Box(
-                                modifier = Modifier
-                                    .width(1.dp)
-                                    .fillMaxHeight()
-                                    .background(InfiniteColors.AttendanceReportGlassBorder)
-                            )
-                            SummaryMetricCell(
-                                title = "Work Hours",
-                                value = summary.totalWorkHoursLabel ?: "—",
-                                icon = Icons.Outlined.AccessTime,
-                                accent = Status_Approved,
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-                    }
-                }
-
-                is UiState.Idle -> Unit
-            }
-
-            Spacer(modifier = Modifier.height(12.dp))
-            HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
-            Spacer(modifier = Modifier.height(10.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = "View Report",
-                    style = body1,
-                    color = Blue_500
-                )
-                Icon(
-                    imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = Blue_500,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun SummaryMetricCell(
-    title: String,
-    value: String,
-    icon: ImageVector,
-    accent: Color,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .fillMaxHeight()
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.SpaceBetween
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(28.dp)
-                    .clip(CircleShape)
-                    .background(accent.copy(alpha = 0.12f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = accent,
-                    modifier = Modifier.size(15.dp)
-                )
-            }
-            Text(
-                text = title,
-                style = body2,
-                color = Purple_300
-            )
-        }
-        Text(
-            text = value,
-            style = headline4,
-            color = accent
-        )
-    }
+    InfiniteAttendanceReportSummaryCard(
+        summaryState = summaryState,
+        periodInfo = periodInfo,
+        modifier = modifier,
+        showViewReportAction = true,
+        onViewReportClick = onViewReportClick
+    )
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -79,6 +79,9 @@ fun InternshipContent(
                 attendanceState = attendanceState,
                 maxItems = 3,
                 showModeLabel = false,
+                title = "Recent Attendance",
+                showExternalHeader = false,
+                showSeeAllAction = true,
                 onSeeAllClick = navigateToListMyAttendance
             )
         }


### PR DESCRIPTION
## Summary
- Shrink Attendance Timeline status badges and tighten content spacing to match the My Attendance Report density.
- Move Home timeline title into the card as **Recent Attendance** with a leading calendar icon.
- Extract a shared `InfiniteAttendanceReportSummaryCard` so Home and History reuse the same report summary surface.
- Keep History timeline title as **Attendance Timeline**, with period-filtered data and max 3 items.
- Restyle Attendance Mode card to match the reference layout while reusing shared mode colors with timeline calendar accents.
- Prefer existing custom typography (`headline4`, `body1`, `body2`, `body3`) and theme colors.

## Scope notes
- Presentation-only polish for Home/History attendance surfaces.
- No backend/auth/session changes.
- History data still follows active period filter.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Badge size looks smaller and balanced
- Recent Attendance title is inside the Home timeline card
- History report summary matches Home summary component
- History timeline still follows selected period and shows max 3 items
- Attendance Mode bar colors match timeline calendar accent colors
- Typography/color usage feels consistent with existing theme assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable attendance report card showing attendance rate, late arrivals, alpha records, and work hours.
  * Added optional “View Report” and “See More” actions to attendance sections.
  * Added configurable headers and improved loading, error, and empty states for attendance timelines.

* **Improvements**
  * Refined attendance cards, timeline rows, progress bars, and status pills with updated spacing, sizing, colors, and typography.
  * Standardized attendance summary and timeline displays across home and history screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->