### PR TITLE
fix: polish history scroll and attendance mode layout

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceModeDistribution.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.WorkOutline
@@ -111,29 +112,20 @@ fun InfiniteAttendanceModeDistributionRow(
     unitLabel: String = "records"
 ) {
     val progress = if (total > 0) count.toFloat() / total.toFloat() else 0f
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = label,
-                color = Purple_500,
-                style = body1
-            )
-            Text(
-                text = "$count $unitLabel",
-                color = Purple_300,
-                style = body2
-            )
-        }
+        Text(
+            text = label,
+            color = Purple_500,
+            style = body1,
+            modifier = Modifier.width(36.dp)
+        )
         Box(
             modifier = Modifier
-                .fillMaxWidth()
+                .weight(1f)
                 .height(10.dp)
                 .clip(RoundedCornerShape(999.dp))
                 .background(InfiniteColors.Surface.copy(alpha = 0.72f))
@@ -147,5 +139,11 @@ fun InfiniteAttendanceModeDistributionRow(
                 trackColor = Color.Transparent
             )
         }
+        Text(
+            text = "$count $unitLabel",
+            color = Purple_300,
+            style = body2,
+            modifier = Modifier.width(58.dp)
+        )
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportActionsCard.kt
@@ -3,12 +3,18 @@ package com.example.infinite_track.presentation.design.components.data
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.button.InfiniteButton
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 
 @Composable
 fun InfiniteAttendanceReportActionsCard(
@@ -23,16 +29,25 @@ fun InfiniteAttendanceReportActionsCard(
     supportMessage: String = ""
 ) {
     InfiniteGlassReportCard(modifier = modifier) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            InfiniteSectionHeader(
-                title = title,
-                subtitle = subtitle
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(
+                text = title,
+                style = headline4,
+                color = Purple_500
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            subtitle?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    text = it,
+                    style = body2,
+                    color = Purple_300
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 InfiniteButton(
                     text = "Export PDF",
                     onClick = onExportClick,
                     variant = InfiniteButtonVariant.Primary,
+                    size = InfiniteSize.Small,
                     state = if (exportEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
                     modifier = Modifier.weight(1f)
                 )
@@ -40,6 +55,7 @@ fun InfiniteAttendanceReportActionsCard(
                     text = "Share Report",
                     onClick = onShareClick,
                     variant = InfiniteButtonVariant.Glass,
+                    size = InfiniteSize.Small,
                     state = if (shareEnabled) InfiniteButtonState.Enabled else InfiniteButtonState.Disabled,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryScreen.kt
@@ -123,17 +123,18 @@ fun HistoryScreen(
         }
     }
 
+    // MainScreen already applies scaffold/bottom-bar padding.
+    // Match Home content insets so History does not double-pad and clip while scrolling.
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = InfiniteColors.Transparent
-    ) { innerPadding ->
+    ) { _ ->
         LazyColumn(
             state = lazyListState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
                 .nestedScroll(pullToRefreshConnection),
-            contentPadding = PaddingValues(start = 20.dp, top = 0.dp, end = 20.dp, bottom = 0.dp),
+            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item {
@@ -223,7 +224,7 @@ fun HistoryScreen(
                             attendanceState = UiState.Success(uiState.records),
                             onSeeAllClick = {},
                             title = "Attendance Timeline",
-                            maxItems = 3,
+                            maxItems = uiState.records.size.coerceAtLeast(1),
                             showModeLabel = false,
                             showExternalHeader = false,
                             showSeeAllAction = false

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/history/HistoryViewModel.kt
@@ -33,7 +33,7 @@ data class HistoryScreenState(
     val summary: AttendanceSummaryInfo? = null,
     val records: List<AttendanceRecord> = emptyList(),
     val currentPage: Int = 1,
-    val pageSize: Int = 3
+    val pageSize: Int = 10
 )
 
 @HiltViewModel
@@ -69,7 +69,7 @@ class HistoryViewModel @Inject constructor(
                 periodInfo = null,
                 summary = null,
                 currentPage = 1,
-                canLoadMore = false,
+                canLoadMore = true,
                 isLoading = false,
                 isRefreshing = false,
                 isLoadingMore = false,
@@ -80,12 +80,16 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    /**
-     * History interface intentionally shows only the latest 3 records.
-     * Pagination is disabled for this screen.
-     */
     fun loadNextPage() {
-        // no-op: max 3 items on history interface
+        val currentState = uiState.value
+        if (!currentState.isLoadingMore &&
+            !currentState.isLoading &&
+            !currentState.isRefreshing &&
+            currentState.canLoadMore
+        ) {
+            _uiState.update { it.copy(currentPage = it.currentPage + 1) }
+            loadHistory(isRefresh = false)
+        }
     }
 
     /**
@@ -200,9 +204,8 @@ class HistoryViewModel @Inject constructor(
                         isLoadingMore = false,
                         periodInfo = historyPage.period,
                         summary = historyPage.summary,
-                        // History interface intentionally keeps only the latest 3 records.
-                        records = mergedRecords.take(3),
-                        canLoadMore = false
+                        records = mergedRecords,
+                        canLoadMore = historyPage.pagination.hasNextPage
                     )
                 }
             }.onFailure { error ->
@@ -234,7 +237,7 @@ class HistoryViewModel @Inject constructor(
                 records = emptyList(),
                 periodInfo = null,
                 summary = null,
-                canLoadMore = it.selectedPeriod != AttendancePeriod.CUSTOM,
+                canLoadMore = true,
                 isLoading = false,
                 isRefreshing = false,
                 isLoadingMore = false,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/EmployeeAndManagementContent.kt
@@ -106,7 +106,7 @@ fun EmployeeAndManagerComponent(
                         showModeLabel = false,
                         title = "Recent Attendance",
                         showExternalHeader = false,
-                        showSeeAllAction = true,
+                        showSeeAllAction = false,
                         onSeeAllClick = navigateListMyAttendance
                     )
                 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/InternshipContent.kt
@@ -81,7 +81,7 @@ fun InternshipContent(
                 showModeLabel = false,
                 title = "Recent Attendance",
                 showExternalHeader = false,
-                showSeeAllAction = true,
+                showSeeAllAction = false,
                 onSeeAllClick = navigateToListMyAttendance
             )
         }


### PR DESCRIPTION
## Summary
- Remove See More from Home Recent Attendance card.
- Align Attendance Mode rows to the reference layout: label | progress bar | day count.
- Restore History Attendance Timeline as period-filtered data without a hard 3-item cap.
- Shrink Export/Share buttons via existing `InfiniteButton` Small size and existing typography.
- Fix History scroll clipping by matching Home content insets and avoiding double scaffold padding.

## Scope notes
- Presentation/layout polish only for Home/History attendance surfaces.
- No backend/auth/session changes.
- History still follows Daily/Weekly/Monthly filter and can load more period records.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Recent Attendance no longer shows See More
- Attendance Mode day counts align with progress bars
- History timeline shows period-filtered records beyond 3 items
- Export/Share buttons are smaller and typography looks consistent
- History scrolling no longer clips content against top/bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)