### PR TITLE
fix: tighten profile cards and restrict report navigation

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummaryCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteAttendanceReportSummaryCard.kt
@@ -54,16 +54,9 @@ fun InfiniteAttendanceReportSummaryCard(
     showViewReportAction: Boolean = true,
     onViewReportClick: (() -> Unit)? = null
 ) {
-    val clickableModifier = if (showViewReportAction && onViewReportClick != null) {
-        Modifier.clickable(onClick = onViewReportClick)
-    } else {
-        Modifier
-    }
-
+    // Only the trailing navigate control should trigger navigation.
     InfiniteGlassReportCard(
-        modifier = modifier
-            .fillMaxWidth()
-            .then(clickableModifier)
+        modifier = modifier.fillMaxWidth()
     ) {
         Column {
             Row(
@@ -180,7 +173,15 @@ fun InfiniteAttendanceReportSummaryCard(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (onViewReportClick != null) {
+                                Modifier.clickable(onClick = onViewReportClick)
+                            } else {
+                                Modifier
+                            }
+                        ),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -191,7 +192,7 @@ fun InfiniteAttendanceReportSummaryCard(
                     )
                     Icon(
                         imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = null,
+                        contentDescription = "Navigate to report",
                         tint = Blue_500,
                         modifier = Modifier.size(18.dp)
                     )

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/profile/ProfileScreen.kt
@@ -63,6 +63,7 @@ import com.example.infinite_track.presentation.components.status.InfiniteTrackSt
 import com.example.infinite_track.presentation.components.status.StatusStates
 import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.body3
 import com.example.infinite_track.presentation.core.headline2
 import com.example.infinite_track.presentation.core.headline3
 import com.example.infinite_track.presentation.core.headline4
@@ -196,7 +197,7 @@ fun ProfileScreen(
     }
 
     // MainScreen already applies scaffold/bottom-bar padding.
-    // Keep page insets aligned with Home/History and avoid top clipping.
+    // Match Home/History content insets exactly.
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = Color.Transparent
@@ -204,7 +205,7 @@ fun ProfileScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 16.dp)
+                .padding(16.dp)
         ) {
             when (profileState) {
                 is UiState.Loading -> {
@@ -521,32 +522,35 @@ private fun AccountSummaryCard(
     modifier: Modifier = Modifier
 ) {
     ProfileGlassCard(
-        modifier = modifier.height(78.dp),
-        shape = RoundedCornerShape(20.dp),
-        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp)
+        modifier = modifier.height(64.dp),
+        shape = RoundedCornerShape(18.dp),
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)
     ) {
         Row(
             modifier = Modifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Icon(
                 painter = painterResource(icon),
                 contentDescription = null,
                 tint = Blue_500,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(16.dp)
             )
-            Column(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
                 Text(
                     text = label,
-                    style = body2,
+                    style = body3,
                     color = Purple_300,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = value,
-                    style = body1,
+                    style = body2,
                     color = Purple_500,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/app/src/main/res/drawable/ic_location_outline.xml
+++ b/app/src/main/res/drawable/ic_location_outline.xml
@@ -4,10 +4,19 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
+    <!-- Regular/outline location pin -->
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+        android:fillColor="#00000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7z"
+        android:strokeWidth="1.8"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
     <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M12,7c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+        android:fillColor="#00000000"
+        android:pathData="M12,6.8c-1.21,0 -2.2,0.99 -2.2,2.2s0.99,2.2 2.2,2.2 2.2,-0.99 2.2,-2.2 -0.99,-2.2 -2.2,-2.2z"
+        android:strokeWidth="1.8"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>

--- a/app/src/main/res/drawable/ic_location_outline_selected.xml
+++ b/app/src/main/res/drawable/ic_location_outline_selected.xml
@@ -4,10 +4,19 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
+    <!-- Regular/outline location pin (selected state uses tint) -->
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z" />
+        android:fillColor="#00000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7z"
+        android:strokeWidth="1.8"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
     <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M12,7c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+        android:fillColor="#00000000"
+        android:pathData="M12,6.8c-1.21,0 -2.2,0.99 -2.2,2.2s0.99,2.2 2.2,2.2 2.2,-0.99 2.2,-2.2 -0.99,-2.2 -2.2,-2.2z"
+        android:strokeWidth="1.8"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>


### PR DESCRIPTION
## Summary
- Reduce Profile role/division/contact card height and internal spacing.
- Align Profile content insets with Home/History to fix top/bottom scroll clipping.
- Convert WFA bottom-bar location icons to a regular outline stroke style.
- Make Home My Attendance Report navigate only via the View Report/chevron action, not the whole card.

## Scope notes
- Presentation/layout polish only for Profile, WFA bottom-bar icons, and Home report navigation.
- No backend/auth/session changes.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Role/division/contact cards are shorter and denser
- Profile top/bottom scroll no longer clips content
- WFA bottom-bar icon looks regular/outline, not bold/filled
- Home report navigates only when tapping View Report/chevron

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Report cards now open reports only when the “View Report” action is selected, preventing accidental navigation from other areas of the card.
  - Added an accessibility description to the report navigation icon.
  - Refined profile account summary card spacing, sizing, typography, and layout.
  - Updated profile screen padding for more consistent presentation.
  - Refreshed location icons with a cleaner outline style in both default and selected states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->