### PR TITLE
fix: polish today status colors and remove profile stroke

### DIFF
--- a/app/src/main/java/com/example/infinite_track/presentation/components/tittle/NameComp.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/tittle/NameComp.kt
@@ -8,12 +8,10 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -26,14 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -54,7 +45,7 @@ fun nameCards(
     division: String,
     profileImage: String?
 ) {
-    val infiniteTransition = rememberInfiniteTransition(label = "home-hello-profile")
+    val infiniteTransition = rememberInfiniteTransition(label = "home-hello")
     val waveRotation by infiniteTransition.animateFloat(
         initialValue = -14f,
         targetValue = 14f,
@@ -63,15 +54,6 @@ fun nameCards(
             repeatMode = RepeatMode.Reverse
         ),
         label = "hello-wave"
-    )
-    val ringRotation by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 2400, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "profile-ring"
     )
 
     Column(
@@ -128,48 +110,19 @@ fun nameCards(
 
             Spacer(modifier = Modifier.width(10.dp))
 
-            Box(
+            AsyncImage(
+                model = profileImage ?: R.drawable.ic_profile,
+                contentDescription = null,
                 modifier = Modifier
-                    .size(58.dp)
-                    .drawBehind {
-                        val strokeWidth = 3.dp.toPx()
-                        val inset = strokeWidth / 2f
-                        rotate(ringRotation) {
-                            drawArc(
-                                brush = Brush.sweepGradient(
-                                    colors = listOf(
-                                        InfiniteColors.Primary,
-                                        InfiniteColors.Secondary,
-                                        InfiniteColors.Accent,
-                                        InfiniteColors.Primary
-                                    )
-                                ),
-                                startAngle = 0f,
-                                sweepAngle = 360f,
-                                useCenter = false,
-                                topLeft = Offset(inset, inset),
-                                size = Size(size.width - strokeWidth, size.height - strokeWidth),
-                                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
-                            )
-                        }
-                    }
-                    .padding(4.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                AsyncImage(
-                    model = profileImage ?: R.drawable.ic_profile,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                        .border(
-                            width = 1.dp,
-                            color = InfiniteColors.AttendanceReportGlassBorder,
-                            shape = CircleShape
-                        ),
-                    contentScale = ContentScale.Crop
-                )
-            }
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .border(
+                        width = 1.dp,
+                        color = InfiniteColors.AttendanceReportGlassBorder,
+                        shape = CircleShape
+                    ),
+                contentScale = ContentScale.Crop
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/home/content/HomeTodayStatusCard.kt
@@ -116,56 +116,56 @@ private fun TodayStatusSuccessCard(
             label = "Status",
             value = todayStatus.displayStatus(statusKey),
             icon = InfiniteIcons.Person,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         ),
         TodayStatusMetric(
             label = "Mode",
             value = displayMode(todayStatus.activeMode),
             icon = InfiniteIcons.Work,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         ),
         TodayStatusMetric(
             label = "Location",
             value = todayStatus.activeLocation?.description ?: "--",
             icon = InfiniteIcons.Location,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         ),
         TodayStatusMetric(
             label = "Check-out",
             value = formatTime(todayStatus.checkedOutAt, todayStatus.checkedOutAtIso),
             icon = InfiniteIcons.Time,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         ),
         TodayStatusMetric(
             label = "Check-in",
             value = formatTime(todayStatus.checkedInAt, todayStatus.checkedInAtIso),
             icon = InfiniteIcons.Time,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         ),
         TodayStatusMetric(
             label = "Geofence",
             value = geofenceSummary(todayStatus, currentLocation),
             icon = InfiniteIcons.Shield,
-            accent = InfiniteColors.Primary,
+            accent = InfiniteColors.Accent,
             badge = true
         ),
         TodayStatusMetric(
             label = "Work Duration",
             value = formatDuration(todayStatus.workDurationSeconds),
             icon = InfiniteIcons.Time,
-            accent = InfiniteColors.Primary
+            accent = Purple_500
         )
     )
 
     InfiniteGlassReportCard {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             TodayStatusHeader()
             Column(modifier = Modifier.fillMaxWidth()) {
                 metrics.chunked(2).forEachIndexed { rowIndex, rowItems ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(70.dp)
+                            .height(62.dp)
                     ) {
                         rowItems.forEachIndexed { itemIndex, metric ->
                             TodayStatusMetricCell(
@@ -198,23 +198,15 @@ private fun TodayStatusSuccessCard(
 private fun TodayStatusHeader() {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(26.dp)
-                .clip(CircleShape)
-                .background(InfiniteColors.Primary.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = InfiniteIcons.Calendar,
-                contentDescription = null,
-                tint = InfiniteColors.Primary,
-                modifier = Modifier.size(14.dp)
-            )
-        }
+        Icon(
+            imageVector = InfiniteIcons.Calendar,
+            contentDescription = null,
+            tint = Purple_500,
+            modifier = Modifier.size(22.dp)
+        )
         Text(
             text = "Today Status",
             color = Purple_500,
@@ -231,27 +223,19 @@ private fun TodayStatusMetricCell(
     Column(
         modifier = modifier
             .fillMaxHeight()
-            .padding(horizontal = 10.dp, vertical = 8.dp),
+            .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .size(26.dp)
-                    .clip(CircleShape)
-                    .background(metric.accent.copy(alpha = 0.12f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = metric.icon,
-                    contentDescription = null,
-                    tint = metric.accent,
-                    modifier = Modifier.size(14.dp)
-                )
-            }
+            Icon(
+                imageVector = metric.icon,
+                contentDescription = null,
+                tint = metric.accent,
+                modifier = Modifier.size(16.dp)
+            )
             Text(
                 text = metric.label,
                 style = body2,
@@ -279,13 +263,13 @@ private fun TodayStatusMetricCell(
 private fun GeofenceBadge(text: String) {
     Box(
         modifier = Modifier
-            .background(InfiniteColors.Primary.copy(alpha = 0.12f), CircleShape)
+            .background(InfiniteColors.Accent.copy(alpha = 0.12f), CircleShape)
             .padding(horizontal = 10.dp, vertical = 3.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = text,
-            color = InfiniteColors.Primary,
+            color = InfiniteColors.Accent,
             style = body2,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -297,7 +281,7 @@ private data class TodayStatusMetric(
     val label: String,
     val value: String,
     val icon: ImageVector,
-    val accent: Color = InfiniteColors.Primary,
+    val accent: Color = Purple_500,
     val badge: Boolean = false
 )
 


### PR DESCRIPTION
## Summary
- Match Today Status title/icon style to My Attendance Report (plain icon, no background circle).
- Use black/dark content and icon colors for metric cells.
- Tighten vertical spacing between Today Status rows/components.
- Set Geofence accent to Payslip accent color.
- Remove Home profile stroke animation and keep a plain avatar.

## Scope notes
- Presentation-only polish for Home greeting and Today Status.
- No backend/auth/session changes.

## Verification
Environment used locally:
```powershell
$env:JAVA_HOME="D:\Java_Home\java 1.8.2"
$env:ANDROID_HOME="C:\Users\Febriyadi\AppData\Local\Android\Sdk"
$env:ANDROID_SDK_ROOT=$env:ANDROID_HOME
$env:Path="$env:JAVA_HOME\bin;$env:ANDROID_HOME\platform-tools;$env:Path"
```

Passed:
- `./gradlew.bat --no-daemon app:assembleDebug`

## Needs Verification
Runtime visual checks on `develop` after merge/pull:
- Today Status title/icon match My Attendance Report style
- Metric content/icons look black/dark and consistent
- Vertical spacing is tighter
- Geofence uses Payslip accent color
- Home profile avatar has no stroke animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home screen’s daily status card with refined spacing, sizing, icon treatments, and purple accent colors.
  * Restyled the geofence badge for improved visual consistency.
  * Simplified the profile image presentation by removing the animated gradient ring.
  * Preserved the waving-hand animation and existing profile image behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->