### PR TITLE
INF-230 Refine status feedback components

### DIFF
--- a/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
@@ -53,6 +53,33 @@ class InfiniteStateStatusComponentsTest {
         assertTrue(retried && dismissed)
     }
 
+    @Test fun transientSuccessAlertUsesTimedDismissWhileActionableStatesRemainPersistent() {
+        var dismissed = false
+        composeRule.mainClock.autoAdvance = false
+        composeRule.setContent {
+            Infinite_TrackTheme {
+                InfiniteInlineAlert(
+                    title = "Attendance saved",
+                    message = "Check-in recorded.",
+                    semantic = InfiniteSemantic.Success,
+                    onDismiss = { dismissed = true }
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Attendance saved").assertIsDisplayed()
+        composeRule.mainClock.advanceTimeBy(4_250)
+        composeRule.onNodeWithText("Attendance saved").assertDoesNotExist()
+        composeRule.runOnIdle { assertTrue(dismissed) }
+
+        assertEquals(InfiniteInlineAlertDuration.Short, InfiniteSemantic.Info.defaultInlineAlertDuration())
+        assertEquals(InfiniteInlineAlertDuration.Persistent, InfiniteSemantic.Warning.defaultInlineAlertDuration())
+        assertEquals(
+            InfiniteInlineAlertDuration.Persistent,
+            InfiniteSemantic.Success.defaultInlineAlertDuration(hasAction = true)
+        )
+    }
+
     @Test fun everySemanticHasDistinctAccessibleFeedbackAndIconContract() {
         InfiniteSemantic.entries.forEach { semantic ->
             composeRule.setContent { Infinite_TrackTheme { InfiniteInlineAlert(semantic.name, "Message", semantic) } }
@@ -66,7 +93,7 @@ class InfiniteStateStatusComponentsTest {
         assertTrue(!statusDialogUsesIllustration(null))
         val semantic = InfiniteSemantic.Success
         val default = resolveInfiniteStatusPillPalette(semantic, false, null, InfiniteStatusVariant.Active)
-        assertEquals(infiniteFeedbackPalette(semantic).surfaceEnd, default.container)
+        assertEquals(infiniteFeedbackPalette(semantic).stateContainer, default.container)
         val override = Color.Magenta
         assertEquals(override, resolveInfiniteStatusPillPalette(semantic, false, override, InfiniteStatusVariant.Active).content)
         assertEquals(InfiniteStatusVariant.Active.toAttendanceBadgeColor(), resolveInfiniteStatusPillPalette(semantic, true, null, InfiniteStatusVariant.Active).content)

--- a/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/button/attendance/AttendanceBottomSheetContent.kt
@@ -17,6 +17,7 @@ import com.example.infinite_track.presentation.components.button.InfiniteTrackBu
 import com.example.infinite_track.presentation.components.status.InfiniteTrackInlineAlert
 import com.example.infinite_track.presentation.components.status.StatusStates
 import com.example.infinite_track.presentation.core.headline4
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlertDuration
 import com.example.infinite_track.presentation.screen.attendance.AttendanceActionState
 import com.example.infinite_track.presentation.screen.attendance.AttendanceBlockReason
 import com.example.infinite_track.presentation.theme.Infinite_TrackTheme
@@ -132,7 +133,8 @@ private fun AttendanceActionInlineAlert(
             InfiniteTrackInlineAlert(
                 status = StatusStates.Info,
                 title = "Verifikasi wajah",
-                message = "Membuka scanner wajah untuk melanjutkan absensi."
+                message = "Membuka scanner wajah untuk melanjutkan absensi.",
+                duration = InfiniteInlineAlertDuration.Persistent
             )
         }
 
@@ -140,7 +142,8 @@ private fun AttendanceActionInlineAlert(
             InfiniteTrackInlineAlert(
                 status = StatusStates.Info,
                 title = "Mengirim absensi",
-                message = actionState.message
+                message = actionState.message,
+                duration = InfiniteInlineAlertDuration.Persistent
             )
         }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/components/status/InfiniteTrackInlineAlert.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/status/InfiniteTrackInlineAlert.kt
@@ -1,5 +1,23 @@
 package com.example.infinite_track.presentation.components.status
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlertDuration
 import com.example.infinite_track.presentation.design.components.status.InfiniteInlineAlert
-@Composable fun InfiniteTrackInlineAlert(status: StatusStateSpec, message: String, modifier: Modifier = Modifier, title: String? = status.value, onDismiss: (() -> Unit)? = null) = InfiniteInlineAlert(title.orEmpty(), message, status.toInfiniteSemantic(), modifier, onDismiss)
+import com.example.infinite_track.presentation.design.components.status.defaultInlineAlertDuration
+
+@Composable
+fun InfiniteTrackInlineAlert(
+    status: StatusStateSpec,
+    message: String,
+    modifier: Modifier = Modifier,
+    title: String? = status.value,
+    onDismiss: (() -> Unit)? = null,
+    duration: InfiniteInlineAlertDuration = status.toInfiniteSemantic().defaultInlineAlertDuration()
+) = InfiniteInlineAlert(
+    title = title.orEmpty(),
+    message = message,
+    semantic = status.toInfiniteSemantic(),
+    modifier = modifier,
+    onDismiss = onDismiss,
+    duration = duration
+)

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
@@ -1,8 +1,14 @@
 package com.example.infinite_track.presentation.design.components.status
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,10 +29,18 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
@@ -35,37 +49,132 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.example.infinite_track.presentation.design.tokens.InfiniteFeedbackTypography
+import com.example.infinite_track.presentation.design.tokens.InfiniteMotion
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
 import com.example.infinite_track.presentation.design.tokens.InfiniteSpacing
 import com.example.infinite_track.presentation.design.tokens.infiniteFeedbackPalette
 import com.example.infinite_track.presentation.theme.White
+import kotlinx.coroutines.delay
 
-@Composable
-fun InfiniteInlineAlert(title: String, message: String, semantic: InfiniteSemantic, modifier: Modifier = Modifier, onDismiss: (() -> Unit)? = null) {
-    InfiniteInlineAlertContent(title, message, semantic, null, null, modifier, onDismiss)
+enum class InfiniteInlineAlertDuration(internal val timeoutMillis: Int?) {
+    Short(4_000),
+    Long(8_000),
+    Persistent(null)
+}
+
+fun InfiniteSemantic.defaultInlineAlertDuration(
+    hasAction: Boolean = false
+): InfiniteInlineAlertDuration {
+    if (hasAction) return InfiniteInlineAlertDuration.Persistent
+    return when (this) {
+        InfiniteSemantic.Success,
+        InfiniteSemantic.Info -> InfiniteInlineAlertDuration.Short
+        InfiniteSemantic.Primary,
+        InfiniteSemantic.Secondary,
+        InfiniteSemantic.Warning,
+        InfiniteSemantic.Error,
+        InfiniteSemantic.Neutral -> InfiniteInlineAlertDuration.Persistent
+    }
 }
 
 @Composable
-fun InfiniteInlineAlert(title: String, message: String, semantic: InfiniteSemantic, actionLabel: String, onAction: () -> Unit, modifier: Modifier = Modifier, onDismiss: (() -> Unit)? = null) {
-    InfiniteInlineAlertContent(title, message, semantic, actionLabel, onAction, modifier, onDismiss)
+fun InfiniteInlineAlert(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    modifier: Modifier = Modifier,
+    onDismiss: (() -> Unit)? = null,
+    duration: InfiniteInlineAlertDuration = semantic.defaultInlineAlertDuration()
+) {
+    InfiniteInlineAlertContent(title, message, semantic, null, null, modifier, onDismiss, duration)
 }
 
 @Composable
-private fun InfiniteInlineAlertContent(title: String, message: String, semantic: InfiniteSemantic, actionLabel: String?, onAction: (() -> Unit)?, modifier: Modifier, onDismiss: (() -> Unit)?) {
+fun InfiniteInlineAlert(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    actionLabel: String,
+    onAction: () -> Unit,
+    modifier: Modifier = Modifier,
+    onDismiss: (() -> Unit)? = null,
+    duration: InfiniteInlineAlertDuration = semantic.defaultInlineAlertDuration(hasAction = true)
+) {
+    InfiniteInlineAlertContent(title, message, semantic, actionLabel, onAction, modifier, onDismiss, duration)
+}
+
+@Composable
+private fun InfiniteInlineAlertContent(
+    title: String,
+    message: String,
+    semantic: InfiniteSemantic,
+    actionLabel: String?,
+    onAction: (() -> Unit)?,
+    modifier: Modifier,
+    onDismiss: (() -> Unit)?,
+    duration: InfiniteInlineAlertDuration
+) {
     val palette = infiniteFeedbackPalette(semantic)
-    InfiniteFeedbackGlassSurface(
-        semantic = semantic,
-        modifier = modifier.fillMaxWidth().semantics(mergeDescendants = true) { contentDescription = "$title. $message" }
-    ) {
-        Row(Modifier.padding(InfiniteSpacing.Default.lg), horizontalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.sm), verticalAlignment = Alignment.Top) {
-            Icon(semanticIcon(semantic), null, tint = palette.accent, modifier = Modifier.size(22.dp))
-            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(title, color = palette.content, style = InfiniteFeedbackTypography.snackbarTitle)
-                Text(message, color = palette.supportingContent, style = InfiniteFeedbackTypography.supportingBody)
-                if (actionLabel != null && onAction != null) TextButton(actionLabel, onAction)
+    var visible by remember(title, message, semantic, duration) { mutableStateOf(true) }
+    var dismissalRequested by remember(title, message, semantic, duration) { mutableStateOf(false) }
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+
+    LaunchedEffect(title, message, semantic, duration) {
+        duration.timeoutMillis?.let { timeout ->
+            delay(timeout.toLong())
+            if (!dismissalRequested) {
+                dismissalRequested = true
+                visible = false
+                delay(InfiniteMotion.ExitDurationMillis.toLong())
+                currentOnDismiss?.invoke()
             }
-            if (onDismiss != null) IconButton(onDismiss, Modifier.sizeIn(48.dp, 48.dp)) {
-                Icon(Icons.Default.Close, "Dismiss alert", tint = palette.content)
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = fadeIn(InfiniteMotion.enterTween()) +
+            expandVertically(InfiniteMotion.enterTween(), expandFrom = Alignment.Top),
+        exit = fadeOut(InfiniteMotion.exitTween()) +
+            shrinkVertically(InfiniteMotion.exitTween(), shrinkTowards = Alignment.Top)
+    ) {
+        InfiniteFeedbackGlassSurface(
+            semantic = semantic,
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics(mergeDescendants = true) { contentDescription = "$title. $message" }
+        ) {
+            Row(
+                Modifier.padding(InfiniteSpacing.Default.lg),
+                horizontalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.md),
+                verticalAlignment = Alignment.Top
+            ) {
+                FeedbackIcon(semantic = semantic, size = 44.dp, iconSize = 24.dp)
+                Column(
+                    Modifier
+                        .weight(1f)
+                        .padding(top = 2.dp),
+                    verticalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.xs)
+                ) {
+                    Text(title, color = palette.content, style = InfiniteFeedbackTypography.snackbarTitle)
+                    Text(message, color = palette.supportingContent, style = InfiniteFeedbackTypography.supportingBody)
+                    if (actionLabel != null && onAction != null) TextButton(actionLabel, onAction)
+                }
+                if (onDismiss != null || duration != InfiniteInlineAlertDuration.Persistent) {
+                    IconButton(
+                        onClick = {
+                            if (!dismissalRequested) {
+                                dismissalRequested = true
+                                visible = false
+                                currentOnDismiss?.invoke()
+                            }
+                        },
+                        modifier = Modifier.sizeIn(48.dp, 48.dp)
+                    ) {
+                        Icon(Icons.Default.Close, "Dismiss alert", tint = palette.supportingContent)
+                    }
+                }
             }
         }
     }
@@ -87,7 +196,7 @@ internal fun InfiniteStatusDialogContent(title: String, message: String, semanti
     val palette = infiniteFeedbackPalette(semantic)
     Dialog(onDismissRequest = onDismiss) { InfiniteFeedbackGlassSurface(semantic, modifier.fillMaxWidth()) {
         Column(Modifier.fillMaxWidth().padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-            if (imageRes != null) Image(painterResource(imageRes), null, Modifier.size(112.dp)) else Icon(semanticIcon(semantic), null, tint = palette.accent, modifier = Modifier.size(64.dp))
+            if (imageRes != null) Image(painterResource(imageRes), null, Modifier.size(112.dp)) else FeedbackIcon(semantic)
             Spacer(Modifier.height(18.dp)); Text(title, style = InfiniteFeedbackTypography.dialogTitle, color = palette.content, textAlign = TextAlign.Center)
             Spacer(Modifier.height(10.dp)); Text(message, style = InfiniteFeedbackTypography.dialogBody, color = palette.supportingContent, textAlign = TextAlign.Center)
             Spacer(Modifier.height(24.dp)); Button(onConfirm, Modifier.fillMaxWidth().sizeIn(minHeight = 48.dp), colors = ButtonDefaults.buttonColors(containerColor = infiniteFeedbackPalette(InfiniteSemantic.Primary).accent, contentColor = White)) { Text(confirmText, style = InfiniteFeedbackTypography.actionLabel) }
@@ -111,7 +220,7 @@ internal fun InfiniteConfirmDialogBody(title: String, message: String, semantic:
     val palette = infiniteFeedbackPalette(semantic)
     InfiniteFeedbackGlassSurface(semantic, modifier.fillMaxWidth()) {
         Column(Modifier.fillMaxWidth().padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(semanticIcon(semantic), null, tint = palette.accent, modifier = Modifier.size(58.dp)); Spacer(Modifier.height(18.dp))
+            FeedbackIcon(semantic); Spacer(Modifier.height(18.dp))
             Text(title, style = InfiniteFeedbackTypography.dialogTitle, color = palette.content, textAlign = TextAlign.Center); Spacer(Modifier.height(10.dp))
             Text(message, style = InfiniteFeedbackTypography.dialogBody, color = palette.supportingContent, textAlign = TextAlign.Center); Spacer(Modifier.height(24.dp))
             BoxWithConstraints {
@@ -129,6 +238,30 @@ private fun DialogButtons(cancelText: String, confirmText: String, onDismiss: ()
     val modifier = if (weighted) Modifier.sizeIn(minHeight = 48.dp) else Modifier.fillMaxWidth().sizeIn(minHeight = 48.dp)
     OutlinedButton(onDismiss, modifier) { Text(cancelText, style = InfiniteFeedbackTypography.actionLabel) }
     Button(onConfirm, modifier, colors = ButtonDefaults.buttonColors(containerColor = if (destructive) InfiniteSemantic.Error.let { infiniteFeedbackPalette(it).accent } else infiniteFeedbackPalette(InfiniteSemantic.Primary).accent, contentColor = White)) { Text(confirmText, style = InfiniteFeedbackTypography.actionLabel) }
+}
+
+@Composable
+private fun FeedbackIcon(
+    semantic: InfiniteSemantic,
+    size: androidx.compose.ui.unit.Dp = 64.dp,
+    iconSize: androidx.compose.ui.unit.Dp = 32.dp
+) {
+    val palette = infiniteFeedbackPalette(semantic)
+    Surface(
+        modifier = Modifier.size(size),
+        shape = CircleShape,
+        color = palette.stateContainer,
+        contentColor = palette.accent
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = semanticIcon(semantic),
+                contentDescription = null,
+                modifier = Modifier.size(iconSize),
+                tint = palette.accent
+            )
+        }
+    }
 }
 
 internal fun semanticIcon(semantic: InfiniteSemantic) = when (semantic) {

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedbackGlassSurface.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedbackGlassSurface.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -30,8 +29,8 @@ fun InfiniteFeedbackGlassSurface(
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(InfiniteRadius.Large),
     shadowElevation: Dp = InfiniteElevation.Soft,
-    showAccentRail: Boolean = true,
-    showTopHighlight: Boolean = true,
+    showAccentRail: Boolean = false,
+    showTopHighlight: Boolean = false,
     content: @Composable BoxScope.() -> Unit
 ) {
     val palette = infiniteFeedbackPalette(semantic)
@@ -39,7 +38,7 @@ fun InfiniteFeedbackGlassSurface(
         modifier = modifier
             .shadow(shadowElevation, shape, ambientColor = palette.shadow, spotColor = palette.shadow)
             .clip(shape)
-            .background(Brush.verticalGradient(listOf(palette.surfaceStart, palette.surfaceEnd)))
+            .background(palette.surface)
             .border(1.dp, palette.border, shape)
     ) {
         if (showAccentRail || showTopHighlight) {

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
@@ -51,7 +51,7 @@ internal data class InfiniteStatusPillPalette(val container: Color, val content:
 internal fun resolveInfiniteStatusPillPalette(semantic: InfiniteSemantic, shared: Boolean, override: Color?, variant: InfiniteStatusVariant): InfiniteStatusPillPalette {
     val palette = infiniteFeedbackPalette(semantic); val sharedColor = override ?: variant.toAttendanceBadgeColor()
     return if (shared || override != null) InfiniteStatusPillPalette(sharedColor.copy(alpha = .13f), sharedColor, sharedColor.copy(alpha = .35f), sharedColor)
-    else InfiniteStatusPillPalette(palette.surfaceEnd, palette.content, palette.border, palette.accent)
+    else InfiniteStatusPillPalette(palette.stateContainer, palette.content, palette.border, palette.accent)
 }
 
 @Composable

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
@@ -10,13 +10,12 @@ import com.example.infinite_track.presentation.theme.sfCompact_font
 
 @Immutable
 data class InfiniteFeedbackPalette(
-    val surfaceStart: Color,
-    val surfaceEnd: Color,
+    val surface: Color,
+    val stateContainer: Color,
     val content: Color,
     val supportingContent: Color,
     val border: Color,
     val accent: Color,
-    val glow: Color,
     val shadow: Color,
     val topHighlight: Color
 )
@@ -69,15 +68,14 @@ object InfiniteFeedbackTypography {
 fun infiniteFeedbackPalette(semantic: InfiniteSemantic): InfiniteFeedbackPalette {
     val semanticColors = semanticColors(semantic)
     return InfiniteFeedbackPalette(
-        surfaceStart = White.copy(alpha = 0.92f),
-        surfaceEnd = semanticColors.container.copy(alpha = 0.72f),
+        surface = White.copy(alpha = 0.94f),
+        stateContainer = semanticColors.container,
         content = semanticColors.content,
         supportingContent = semanticColors.content.copy(alpha = 0.76f),
-        border = semanticColors.border.copy(alpha = 0.82f),
+        border = semanticColors.border.copy(alpha = 0.72f),
         accent = semanticColors.accent,
-        glow = semanticColors.accent.copy(alpha = 0.20f),
-        shadow = semanticColors.accent.copy(alpha = 0.18f),
-        topHighlight = White.copy(alpha = 0.96f)
+        shadow = InfiniteColors.Text.copy(alpha = 0.10f),
+        topHighlight = White.copy(alpha = 0.88f)
     )
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteMotion.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteMotion.kt
@@ -1,15 +1,31 @@
 package com.example.infinite_track.presentation.design.tokens
 
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 
 object InfiniteMotion {
     const val FastDurationMillis = 160
     const val NormalDurationMillis = 240
     const val SlowDurationMillis = 320
+    const val EnterDurationMillis = 300
+    const val ExitDurationMillis = 200
+
+    private val EmphasizedEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+    private val EmphasizedDecelerateEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+    private val EmphasizedAccelerateEasing = CubicBezierEasing(0.3f, 0f, 0.8f, 0.15f)
 
     fun <T> normalTween() = tween<T>(
         durationMillis = NormalDurationMillis,
-        easing = FastOutSlowInEasing
+        easing = EmphasizedEasing
+    )
+
+    fun <T> enterTween() = tween<T>(
+        durationMillis = EnterDurationMillis,
+        easing = EmphasizedDecelerateEasing
+    )
+
+    fun <T> exitTween() = tween<T>(
+        durationMillis = ExitDurationMillis,
+        easing = EmphasizedAccelerateEasing
     )
 }

--- a/app/src/test/java/com/example/infinite_track/presentation/design/components/status/InfiniteInlineAlertPolicyTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/design/components/status/InfiniteInlineAlertPolicyTest.kt
@@ -1,0 +1,36 @@
+package com.example.infinite_track.presentation.design.components.status
+
+import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InfiniteInlineAlertPolicyTest {
+
+    @Test
+    fun `success and info without actions use short timed feedback`() {
+        assertEquals(
+            InfiniteInlineAlertDuration.Short,
+            InfiniteSemantic.Success.defaultInlineAlertDuration()
+        )
+        assertEquals(
+            InfiniteInlineAlertDuration.Short,
+            InfiniteSemantic.Info.defaultInlineAlertDuration()
+        )
+    }
+
+    @Test
+    fun `actionable warning error and processing overrides remain persistent`() {
+        assertEquals(
+            InfiniteInlineAlertDuration.Persistent,
+            InfiniteSemantic.Warning.defaultInlineAlertDuration()
+        )
+        assertEquals(
+            InfiniteInlineAlertDuration.Persistent,
+            InfiniteSemantic.Error.defaultInlineAlertDuration()
+        )
+        assertEquals(
+            InfiniteInlineAlertDuration.Persistent,
+            InfiniteSemantic.Success.defaultInlineAlertDuration(hasAction = true)
+        )
+    }
+}

--- a/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
@@ -16,9 +16,8 @@ class InfiniteFeedbackTokensTest {
         InfiniteSemantic.entries.forEach { semantic ->
             val palette = infiniteFeedbackPalette(semantic)
 
-            assertNotEquals(palette.surfaceStart, palette.surfaceEnd)
+            assertNotEquals(palette.surface, palette.stateContainer)
             assertNotEquals(palette.content, palette.border)
-            assertNotEquals(palette.accent, palette.glow)
             assertNotEquals(palette.shadow, palette.topHighlight)
         }
     }
@@ -60,12 +59,10 @@ class InfiniteFeedbackTokensTest {
         InfiniteSemantic.entries.forEach { semantic ->
             val palette = infiniteFeedbackPalette(semantic)
 
-            listOf(palette.surfaceStart, palette.surfaceEnd).forEach { surface ->
-                assertTrue(
-                    "${semantic.name} content must meet 4.5 to 1 over glass surface",
-                    contrastRatio(palette.content, surface.compositedOver(Color.White)) >= 4.5
-                )
-            }
+            assertTrue(
+                "${semantic.name} content must meet 4.5 to 1 over the solid feedback surface",
+                contrastRatio(palette.content, palette.surface.compositedOver(Color.White)) >= 4.5
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

- replace the shared feedback gradient with a solid, semi-transparent surface
- use semantic color on borders and icon containers instead of full-card gradients
- refine inline alerts and confirmation/status dialogs to match the approved state-component direction
- auto-dismiss transient Success and Info inline alerts after 4 seconds
- keep Warning, Error, actionable alerts, face verification, and attendance submission states persistent
- update feedback palette, motion, and component-policy tests

## Why

The shared feedback surface applied a vertical semantic gradient to inline alerts, snackbars, dialogs, and embedded states. This made warning cards and confirmation dialogs visually heavy and inconsistent with the requested state-system reference.

## Impact

All consumers of the shared feedback surface now receive the solid treatment. Transient feedback clears automatically, while recovery and active-process states remain visible until the owning flow changes or the user acts.

## Validation

- `app:compileDebugKotlin`
- `app:testDebugUnitTest`
- `app:compileDebugAndroidTestKotlin`
- `app:assembleDebug`

Runtime visual verification remains scheduled on `develop` after review, following the project workflow.

Linear: INF-230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline alerts now support timed or persistent display behavior based on status and available actions.
  * Success and informational alerts can dismiss automatically, while actionable, warning, and error alerts remain visible.
  * Added smoother enter and exit animations for feedback components.
  * Updated feedback icons, colors, surfaces, and status pills for clearer visual presentation.
* **Bug Fixes**
  * Improved alert dismissal behavior and contrast safety across feedback states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->