### PR TITLE
fix: redesign home today status greeting and services

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/components/tittle/NameComp.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/tittle/NameComp.kt
@@ -1,30 +1,49 @@
 package com.example.infinite_track.presentation.components.tittle
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.WavingHand
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.example.infinite_track.R
 import com.example.infinite_track.presentation.components.modifiers.basicMarquee
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.theme.Purple_300
-import com.example.infinite_track.presentation.theme.Purple_400
 import com.example.infinite_track.presentation.theme.Purple_500
 
 @Composable
@@ -33,66 +52,121 @@ fun nameCards(
     greeting: String,
     userName: String,
     division: String,
-    profileImage: String?,
-
-    ) {
-    val fontss = FontFamily(
-        Font(R.font.sf_compact_bold, FontWeight.Bold),
-        Font(R.font.sf_compact_thin, FontWeight.Thin),
-        Font(R.font.sf_compact_italic, FontWeight.Light),
-        Font(R.font.sf_compact_medium, FontWeight.Medium),
+    profileImage: String?
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "home-hello-profile")
+    val waveRotation by infiniteTransition.animateFloat(
+        initialValue = -14f,
+        targetValue = 14f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 700, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "hello-wave"
     )
-    Column {
-        Text(
-            text = greeting,
-            color = Purple_400,
-            fontFamily = fontss,
-            fontWeight = FontWeight.Thin
-        )
+    val ringRotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2400, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "profile-ring"
+    )
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
         Row(
-            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Row(
-                modifier = modifier
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
+            Text(
+                text = greeting,
+                style = body1,
+                color = Purple_300
+            )
+            Icon(
+                imageVector = Icons.Outlined.WavingHand,
+                contentDescription = null,
+                tint = InfiniteColors.Primary,
+                modifier = Modifier
+                    .size(18.dp)
+                    .rotate(waveRotation)
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                Column(
-                    modifier = Modifier
-                        .width(250.dp)
-                ) {
-                    Text(
-                        text = userName,
-                            fontSize = 27.sp,
-                        fontFamily = fontss,
-                        fontWeight = FontWeight.Medium,
-                        color = Purple_500,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                Text(
+                    text = userName,
+                    style = headline3,
+                    color = Purple_500,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = division,
+                    style = body1,
+                    color = Purple_300,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.basicMarquee(
+                        delayMillis = 1200,
+                        velocityMultiplier = 0.8f
                     )
-                    Text(
-                        text = division,
-                        fontSize = 16.sp,
-                        color = Purple_300,
-                        fontFamily = fontss,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.basicMarquee(
-                            delayMillis = 1200,
-                            velocityMultiplier = 0.8f
-                        )
-                    )
-                }
+                )
+            }
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Box(
+                modifier = Modifier
+                    .size(58.dp)
+                    .drawBehind {
+                        val strokeWidth = 3.dp.toPx()
+                        val inset = strokeWidth / 2f
+                        rotate(ringRotation) {
+                            drawArc(
+                                brush = Brush.sweepGradient(
+                                    colors = listOf(
+                                        InfiniteColors.Primary,
+                                        InfiniteColors.Secondary,
+                                        InfiniteColors.Accent,
+                                        InfiniteColors.Primary
+                                    )
+                                ),
+                                startAngle = 0f,
+                                sweepAngle = 360f,
+                                useCenter = false,
+                                topLeft = Offset(inset, inset),
+                                size = Size(size.width - strokeWidth, size.height - strokeWidth),
+                                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                            )
+                        }
+                    }
+                    .padding(4.dp),
+                contentAlignment = Alignment.Center
+            ) {
                 AsyncImage(
                     model = profileImage ?: R.drawable.ic_profile,
-                    contentDescription = "",
+                    contentDescription = null,
                     modifier = Modifier
-                        .padding(horizontal = 8.dp)
-                        .height(50.dp)
-                        .width(50.dp)
-                        .clip(CircleShape),
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .border(
+                            width = 1.dp,
+                            color = InfiniteColors.AttendanceReportGlassBorder,
+                            shape = CircleShape
+                        ),
                     contentScale = ContentScale.Crop
                 )
             }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteServiceItem.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/data/InfiniteServiceItem.kt
@@ -1,30 +1,34 @@
 package com.example.infinite_track.presentation.design.components.data
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
+import com.example.infinite_track.presentation.theme.Purple_300
+import com.example.infinite_track.presentation.theme.Purple_500
 
 @Composable
 fun InfiniteServiceItem(
@@ -34,7 +38,7 @@ fun InfiniteServiceItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     accentColor: Color = InfiniteColors.Primary,
-    containerColor: Color = InfiniteColors.Surface.copy(alpha = 0.64f)
+    containerColor: Color = InfiniteColors.AttendanceReportGlassSurface
 ) {
     Surface(
         modifier = modifier.clickable(onClick = onClick),
@@ -49,20 +53,19 @@ fun InfiniteServiceItem(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Surface(
-                modifier = Modifier.size(40.dp),
-                shape = RoundedCornerShape(14.dp),
-                color = InfiniteColors.Surface.copy(alpha = 0.85f),
-                border = BorderStroke(1.dp, accentColor.copy(alpha = 0.18f))
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(accentColor.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
             ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = null,
-                        tint = accentColor,
-                        modifier = Modifier.size(22.dp)
-                    )
-                }
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.size(18.dp)
+                )
             }
 
             Column(
@@ -71,29 +74,27 @@ fun InfiniteServiceItem(
             ) {
                 Text(
                     text = title,
-                    color = InfiniteColors.Text,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
+                    color = Purple_500,
+                    style = body1,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 if (subtitle.isNotBlank()) {
                     Text(
                         text = subtitle,
-                        color = InfiniteColors.AttendanceReportMutedText,
-                        style = MaterialTheme.typography.bodySmall,
+                        color = Purple_300,
+                        style = body2,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
             }
 
-            Spacer(modifier = Modifier.size(1.dp))
             Icon(
                 imageVector = InfiniteIcons.ChevronRight,
                 contentDescription = null,
-                tint = InfiniteColors.AttendanceReportMutedText,
-                modifier = Modifier.size(18.dp)
+                tint = Purple_300,
+                modifier = Modifier.size(16.dp)
             )
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteIcons.kt
@@ -1,47 +1,51 @@
 package com.example.infinite_track.presentation.design.tokens
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.AccessTime
-import androidx.compose.material.icons.rounded.AccountBalanceWallet
-import androidx.compose.material.icons.rounded.CalendarMonth
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.ChevronRight
-import androidx.compose.material.icons.rounded.Description
-import androidx.compose.material.icons.rounded.Error
-import androidx.compose.material.icons.rounded.FileDownload
-import androidx.compose.material.icons.rounded.FilterList
-import androidx.compose.material.icons.rounded.Folder
-import androidx.compose.material.icons.rounded.Info
-import androidx.compose.material.icons.rounded.LocationOn
-import androidx.compose.material.icons.rounded.MoreHoriz
-import androidx.compose.material.icons.rounded.Person
-import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material.icons.rounded.Share
-import androidx.compose.material.icons.rounded.VerifiedUser
-import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material.icons.rounded.Work
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.AccountBalanceWallet
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ChevronRight
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.FileDownload
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.MoreHoriz
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.VerifiedUser
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material.icons.outlined.WorkOutline
 import androidx.compose.ui.graphics.vector.ImageVector
 
+/**
+ * Shared icon set for the app.
+ * Prefer outlined/regular icons so Home/Attendance/Company Services stay visually consistent.
+ */
 object InfiniteIcons {
-    val Calendar = Icons.Rounded.CalendarMonth
-    val Time = Icons.Rounded.AccessTime
-    val Success = Icons.Rounded.CheckCircle
-    val Info = Icons.Rounded.Info
-    val Warning = Icons.Rounded.Warning
-    val Error = Icons.Rounded.Error
-    val Location = Icons.Rounded.LocationOn
-    val Search = Icons.Rounded.Search
-    val Refresh = Icons.Rounded.Refresh
-    val Filter = Icons.Rounded.FilterList
-    val Download = Icons.Rounded.FileDownload
-    val Share = Icons.Rounded.Share
-    val Person = Icons.Rounded.Person
-    val Work = Icons.Rounded.Work
-    val Shield = Icons.Rounded.VerifiedUser
-    val Wallet = Icons.Rounded.AccountBalanceWallet
-    val Folder = Icons.Rounded.Folder
-    val Document = Icons.Rounded.Description
-    val ChevronRight = Icons.Rounded.ChevronRight
-    val More: ImageVector = Icons.Rounded.MoreHoriz
+    val Calendar = Icons.Outlined.CalendarMonth
+    val Time = Icons.Outlined.AccessTime
+    val Success = Icons.Outlined.CheckCircle
+    val Info = Icons.Outlined.Info
+    val Warning = Icons.Outlined.WarningAmber
+    val Error = Icons.Outlined.ErrorOutline
+    val Location = Icons.Outlined.LocationOn
+    val Search = Icons.Outlined.Search
+    val Refresh = Icons.Outlined.Refresh
+    val Filter = Icons.Outlined.FilterList
+    val Download = Icons.Outlined.FileDownload
+    val Share = Icons.Outlined.Share
+    val Person = Icons.Outlined.Person
+    val Work = Icons.Outlined.WorkOutline
+    val Shield = Icons.Outlined.VerifiedUser
+    val Wallet = Icons.Outlined.AccountBalanceWallet
+    val Folder = Icons.Outlined.Folder
+    val Document = Icons.Outlined.Description
+    val ChevronRight = Icons.Outlined.ChevronRight
+    val More: ImageVector = Icons.Outlined.MoreHoriz
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/CompanyServicesGrid.kt
@@ -4,15 +4,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import com.example.infinite_track.presentation.components.tittle.Tittle
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.components.data.InfiniteServiceItem
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
+import com.example.infinite_track.presentation.theme.Purple_500
 
 @Composable
 fun CompanyServicesGrid(
@@ -47,16 +49,20 @@ fun CompanyServicesGrid(
             title = "Documents",
             subtitle = "",
             icon = InfiniteIcons.Folder,
-            accentColor = Color(0xFF4F7CFF),
+            accentColor = InfiniteColors.Primary,
             onClick = onComingSoonClick
         )
     )
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        Tittle(tittle = "Company Services")
+        Text(
+            text = "Company Services",
+            style = headline4,
+            color = Purple_500
+        )
 
         services.chunked(2).forEach { rowItems ->
             Row(

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
@@ -1,26 +1,26 @@
 package com.example.infinite_track.presentation.screen.home.content
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
@@ -28,17 +28,15 @@ import androidx.compose.ui.unit.dp
 import com.example.infinite_track.domain.model.attendance.TodayStatus
 import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
-import com.example.infinite_track.presentation.core.bodyThin
 import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.data.InfiniteGlassReportCard
 import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
 import com.example.infinite_track.presentation.design.tokens.InfiniteIcons
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
 import com.example.infinite_track.presentation.screen.home.HomeTodayStatusUiState
-import com.example.infinite_track.presentation.theme.Blue_500
 import com.example.infinite_track.presentation.theme.Purple_300
 import com.example.infinite_track.presentation.theme.Purple_500
-import com.example.infinite_track.presentation.theme.White
 import com.example.infinite_track.utils.UiState
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -76,7 +74,7 @@ fun HomeTodayStatusCard(
 
 @Composable
 private fun TodayStatusLoadingCard() {
-    TodayStatusSurface {
+    InfiniteGlassReportCard {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -90,7 +88,7 @@ private fun TodayStatusLoadingCard() {
 
 @Composable
 private fun TodayStatusErrorCard(message: String) {
-    TodayStatusSurface {
+    InfiniteGlassReportCard {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             TodayStatusHeader()
             Text(
@@ -118,62 +116,77 @@ private fun TodayStatusSuccessCard(
             label = "Status",
             value = todayStatus.displayStatus(statusKey),
             icon = InfiniteIcons.Person,
-            valueColor = InfiniteColors.Primary
+            accent = InfiniteColors.Primary
         ),
         TodayStatusMetric(
             label = "Mode",
             value = displayMode(todayStatus.activeMode),
-            icon = InfiniteIcons.Work
+            icon = InfiniteIcons.Work,
+            accent = InfiniteColors.Primary
         ),
         TodayStatusMetric(
             label = "Location",
             value = todayStatus.activeLocation?.description ?: "--",
-            icon = InfiniteIcons.Location
+            icon = InfiniteIcons.Location,
+            accent = InfiniteColors.Primary
         ),
         TodayStatusMetric(
             label = "Check-out",
             value = formatTime(todayStatus.checkedOutAt, todayStatus.checkedOutAtIso),
-            icon = InfiniteIcons.Time
+            icon = InfiniteIcons.Time,
+            accent = InfiniteColors.Primary
         ),
         TodayStatusMetric(
             label = "Check-in",
             value = formatTime(todayStatus.checkedInAt, todayStatus.checkedInAtIso),
-            icon = InfiniteIcons.Time
+            icon = InfiniteIcons.Time,
+            accent = InfiniteColors.Primary
         ),
         TodayStatusMetric(
             label = "Geofence",
             value = geofenceSummary(todayStatus, currentLocation),
             icon = InfiniteIcons.Shield,
+            accent = InfiniteColors.Primary,
             badge = true
         ),
         TodayStatusMetric(
             label = "Work Duration",
             value = formatDuration(todayStatus.workDurationSeconds),
-            icon = InfiniteIcons.Time
+            icon = InfiniteIcons.Time,
+            accent = InfiniteColors.Primary
         )
     )
 
-    TodayStatusSurface {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    InfiniteGlassReportCard {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             TodayStatusHeader()
-            Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 metrics.chunked(2).forEachIndexed { rowIndex, rowItems ->
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(70.dp)
                     ) {
-                        rowItems.forEach { metric ->
-                            TodayStatusMetricItem(
+                        rowItems.forEachIndexed { itemIndex, metric ->
+                            TodayStatusMetricCell(
                                 metric = metric,
                                 modifier = Modifier.weight(1f)
                             )
+                            if (itemIndex == 0 && rowItems.size > 1) {
+                                Box(
+                                    modifier = Modifier
+                                        .width(1.dp)
+                                        .fillMaxHeight()
+                                        .background(InfiniteColors.AttendanceReportGlassBorder)
+                                )
+                            }
                         }
                         if (rowItems.size == 1) {
                             Spacer(modifier = Modifier.weight(1f))
                         }
                     }
                     if (rowIndex < metrics.chunked(2).lastIndex) {
-                        Spacer(modifier = Modifier.height(8.dp))
+                        HorizontalDivider(color = InfiniteColors.AttendanceReportGlassBorder)
                     }
                 }
             }
@@ -185,63 +198,79 @@ private fun TodayStatusSuccessCard(
 private fun TodayStatusHeader() {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = InfiniteIcons.Calendar,
-            contentDescription = null,
-            tint = Blue_500,
-            modifier = Modifier.size(18.dp)
-        )
+        Box(
+            modifier = Modifier
+                .size(26.dp)
+                .clip(CircleShape)
+                .background(InfiniteColors.Primary.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = InfiniteIcons.Calendar,
+                contentDescription = null,
+                tint = InfiniteColors.Primary,
+                modifier = Modifier.size(14.dp)
+            )
+        }
         Text(
             text = "Today Status",
             color = Purple_500,
-            style = body1
+            style = headline4
         )
     }
 }
 
 @Composable
-private fun TodayStatusMetricItem(
+private fun TodayStatusMetricCell(
     metric: TodayStatusMetric,
     modifier: Modifier = Modifier
 ) {
-    Row(
+    Column(
         modifier = modifier
-            .background(White.copy(alpha = 0.30f), RoundedCornerShape(14.dp))
-            .padding(horizontal = 10.dp, vertical = 9.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .fillMaxHeight()
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        Icon(
-            imageVector = metric.icon,
-            contentDescription = null,
-            tint = Purple_500.copy(alpha = 0.88f),
-            modifier = Modifier.size(20.dp)
-        )
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            Box(
+                modifier = Modifier
+                    .size(26.dp)
+                    .clip(CircleShape)
+                    .background(metric.accent.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = metric.icon,
+                    contentDescription = null,
+                    tint = metric.accent,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
             Text(
                 text = metric.label,
+                style = body2,
                 color = Purple_300,
-                style = bodyThin,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            if (metric.badge) {
-                GeofenceBadge(text = metric.value)
-            } else {
-                Text(
-                    text = metric.value,
-                    color = metric.valueColor,
-                    style = headline4,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+        }
+
+        if (metric.badge) {
+            GeofenceBadge(text = metric.value)
+        } else {
+            Text(
+                text = metric.value,
+                style = headline4,
+                color = metric.accent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }
@@ -250,13 +279,13 @@ private fun TodayStatusMetricItem(
 private fun GeofenceBadge(text: String) {
     Box(
         modifier = Modifier
-            .background(InfiniteColors.Accent.copy(alpha = 0.58f), RoundedCornerShape(999.dp))
-            .padding(horizontal = 12.dp, vertical = 4.dp),
+            .background(InfiniteColors.Primary.copy(alpha = 0.12f), CircleShape)
+            .padding(horizontal = 10.dp, vertical = 3.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = text,
-            color = Purple_500,
+            color = InfiniteColors.Primary,
             style = body2,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -264,36 +293,11 @@ private fun GeofenceBadge(text: String) {
     }
 }
 
-@Composable
-private fun TodayStatusSurface(content: @Composable () -> Unit) {
-    Card(
-        shape = RoundedCornerShape(18.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0x33FFFFFF)),
-        border = BorderStroke(1.dp, White.copy(alpha = 0.92f)),
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 8.dp,
-                shape = RoundedCornerShape(18.dp),
-                ambientColor = Blue_500.copy(alpha = 0.24f),
-                spotColor = Blue_500.copy(alpha = 0.20f)
-            )
-    ) {
-        Box(
-            modifier = Modifier
-                .background(White.copy(alpha = 0.08f))
-                .padding(horizontal = 14.dp, vertical = 12.dp)
-        ) {
-            content()
-        }
-    }
-}
-
 private data class TodayStatusMetric(
     val label: String,
     val value: String,
     val icon: ImageVector,
-    val valueColor: Color = InfiniteColors.Text,
+    val accent: Color = InfiniteColors.Primary,
     val badge: Boolean = false
 )
 


### PR DESCRIPTION
## Summary
- Convert Today Status metrics into a single report-style card separated by dividers, matching My Attendance Report.
- Switch Today Status icons to outlined/regular variants with accent icon backgrounds.
- Redesign Hello greeting with a waving icon animation and profile avatar stroke animation using Primary/Secondary/Accent.
- Align greeting/name/program typography and colors with existing text styles.
- Restyle Company Services with smaller title, outlined icons, and accent-matched icon containers.

## Scope notes
- Presentation-only redesign for Home greeting, Today Status, and Company Services.
- No backend/auth/session changes.
- Reuses existing typography and report surface tokens.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Today Status uses one card with dividers, not nested cards
- Today Status surface/icons match report style
- Hello waving icon animates
- Profile avatar shows animated three-color stroke ring
- Name/program/hello typography looks consistent
- Company Services title is smaller and icons are regular/outlined
- Service icon backgrounds match icon accent colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)