### PR TITLE
fix: align wfa cards and profile surfaces with report style

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/navigation/WfaShellNavigationContract.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/navigation/WfaShellNavigationContract.kt
@@ -48,8 +48,8 @@ object WfaShellNavigationContract {
         ),
         NavigationItem(
             tittle = R.string.bottom_menu_wfa,
-            selectedIcon = R.drawable.ic_contact_selected,
-            unselectedIcon = R.drawable.ic_contact,
+            selectedIcon = R.drawable.ic_location_outline_selected,
+            unselectedIcon = R.drawable.ic_location_outline,
             screen = Screen.Wfa
         ),
         NavigationItem(

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -70,6 +70,9 @@ import com.example.infinite_track.presentation.design.components.status.Infinite
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
+import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.utils.UiState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -193,7 +196,7 @@ fun ProfileScreen(
     }
 
     // MainScreen already applies scaffold/bottom-bar padding.
-    // Keep page insets aligned with Home/History.
+    // Keep page insets aligned with Home/History and avoid top clipping.
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = Color.Transparent
@@ -201,7 +204,7 @@ fun ProfileScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
+                .padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 16.dp)
         ) {
             when (profileState) {
                 is UiState.Loading -> {
@@ -290,7 +293,7 @@ private fun AccountHubContent(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         IdentityHeroCard(
             user = user,
@@ -397,13 +400,13 @@ private fun AccountHubContent(
 @Composable
 private fun ProfileGlassCard(
     modifier: Modifier = Modifier,
-    shape: RoundedCornerShape,
-    borderColor: Color = InfiniteColors.AccountHubOutline,
-    shadowColor: Color = InfiniteColors.AccountHubPrimary.copy(alpha = 0.18f),
+    shape: RoundedCornerShape = RoundedCornerShape(24.dp),
+    borderColor: Color = InfiniteColors.AttendanceReportGlassBorder,
+    shadowColor: Color = InfiniteColors.Primary.copy(alpha = 0.10f),
     backgroundBrush: Brush = Brush.linearGradient(
         colors = listOf(
-            InfiniteColors.Surface.copy(alpha = 0.22f),
-            InfiniteColors.Surface.copy(alpha = 0.10f)
+            InfiniteColors.AttendanceReportGlassSurface,
+            InfiniteColors.AttendanceReportGlassSurface
         )
     ),
     contentPadding: PaddingValues,
@@ -414,7 +417,7 @@ private fun ProfileGlassCard(
             elevation = 8.dp,
             shape = shape,
             ambientColor = shadowColor,
-            spotColor = shadowColor,
+            spotColor = InfiniteColors.Accent.copy(alpha = 0.08f),
             clip = false
         ),
         shape = shape,
@@ -445,84 +448,66 @@ private fun IdentityHeroCard(
 
     ProfileGlassCard(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(28.dp),
-        borderColor = InfiniteColors.AccountHubHeroOutline,
-        backgroundBrush = InfiniteColors.AccountHubHeroGradient,
-        contentPadding = PaddingValues(20.dp)
+        shape = RoundedCornerShape(24.dp),
+        contentPadding = PaddingValues(16.dp)
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth()
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Box(
+            AsyncImage(
+                model = user.photoUrl?.takeIf { it.isNotBlank() },
+                contentDescription = null,
+                placeholder = painterResource(R.drawable.ic_profile),
+                error = painterResource(R.drawable.ic_profile),
+                fallback = painterResource(R.drawable.ic_profile),
                 modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .size(124.dp)
+                    .size(84.dp)
                     .clip(CircleShape)
-                    .background(InfiniteColors.AccountHubDecorativeTint)
+                    .border(1.dp, InfiniteColors.AttendanceReportGlassBorder, CircleShape),
+                contentScale = ContentScale.Crop
             )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(18.dp),
-                verticalAlignment = Alignment.CenterVertically
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Box(
-                        modifier = Modifier
-                            .size(118.dp)
-                            .clip(CircleShape)
-                            .background(InfiniteColors.AccountHubAvatarRingGradient)
-                            .padding(4.dp)
-                    ) {
-                        AsyncImage(
-                            model = user.photoUrl?.takeIf { it.isNotBlank() },
-                            contentDescription = null,
-                            placeholder = painterResource(R.drawable.ic_profile),
-                            error = painterResource(R.drawable.ic_profile),
-                            fallback = painterResource(R.drawable.ic_profile),
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .clip(CircleShape)
-                                .border(3.dp, InfiniteColors.AccountHubOutline, CircleShape),
-                            contentScale = ContentScale.Crop
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(14.dp))
-                    InfiniteStatusPill(
-                        label = stringResource(R.string.account_hub_active_status, role),
-                        variant = InfiniteStatusVariant.Active,
-                        size = InfiniteSize.Small
-                    )
-                }
-
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(9.dp)
-                ) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            text = fullName,
-                            style = headline2,
-                            color = InfiniteColors.AccountHubTitle,
-                            fontWeight = FontWeight.Medium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = position,
-                            style = body1,
-                            color = InfiniteColors.AccountHubSectionAccent,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-
-                    SoftPill(text = role, icon = R.drawable.ic_profile)
-                    IdentityInfoRow(icon = R.drawable.ic_division, text = division)
-                    IdentityInfoRow(
-                        icon = R.drawable.ic_description,
-                        text = stringResource(R.string.account_hub_identifier, user.nipNim)
-                    )
-                }
+                Text(
+                    text = fullName,
+                    style = headline4,
+                    color = Purple_500,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = position,
+                    style = body1,
+                    color = Purple_300,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = role,
+                    style = body2,
+                    color = Blue_500,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = division,
+                    style = body2,
+                    color = Purple_300,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = stringResource(R.string.account_hub_identifier, user.nipNim),
+                    style = body2,
+                    color = Purple_300,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }
@@ -536,41 +521,33 @@ private fun AccountSummaryCard(
     modifier: Modifier = Modifier
 ) {
     ProfileGlassCard(
-        modifier = modifier.height(92.dp),
+        modifier = modifier.height(78.dp),
         shape = RoundedCornerShape(20.dp),
-        backgroundBrush = Brush.linearGradient(
-            colors = listOf(
-                InfiniteColors.Surface.copy(alpha = 0.20f),
-                InfiniteColors.Surface.copy(alpha = 0.08f)
-            )
-        ),
-        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 0.dp)
+        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp)
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Icon(
                 painter = painterResource(icon),
                 contentDescription = null,
-                tint = InfiniteColors.AccountHubPrimary,
-                modifier = Modifier.size(26.dp)
+                tint = Blue_500,
+                modifier = Modifier.size(20.dp)
             )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = label,
                     style = body2,
-                    color = InfiniteColors.AccountHubMutedText,
+                    color = Purple_300,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = value,
                     style = body1,
-                    color = InfiniteColors.AccountHubTitle,
-                    fontWeight = FontWeight.Medium,
+                    color = Purple_500,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -587,22 +564,15 @@ private fun AccountHubSection(
     ProfileGlassCard(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(24.dp),
-        backgroundBrush = Brush.linearGradient(
-            colors = listOf(
-                InfiniteColors.Surface.copy(alpha = 0.18f),
-                InfiniteColors.Surface.copy(alpha = 0.06f)
-            )
-        ),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 14.dp)
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             Text(
                 text = title,
                 style = body1,
-                color = InfiniteColors.AccountHubSectionAccent,
-                fontWeight = FontWeight.Medium
+                color = Purple_500
             )
             content()
         }
@@ -618,32 +588,32 @@ private fun AccountHubMenuRow(
     modifier: Modifier = Modifier,
     destructive: Boolean = false
 ) {
-    val accent = if (destructive) InfiniteColors.AccountHubDestructive else InfiniteColors.AccountHubPrimary
+    val accent = if (destructive) InfiniteColors.AccountHubDestructive else Blue_500
     val rowBackground = if (destructive) InfiniteColors.AccountHubDestructiveContainer else Color.Transparent
 
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(18.dp))
+            .clip(RoundedCornerShape(14.dp))
             .background(rowBackground)
             .clickable { onClick() }
-            .padding(horizontal = 10.dp, vertical = 12.dp),
+            .padding(horizontal = 8.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(14.dp)
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         Surface(
-            shape = RoundedCornerShape(14.dp),
-            color = InfiniteColors.AccountHubIconSurface,
-            border = BorderStroke(1.dp, InfiniteColors.AccountHubIconBorder),
-            shadowElevation = 3.dp
+            shape = RoundedCornerShape(12.dp),
+            color = InfiniteColors.AttendanceReportGlassSurface,
+            border = BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder),
+            shadowElevation = 0.dp
         ) {
             Icon(
                 painter = painterResource(icon),
                 contentDescription = null,
                 tint = accent,
                 modifier = Modifier
-                    .padding(12.dp)
-                    .size(24.dp)
+                    .padding(8.dp)
+                    .size(18.dp)
             )
         }
         Column(modifier = Modifier.weight(1f)) {
@@ -675,8 +645,8 @@ private fun AccountHubMenuRow(
 @Composable
 private fun AccountHubDivider() {
     HorizontalDivider(
-        modifier = Modifier.padding(start = 72.dp),
-        color = InfiniteColors.AccountHubDividerColor
+        modifier = Modifier.padding(start = 52.dp),
+        color = InfiniteColors.AttendanceReportGlassBorder
     )
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -17,9 +18,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.HourglassEmpty
-import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -29,22 +31,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.booking.BookingHistoryItem
-import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.core.body3
 import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusPill
 import com.example.infinite_track.presentation.design.components.status.InfiniteStatusVariant
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteSize
-import com.example.infinite_track.presentation.theme.Blue_100
 import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
-import com.example.infinite_track.presentation.theme.White
 import com.example.infinite_track.presentation.theme.requestStatusColor
 
 @Composable
@@ -65,16 +66,16 @@ fun WfaRequestCard(
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
             .shadow(
-                elevation = 6.dp,
-                shape = RoundedCornerShape(18.dp),
-                ambientColor = Blue_500.copy(alpha = 0.18f),
-                spotColor = Blue_500.copy(alpha = 0.12f)
+                elevation = 8.dp,
+                shape = RoundedCornerShape(24.dp),
+                ambientColor = InfiniteColors.Primary.copy(alpha = 0.10f),
+                spotColor = InfiniteColors.Accent.copy(alpha = 0.08f)
             )
-            .clip(RoundedCornerShape(18.dp))
-            .background(White.copy(alpha = 0.34f))
+            .clip(RoundedCornerShape(24.dp))
+            .background(InfiniteColors.AttendanceReportGlassSurface)
             .border(
-                BorderStroke(1.dp, Blue_100.copy(alpha = 0.9f)),
-                RoundedCornerShape(18.dp)
+                BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder),
+                RoundedCornerShape(24.dp)
             )
     ) {
         Box(
@@ -109,7 +110,7 @@ fun WfaRequestCard(
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Outlined.LocationOn,
+                            imageVector = Icons.Filled.LocationOn,
                             contentDescription = null,
                             tint = Blue_500,
                             modifier = Modifier.size(14.dp)
@@ -132,7 +133,7 @@ fun WfaRequestCard(
                 )
             }
 
-            HorizontalDivider(color = Blue_100.copy(alpha = 0.8f))
+            HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -144,20 +145,20 @@ fun WfaRequestCard(
                     style = body2,
                     color = Purple_300
                 )
-                ScoreBadge(
+                ScoreProgressBadge(
                     score = booking.suitabilityScore,
                     color = statusColor
                 )
                 Text(
                     text = booking.suitabilityLabel,
-                    style = body1,
+                    style = body2,
                     color = statusColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }
 
-            HorizontalDivider(color = Blue_100.copy(alpha = 0.8f))
+            HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -172,7 +173,7 @@ fun WfaRequestCard(
                 )
                 Text(
                     text = booking.notes.ifBlank { "-" },
-                    style = body1,
+                    style = body2,
                     color = Purple_500,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -203,14 +204,31 @@ fun WfaRequestCard(
 }
 
 @Composable
-private fun ScoreBadge(score: Double?, color: Color) {
+private fun ScoreProgressBadge(
+    score: Double?,
+    color: Color
+) {
+    val progress = ((score ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f)
     Box(
-        modifier = Modifier
-            .size(30.dp)
-            .clip(CircleShape)
-            .border(BorderStroke(1.5.dp, color), CircleShape),
+        modifier = Modifier.size(36.dp),
         contentAlignment = Alignment.Center
     ) {
+        CircularProgressIndicator(
+            progress = { 1f },
+            modifier = Modifier.fillMaxSize(),
+            color = color.copy(alpha = 0.16f),
+            strokeWidth = 3.dp,
+            trackColor = Color.Transparent,
+            strokeCap = StrokeCap.Round
+        )
+        CircularProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxSize(),
+            color = color,
+            strokeWidth = 3.dp,
+            trackColor = Color.Transparent,
+            strokeCap = StrokeCap.Round
+        )
         Text(
             text = score?.let { String.format("%.1f", it) } ?: "-",
             style = body3,

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/wfa/components/WfaRequestStatusSummary.kt
@@ -30,13 +30,12 @@ import com.example.infinite_track.domain.model.booking.BookingHistorySummary
 import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.core.body3
 import com.example.infinite_track.presentation.core.headline4
-import com.example.infinite_track.presentation.theme.Blue_500
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
 import com.example.infinite_track.presentation.theme.Status_Approved
 import com.example.infinite_track.presentation.theme.Status_Pending
 import com.example.infinite_track.presentation.theme.Status_Rejected
-import com.example.infinite_track.presentation.theme.White
 
 @Composable
 fun WfaRequestStatusSummary(
@@ -86,13 +85,13 @@ private fun SummaryCard(
     Column(
         modifier = modifier
             .shadow(
-                elevation = 6.dp,
-                shape = RoundedCornerShape(18.dp),
-                ambientColor = Blue_500.copy(alpha = 0.18f),
-                spotColor = Blue_500.copy(alpha = 0.12f)
+                elevation = 8.dp,
+                shape = RoundedCornerShape(24.dp),
+                ambientColor = InfiniteColors.Primary.copy(alpha = 0.10f),
+                spotColor = InfiniteColors.Accent.copy(alpha = 0.08f)
             )
-            .background(White.copy(alpha = 0.34f), RoundedCornerShape(18.dp))
-            .border(BorderStroke(1.dp, color.copy(alpha = 0.28f)), RoundedCornerShape(18.dp))
+            .background(InfiniteColors.AttendanceReportGlassSurface, RoundedCornerShape(24.dp))
+            .border(BorderStroke(1.dp, InfiniteColors.AttendanceReportGlassBorder), RoundedCornerShape(24.dp))
             .padding(horizontal = 10.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/app/src/main/res/drawable/ic_location_outline.xml
+++ b/app/src/main/res/drawable/ic_location_outline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,7c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_location_outline_selected.xml
+++ b/app/src/main/res/drawable/ic_location_outline_selected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,7c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>


### PR DESCRIPTION
## Summary
- Align WFA request and status card backgrounds with My Attendance Report surface/border tokens.
- Make request location icons solid and switch WFA bottom-bar icons to regular/outline location icons.
- Convert suitability score UI into a circular progress ring matching the reference.
- Keep notes title/value at the same typography size and use white report-style dividers.
- Simplify Profile identity card, unify typography/color tokens, tighten vertical spacing, and reduce top scroll clipping.

## Scope notes
- Presentation/layout polish only for WFA request cards and Profile account hub surfaces.
- No backend/auth/session changes.
- Keeps existing WFA request data attributes.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- WFA request card background matches My Attendance Report cards
- Location icon in request card is solid
- WFA bottom bar uses outline location icons
- Score badge shows progress ring like the reference
- Notes title/value share the same text size
- Dividers look white/report-style
- Profile identity card is plainer and denser
- Profile top scroll no longer clips content

🤖 Generated with [Claude Code](https://claude.com/claude-code)