### PR TITLE
INF-230 Refine permission typography and controls

### DIFF
--- a/app/src/androidTest/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreenTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreenTest.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -181,6 +183,40 @@ class AttendancePermissionReadinessScreenTest {
     }
 
     @Test
+    fun optionalSwitchCanRequestEnable() {
+        val events = mutableListOf<AttendancePermissionReadinessEvent>()
+        render(partialState(), onEvent = events::add)
+
+        composeRule.onNodeWithTag("permission-optional-toggle").performClick()
+        composeRule.onNodeWithTag(
+            "permission-access-toggle-notification",
+            useUnmergedTree = true
+        )
+            .assertIsOff()
+            .performClick()
+        assertEquals(
+            listOf(
+                AttendancePermissionReadinessEvent.PermissionItemClicked(
+                    AttendanceAccess.NOTIFICATION
+                )
+            ),
+            events
+        )
+
+    }
+
+    @Test
+    fun optionalSwitchReflectsReadyState() {
+        render(readyState(optionalReady = true))
+
+        composeRule.onNodeWithTag("permission-optional-toggle").performClick()
+        composeRule.onNodeWithTag(
+            "permission-access-toggle-notification",
+            useUnmergedTree = true
+        ).assertIsOn()
+    }
+
+    @Test
     fun readyPanelShowsReadySummary() {
         render(readyState(optionalReady = false))
 
@@ -311,14 +347,14 @@ class AttendancePermissionReadinessScreenTest {
                 permissionItem(
                     AttendanceAccess.NOTIFICATION,
                     if (optionalReady) "Siap" else "Terbatas",
-                    if (optionalReady) null else "Aktifkan",
+                    if (optionalReady) "Kelola" else "Aktifkan",
                     if (optionalReady) InfiniteSemantic.Success else InfiniteSemantic.Warning,
                     optionalReady
                 ),
                 permissionItem(
                     AttendanceAccess.BACKGROUND_LOCATION,
                     if (optionalReady) "Siap" else "Terbatas",
-                    if (optionalReady) null else "Atur akses",
+                    if (optionalReady) "Kelola" else "Atur akses",
                     if (optionalReady) InfiniteSemantic.Success else InfiniteSemantic.Warning,
                     optionalReady
                 )
@@ -397,7 +433,8 @@ class AttendancePermissionReadinessScreenTest {
             stateDescription = "$title, ${requirement.lowercase()}, $status${
                 action?.let { ", aksi $it" }.orEmpty()
             }",
-            isReady = ready
+            isReady = ready,
+            usesToggle = requirement == "Opsional"
         )
     }
 }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/AttendanceScreen.kt
@@ -476,9 +476,7 @@ fun AttendanceScreen(
 
                     // Top bar with location focus button - fixed parameters
                     AttendanceTopBar(
-                        modifier = Modifier
-                            .statusBarsPadding()
-                            .padding(16.dp),
+                        modifier = Modifier.statusBarsPadding(),
                         onBackClicked = { navController.navigateUp() },
                         onFocusLocationClicked = { viewModel.onFocusLocationClicked() },
                         onPermissionClicked = {
@@ -621,8 +619,7 @@ fun AttendanceScreenPreview() {
             AttendanceTopBar(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .statusBarsPadding()
-                    .padding(horizontal = 20.dp),
+                    .statusBarsPadding(),
                 onBackClicked = { },
                 onFocusLocationClicked = { },
                 onPermissionClicked = { }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessContract.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessContract.kt
@@ -24,7 +24,8 @@ data class PermissionItemUiModel(
     val iconKey: PermissionIconKey,
     val semantic: InfiniteSemantic,
     val stateDescription: String,
-    val isReady: Boolean
+    val isReady: Boolean,
+    val usesToggle: Boolean = false
 )
 
 data class AttendancePermissionFeedback(

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.testTag
@@ -52,8 +53,12 @@ import com.example.infinite_track.presentation.design.components.button.Infinite
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonState
 import com.example.infinite_track.presentation.design.components.button.InfiniteButtonVariant
 import com.example.infinite_track.presentation.design.components.state.InfiniteLoadingState
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.body2_5
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteFeedbackTypography
 import com.example.infinite_track.presentation.design.tokens.InfiniteMotion
 import com.example.infinite_track.presentation.design.tokens.InfiniteSpacing
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
@@ -279,7 +284,7 @@ private fun PermissionPanelHero(
             }
             Text(
                 text = if (canContinue) "Akses attendance siap" else "Izin akses diperlukan",
-                style = InfiniteFeedbackTypography.dialogTitle,
+                style = headline3,
                 color = InfiniteColors.Text
             )
             Text(
@@ -288,7 +293,7 @@ private fun PermissionPanelHero(
                 } else {
                     "Lengkapi akses wajib sebelum menjalankan presensi dan verifikasi wajah."
                 },
-                style = InfiniteFeedbackTypography.dialogBody,
+                style = body1,
                 color = InfiniteColors.Text.copy(alpha = 0.70f)
             )
             Row(
@@ -298,12 +303,12 @@ private fun PermissionPanelHero(
             ) {
                 Text(
                     text = "$readyCount/$totalCount akses wajib siap",
-                    style = InfiniteFeedbackTypography.actionLabel,
+                    style = body2,
                     color = InfiniteColors.Primary
                 )
                 Text(
                     text = "${(progress * 100).toInt()}%",
-                    style = InfiniteFeedbackTypography.pillLabel,
+                    style = body2_5,
                     color = InfiniteColors.Text.copy(alpha = 0.64f)
                 )
             }
@@ -311,7 +316,8 @@ private fun PermissionPanelHero(
                 progress = { progress.coerceIn(0f, 1f) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(8.dp),
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(999.dp)),
                 color = if (canContinue) InfiniteColors.Success else InfiniteColors.Primary,
                 trackColor = InfiniteColors.Neutral.copy(alpha = 0.14f)
             )
@@ -327,12 +333,12 @@ private fun PermissionSectionLabel(
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(
             text = title,
-            style = InfiniteFeedbackTypography.snackbarTitle,
+            style = headline4,
             color = InfiniteColors.Text
         )
         Text(
             text = subtitle,
-            style = InfiniteFeedbackTypography.supportingBody,
+            style = body2,
             color = InfiniteColors.Text.copy(alpha = 0.64f)
         )
     }
@@ -375,12 +381,12 @@ private fun OptionalPermissionHeader(
             ) {
                 Text(
                     text = "Akses opsional",
-                    style = InfiniteFeedbackTypography.snackbarTitle,
+                    style = headline4,
                     color = InfiniteColors.Text
                 )
                 Text(
-                    text = "$readyCount/$totalCount aktif · tidak menghambat absensi manual",
-                    style = InfiniteFeedbackTypography.pillLabel,
+                    text = "$readyCount/$totalCount aktif · ubah kapan saja melalui pengaturan perangkat",
+                    style = body2,
                     color = InfiniteColors.Text.copy(alpha = 0.64f)
                 )
             }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiMapper.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiMapper.kt
@@ -56,7 +56,9 @@ class AttendancePermissionReadinessUiMapper @Inject constructor() {
             iconKey = iconFor(entry.access),
             semantic = copy.semantic,
             stateDescription = "${titleFor(entry.access)}, ${if (entry.access.requirement == AttendanceAccessRequirement.REQUIRED) "wajib" else "opsional"}, ${copy.statusLabel}${actionLabelFor(entry)?.let { ", aksi $it" }.orEmpty()}",
-            isReady = entry.status == AttendanceAccessStatus.READY || entry.status == AttendanceAccessStatus.NOT_REQUIRED_ON_DEVICE
+            isReady = entry.status == AttendanceAccessStatus.READY || entry.status == AttendanceAccessStatus.NOT_REQUIRED_ON_DEVICE,
+            usesToggle = entry.access.requirement == AttendanceAccessRequirement.OPTIONAL &&
+                entry.status != AttendanceAccessStatus.NOT_REQUIRED_ON_DEVICE
         )
     }
 
@@ -79,7 +81,8 @@ class AttendancePermissionReadinessUiMapper @Inject constructor() {
         AttendanceAccessRecovery.OPEN_APPLICATION_SETTINGS,
         AttendanceAccessRecovery.OPEN_DEVICE_LOCATION_SETTINGS -> "Buka pengaturan"
         AttendanceAccessRecovery.NONE -> when (entry.status) {
-            AttendanceAccessStatus.READY,
+            AttendanceAccessStatus.READY ->
+                if (entry.access.requirement == AttendanceAccessRequirement.OPTIONAL) "Kelola" else null
             AttendanceAccessStatus.NOT_REQUIRED_ON_DEVICE -> null
             else -> "Coba lagi"
         }

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessViewModel.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.infinite_track.domain.model.attendance.permission.AttendanceAccess
 import com.example.infinite_track.domain.model.attendance.permission.AttendanceAccessStatus
+import com.example.infinite_track.domain.model.attendance.permission.AttendanceAccessRequirement
 import com.example.infinite_track.domain.model.attendance.permission.AttendancePermissionNextAction
 import com.example.infinite_track.domain.model.attendance.permission.AttendancePermissionReadiness
 import com.example.infinite_track.domain.model.attendance.permission.AttendancePermissionRequestOutcome
@@ -120,7 +121,20 @@ class AttendancePermissionReadinessViewModel @Inject constructor(
 
     private fun onItemClicked(access: AttendanceAccess) {
         val readiness = effectiveReadiness() ?: return
-        emitAction(resolveNextAction.forAccess(readiness, access))
+        val entry = readiness.entryOf(access)
+        if (
+            access.requirement == AttendanceAccessRequirement.OPTIONAL &&
+            entry?.status == AttendanceAccessStatus.READY
+        ) {
+            if (inFlightAction == null) {
+                emit(
+                    AttendancePermissionReadinessEffect.OpenApplicationSettings(access),
+                    trackInFlight = true
+                )
+            }
+        } else {
+            emitAction(resolveNextAction.forAccess(readiness, access))
+        }
     }
 
     private fun emitAction(action: AttendancePermissionNextAction) {
@@ -194,7 +208,12 @@ class AttendancePermissionReadinessViewModel @Inject constructor(
         AttendancePermissionReadinessEffect.RequestBackgroundLocation ->
             resolveNextAction.forAccess(readiness, AttendanceAccess.BACKGROUND_LOCATION) == AttendancePermissionNextAction.RequestPermission(AttendanceAccess.BACKGROUND_LOCATION)
         is AttendancePermissionReadinessEffect.OpenApplicationSettings ->
-            resolveNextAction.forAccess(readiness, effect.access) == AttendancePermissionNextAction.OpenApplicationSettings(effect.access)
+            (
+                effect.access.requirement == AttendanceAccessRequirement.OPTIONAL &&
+                    readiness.entryOf(effect.access)?.status == AttendanceAccessStatus.READY
+                ) ||
+                resolveNextAction.forAccess(readiness, effect.access) ==
+                AttendancePermissionNextAction.OpenApplicationSettings(effect.access)
         AttendancePermissionReadinessEffect.OpenDeviceLocationSettings ->
             resolveNextAction.forAccess(readiness, AttendanceAccess.DEVICE_LOCATION) == AttendancePermissionNextAction.OpenDeviceLocationSettings
         AttendancePermissionReadinessEffect.ClosePermissionPanel ->

--- a/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionAccessCard.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/screen/attendance/permission/PermissionAccessCard.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.icons.outlined.LocationSearching
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,8 +32,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.core.body2_5
 import com.example.infinite_track.presentation.design.tokens.InfiniteColors
-import com.example.infinite_track.presentation.design.tokens.InfiniteFeedbackTypography
 import com.example.infinite_track.presentation.design.tokens.InfiniteSpacing
 import com.example.infinite_track.presentation.design.tokens.infiniteSemanticColors
 
@@ -63,7 +67,7 @@ internal fun PermissionAccessCard(
                 stateDescription = item.stateDescription
             }
             .clickable(
-                enabled = actionAvailable,
+                enabled = actionAvailable && !item.usesToggle,
                 onClick = { onActionClick?.invoke() }
             ),
         shape = RoundedCornerShape(16.dp),
@@ -102,27 +106,53 @@ internal fun PermissionAccessCard(
             ) {
                 Text(
                     text = item.title,
-                    style = InfiniteFeedbackTypography.snackbarTitle,
+                    style = body1,
                     color = InfiniteColors.Text
                 )
                 Text(
                     text = item.supportingText,
-                    style = InfiniteFeedbackTypography.pillLabel,
+                    style = body2,
                     color = InfiniteColors.Text.copy(alpha = 0.66f),
                     maxLines = 2
                 )
+                if (item.usesToggle) {
+                    Text(
+                        text = item.statusLabel,
+                        style = body2_5,
+                        color = stateColors.accent
+                    )
+                }
             }
 
-            Surface(
-                shape = RoundedCornerShape(999.dp),
-                color = stateColors.container.compositeOver(InfiniteColors.Surface)
-            ) {
-                Text(
-                    text = item.actionLabel ?: item.statusLabel,
-                    style = InfiniteFeedbackTypography.actionLabel,
-                    color = stateColors.accent,
-                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp)
+            if (item.usesToggle) {
+                Switch(
+                    checked = item.isReady,
+                    onCheckedChange = if (actionAvailable) {
+                        { onActionClick?.invoke() }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier.testTag("permission-access-toggle-$accessKey"),
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = InfiniteColors.Surface,
+                        checkedTrackColor = InfiniteColors.Success,
+                        uncheckedThumbColor = InfiniteColors.Surface,
+                        uncheckedTrackColor = InfiniteColors.Neutral.copy(alpha = 0.36f),
+                        uncheckedBorderColor = InfiniteColors.Neutral.copy(alpha = 0.28f)
+                    )
                 )
+            } else {
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = stateColors.container.compositeOver(InfiniteColors.Surface)
+                ) {
+                    Text(
+                        text = item.actionLabel ?: item.statusLabel,
+                        style = body2_5,
+                        color = stateColors.accent,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp)
+                    )
+                }
             }
         }
     }

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiMapperTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessUiMapperTest.kt
@@ -62,6 +62,20 @@ class AttendancePermissionReadinessUiMapperTest {
     }
 
     @Test
+    fun `maps ready optional access as a manageable toggle`() {
+        val state = mapper.map(
+            readiness = readiness(),
+            nextAction = AttendancePermissionNextAction.ContinueToWorkMode
+        )
+
+        state.optionalItems.forEach { item ->
+            assertTrue(item.isReady)
+            assertTrue(item.usesToggle)
+            assertEquals("Kelola", item.actionLabel)
+        }
+    }
+
+    @Test
     fun `maps approximate only location with precise recovery copy`() {
         val state = mapper.map(
             readiness = readiness(
@@ -113,6 +127,7 @@ class AttendancePermissionReadinessUiMapperTest {
         assertEquals("Buka pengaturan", state.requiredItems[2].actionLabel)
         assertEquals("Tidak diperlukan di perangkat ini", state.optionalItems[0].statusLabel)
         assertNull(state.optionalItems[0].actionLabel)
+        assertFalse(state.optionalItems[0].usesToggle)
         assertEquals(PermissionIconKey.NOTIFICATION, state.optionalItems[0].iconKey)
     }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessViewModelTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/screen/attendance/permission/AttendancePermissionReadinessViewModelTest.kt
@@ -75,6 +75,26 @@ class AttendancePermissionReadinessViewModelTest {
     }
 
     @Test
+    fun `ready optional toggle opens application settings for disabling`() = runTest {
+        val viewModel = viewModel(FakeRepository(allRequiredReady()))
+        advanceUntilIdle()
+        val effect = async(UnconfinedTestDispatcher(testScheduler)) { viewModel.effects.first() }
+
+        viewModel.onEvent(
+            AttendancePermissionReadinessEvent.PermissionItemClicked(
+                AttendanceAccess.NOTIFICATION
+            )
+        )
+
+        assertEquals(
+            AttendancePermissionReadinessEffect.OpenApplicationSettings(
+                AttendanceAccess.NOTIFICATION
+            ),
+            effect.await()
+        )
+    }
+
+    @Test
     fun `optional request guard survives an unrelated observation change and clears on callback`() = runTest {
         val repository = FakeRepository(
             readiness(


### PR DESCRIPTION
## Ringkasan

- mengganti typography khusus feedback/snackbar pada permission panel dengan typography utama proyek (`headline3`, `headline4`, `body1`, `body2`, dan `body2_5`)
- membentuk progress indicator sebagai pill dengan radius penuh
- menambahkan switch untuk akses opsional agar status aktif/nonaktif lebih mudah dipahami dan dikelola
- membuka pengaturan Android ketika akses opsional yang sudah aktif ingin dinonaktifkan, lalu menyegarkan status saat kembali
- menghapus padding tambahan pada app bar Work Mode agar marginnya sama dengan app bar lain

## Alasan

Permission panel sebelumnya menggunakan type scale khusus komponen feedback sehingga hierarki teks tidak konsisten dengan layar lain. Work Mode juga menerapkan padding eksternal di atas padding bawaan `InfiniteTopBar`, sehingga app bar terlalu jauh dari tepi layar.

## Dampak pengguna

Hierarchy teks menjadi konsisten, progress lebih halus, opsi permission lebih fleksibel, dan posisi app bar Work Mode mengikuti layout global aplikasi.

## Validasi

- `app:compileDebugKotlin`
- `app:testDebugUnitTest`
- `app:compileDebugAndroidTestKotlin`
- `app:assembleDebug`

Runtime/device review tetap dilakukan setelah perubahan masuk ke `develop`, sesuai workflow proyek.