### PR TITLE
INF-230 Compact status feedback cards

### DIFF
--- a/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
@@ -68,6 +68,7 @@ class InfiniteStateStatusComponentsTest {
         }
 
         composeRule.onNodeWithText("Attendance saved").assertIsDisplayed()
+        composeRule.onNodeWithTag(INLINE_ALERT_TIMER_TAG, useUnmergedTree = true).assertIsDisplayed()
         composeRule.mainClock.advanceTimeBy(4_250)
         composeRule.onNodeWithText("Attendance saved").assertDoesNotExist()
         composeRule.runOnIdle { assertTrue(dismissed) }
@@ -78,6 +79,21 @@ class InfiniteStateStatusComponentsTest {
             InfiniteInlineAlertDuration.Persistent,
             InfiniteSemantic.Success.defaultInlineAlertDuration(hasAction = true)
         )
+    }
+
+    @Test fun persistentAlertDoesNotRenderAutoDismissTimer() {
+        composeRule.setContent {
+            Infinite_TrackTheme {
+                InfiniteInlineAlert(
+                    title = "Location required",
+                    message = "Open access settings.",
+                    semantic = InfiniteSemantic.Warning
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Location required").assertIsDisplayed()
+        composeRule.onNodeWithTag(INLINE_ALERT_TIMER_TAG, useUnmergedTree = true).assertDoesNotExist()
     }
 
     @Test fun everySemanticHasDistinctAccessibleFeedbackAndIconContract() {

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteFeedback.kt
@@ -2,14 +2,19 @@ package com.example.infinite_track.presentation.design.components.status
 
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -41,8 +46,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -55,6 +63,8 @@ import com.example.infinite_track.presentation.design.tokens.InfiniteSpacing
 import com.example.infinite_track.presentation.design.tokens.infiniteFeedbackPalette
 import com.example.infinite_track.presentation.theme.White
 import kotlinx.coroutines.delay
+
+internal const val INLINE_ALERT_TIMER_TAG = "inlineAlertTimer"
 
 enum class InfiniteInlineAlertDuration(internal val timeoutMillis: Int?) {
     Short(4_000),
@@ -117,11 +127,19 @@ private fun InfiniteInlineAlertContent(
     val palette = infiniteFeedbackPalette(semantic)
     var visible by remember(title, message, semantic, duration) { mutableStateOf(true) }
     var dismissalRequested by remember(title, message, semantic, duration) { mutableStateOf(false) }
+    val timerProgress = remember(title, message, semantic, duration) { Animatable(1f) }
     val currentOnDismiss by rememberUpdatedState(onDismiss)
 
     LaunchedEffect(title, message, semantic, duration) {
+        timerProgress.snapTo(1f)
         duration.timeoutMillis?.let { timeout ->
-            delay(timeout.toLong())
+            timerProgress.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(
+                    durationMillis = timeout,
+                    easing = LinearEasing
+                )
+            )
             if (!dismissalRequested) {
                 dismissalRequested = true
                 visible = false
@@ -146,19 +164,22 @@ private fun InfiniteInlineAlertContent(
                 .semantics(mergeDescendants = true) { contentDescription = "$title. $message" }
         ) {
             Row(
-                Modifier.padding(InfiniteSpacing.Default.lg),
-                horizontalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.md),
+                Modifier.padding(
+                    horizontal = InfiniteSpacing.Default.md,
+                    vertical = InfiniteSpacing.Default.sm
+                ),
+                horizontalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.sm),
                 verticalAlignment = Alignment.Top
             ) {
-                FeedbackIcon(semantic = semantic, size = 44.dp, iconSize = 24.dp)
+                FeedbackIcon(semantic = semantic, size = 36.dp, iconSize = 20.dp)
                 Column(
                     Modifier
                         .weight(1f)
-                        .padding(top = 2.dp),
-                    verticalArrangement = Arrangement.spacedBy(InfiniteSpacing.Default.xs)
+                        .padding(top = 1.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
-                    Text(title, color = palette.content, style = InfiniteFeedbackTypography.snackbarTitle)
-                    Text(message, color = palette.supportingContent, style = InfiniteFeedbackTypography.supportingBody)
+                    Text(title, color = palette.content, style = InfiniteFeedbackTypography.inlineTitle)
+                    Text(message, color = palette.supportingContent, style = InfiniteFeedbackTypography.inlineBody)
                     if (actionLabel != null && onAction != null) TextButton(actionLabel, onAction)
                 }
                 if (onDismiss != null || duration != InfiniteInlineAlertDuration.Persistent) {
@@ -176,7 +197,43 @@ private fun InfiniteInlineAlertContent(
                     }
                 }
             }
+            if (duration.timeoutMillis != null) {
+                InlineAlertTimer(
+                    progress = { timerProgress.value },
+                    trackColor = palette.stateContainer,
+                    progressColor = palette.accent
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun BoxScope.InlineAlertTimer(
+    progress: () -> Float,
+    trackColor: androidx.compose.ui.graphics.Color,
+    progressColor: androidx.compose.ui.graphics.Color
+) {
+    Canvas(
+        modifier = Modifier
+            .align(Alignment.BottomStart)
+            .fillMaxWidth()
+            .height(3.dp)
+            .testTag(INLINE_ALERT_TIMER_TAG)
+    ) {
+        val radius = size.height / 2f
+        drawRoundRect(
+            color = trackColor,
+            cornerRadius = CornerRadius(radius, radius)
+        )
+        drawRoundRect(
+            color = progressColor,
+            size = Size(
+                width = size.width * progress().coerceIn(0f, 1f),
+                height = size.height
+            ),
+            cornerRadius = CornerRadius(radius, radius)
+        )
     }
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.theme.Violet_50
 import com.example.infinite_track.presentation.theme.White
 import com.example.infinite_track.presentation.theme.sfCompact_font
 
@@ -21,6 +24,13 @@ data class InfiniteFeedbackPalette(
 )
 
 object InfiniteFeedbackTypography {
+    val inlineTitle = body1.copy(
+        fontWeight = FontWeight.Bold,
+        lineHeight = 18.sp
+    )
+    val inlineBody = body2.copy(
+        lineHeight = 16.sp
+    )
     val snackbarMessage = TextStyle(
         fontFamily = sfCompact_font,
         fontWeight = FontWeight.Medium,
@@ -68,14 +78,14 @@ object InfiniteFeedbackTypography {
 fun infiniteFeedbackPalette(semantic: InfiniteSemantic): InfiniteFeedbackPalette {
     val semanticColors = semanticColors(semantic)
     return InfiniteFeedbackPalette(
-        surface = White.copy(alpha = 0.94f),
+        surface = Violet_50.copy(alpha = 0.5f),
         stateContainer = semanticColors.container,
         content = semanticColors.content,
         supportingContent = semanticColors.content.copy(alpha = 0.76f),
-        border = semanticColors.border.copy(alpha = 0.72f),
+        border = semanticColors.border.copy(alpha = 0.52f),
         accent = semanticColors.accent,
-        shadow = InfiniteColors.Text.copy(alpha = 0.10f),
-        topHighlight = White.copy(alpha = 0.88f)
+        shadow = InfiniteColors.Text.copy(alpha = 0.08f),
+        topHighlight = White.copy(alpha = 0.56f)
     )
 }
 

--- a/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
@@ -3,6 +3,9 @@ package com.example.infinite_track.presentation.design.tokens
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Color
+import com.example.infinite_track.presentation.core.body1
+import com.example.infinite_track.presentation.core.body2
+import com.example.infinite_track.presentation.theme.Violet_50
 import com.example.infinite_track.presentation.theme.sfCompact_font
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -26,7 +29,16 @@ class InfiniteFeedbackTokensTest {
     fun `feedback typography uses registered medium and bold styles with approved line heights`() {
         val typography = InfiniteFeedbackTypography
 
+        assertEquals(body1.fontFamily, typography.inlineTitle.fontFamily)
+        assertEquals(body2.fontFamily, typography.inlineBody.fontFamily)
+        assertEquals(14.sp, typography.inlineTitle.fontSize)
+        assertEquals(18.sp, typography.inlineTitle.lineHeight)
+        assertEquals(12.sp, typography.inlineBody.fontSize)
+        assertEquals(16.sp, typography.inlineBody.lineHeight)
+
         listOf(
+            typography.inlineTitle,
+            typography.inlineBody,
             typography.snackbarMessage,
             typography.snackbarTitle,
             typography.supportingBody,
@@ -59,6 +71,7 @@ class InfiniteFeedbackTokensTest {
         InfiniteSemantic.entries.forEach { semantic ->
             val palette = infiniteFeedbackPalette(semantic)
 
+            assertEquals(Violet_50.copy(alpha = 0.5f), palette.surface)
             assertTrue(
                 "${semantic.name} content must meet 4.5 to 1 over the solid feedback surface",
                 contrastRatio(palette.content, palette.surface.compositedOver(Color.White)) >= 4.5


### PR DESCRIPTION
## Summary
- add a visible 3dp countdown progress line to timed inline alerts
- compact inline alert padding and icon dimensions
- use the existing `body1` and `body2` typography for title and subtitle
- match the feedback surface to the login field's `Violet_50` at 50% alpha
- preserve persistent alert behavior and update UI/token tests

## Why
Follow-up to #92. Visual review showed that timed alerts had no visible duration feedback, the card and text hierarchy were oversized, and the surface was too opaque compared with the existing email/password fields.

## Impact
Transient Success and Info alerts now communicate their remaining display time and use a more compact layout. Persistent Warning, Error, action, and processing states retain their existing behavior.

## Validation
- `app:compileDebugKotlin`
- `app:testDebugUnitTest`
- `app:compileDebugAndroidTestKotlin`
- `app:assembleDebug`

Runtime visual verification remains scheduled on `develop`.

Linear: INF-230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an animated countdown indicator to time-limited inline alerts.
  - Alerts now visibly show remaining display time before automatically dismissing.
  - Persistent alerts remain visible without displaying a countdown.

- **Style**
  - Refined inline alert typography, spacing, icon sizing, colors, borders, shadows, and highlights for a clearer, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->