### PR TITLE
INF-230: Align state status typography and surfaces

### DIFF
--- a/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
+++ b/app/src/androidTest/java/com/example/infinite_track/presentation/design/components/status/InfiniteStateStatusComponentsTest.kt
@@ -109,7 +109,7 @@ class InfiniteStateStatusComponentsTest {
         assertTrue(!statusDialogUsesIllustration(null))
         val semantic = InfiniteSemantic.Success
         val default = resolveInfiniteStatusPillPalette(semantic, false, null, InfiniteStatusVariant.Active)
-        assertEquals(infiniteFeedbackPalette(semantic).stateContainer, default.container)
+        assertEquals(infiniteFeedbackPalette(semantic).surface, default.container)
         val override = Color.Magenta
         assertEquals(override, resolveInfiniteStatusPillPalette(semantic, false, override, InfiniteStatusVariant.Active).content)
         assertEquals(InfiniteStatusVariant.Active.toAttendanceBadgeColor(), resolveInfiniteStatusPillPalette(semantic, true, null, InfiniteStatusVariant.Active).content)

--- a/app/src/main/java/com/example/infinite_track/presentation/components/status/StatusStateTokens.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/components/status/StatusStateTokens.kt
@@ -9,16 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.example.infinite_track.presentation.theme.Blue_50
-import com.example.infinite_track.presentation.theme.Blue_500
-import com.example.infinite_track.presentation.theme.Blue_700
-import com.example.infinite_track.presentation.theme.Blue_Info
-import com.example.infinite_track.presentation.theme.Green_Success
-import com.example.infinite_track.presentation.theme.Orange_50
-import com.example.infinite_track.presentation.theme.Purple_500
-import com.example.infinite_track.presentation.theme.Red_Error
-import com.example.infinite_track.presentation.theme.Yellow_Warning
 import com.example.infinite_track.presentation.design.tokens.InfiniteSemantic
+import com.example.infinite_track.presentation.design.tokens.infiniteFeedbackPalette
 
 @Immutable
 data class StatusStateTokens(
@@ -31,43 +23,19 @@ data class StatusStateTokens(
 
 @Composable
 fun rememberStatusStateTokens(status: StatusStateSpec): StatusStateTokens {
-    return when (status.id.trim().lowercase()) {
-        "success" -> StatusStateTokens(
-            containerColor = Green_Success.copy(alpha = 0.14f),
-            contentColor = Purple_500,
-            borderColor = Green_Success,
-            iconTint = Green_Success,
-            icon = Icons.Filled.CheckCircle
-        )
-
-        "error" -> StatusStateTokens(
-            containerColor = Red_Error.copy(alpha = 0.12f),
-            contentColor = Purple_500,
-            borderColor = Red_Error,
-            iconTint = Red_Error,
-            icon = Icons.Filled.Error
-        )
-
-        "warning" -> StatusStateTokens(
-            containerColor = Orange_50,
-            contentColor = Purple_500,
-            borderColor = Yellow_Warning,
-            iconTint = Yellow_Warning,
-            icon = Icons.Filled.Warning
-        )
-
-        "info" -> infoTokens()
-        else -> infoTokens()
-    }
-}
-
-private fun infoTokens(): StatusStateTokens {
+    val semantic = status.toInfiniteSemantic()
+    val palette = infiniteFeedbackPalette(semantic)
     return StatusStateTokens(
-        containerColor = Blue_50,
-        contentColor = Blue_700,
-        borderColor = Blue_500.copy(alpha = 0.35f),
-        iconTint = Blue_Info,
-        icon = Icons.Filled.Info
+        containerColor = palette.surface,
+        contentColor = palette.content,
+        borderColor = palette.border,
+        iconTint = palette.accent,
+        icon = when (semantic) {
+            InfiniteSemantic.Success -> Icons.Filled.CheckCircle
+            InfiniteSemantic.Warning -> Icons.Filled.Warning
+            InfiniteSemantic.Error -> Icons.Filled.Error
+            else -> Icons.Filled.Info
+        }
     )
 }
 

--- a/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/components/status/InfiniteStatusPill.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -49,9 +48,23 @@ enum class InfiniteStatusVariant {
 
 internal data class InfiniteStatusPillPalette(val container: Color, val content: Color, val border: Color, val accent: Color)
 internal fun resolveInfiniteStatusPillPalette(semantic: InfiniteSemantic, shared: Boolean, override: Color?, variant: InfiniteStatusVariant): InfiniteStatusPillPalette {
-    val palette = infiniteFeedbackPalette(semantic); val sharedColor = override ?: variant.toAttendanceBadgeColor()
-    return if (shared || override != null) InfiniteStatusPillPalette(sharedColor.copy(alpha = .13f), sharedColor, sharedColor.copy(alpha = .35f), sharedColor)
-    else InfiniteStatusPillPalette(palette.stateContainer, palette.content, palette.border, palette.accent)
+    val palette = infiniteFeedbackPalette(semantic)
+    val sharedColor = override ?: variant.toAttendanceBadgeColor()
+    return if (shared || override != null) {
+        InfiniteStatusPillPalette(
+            container = palette.surface,
+            content = sharedColor,
+            border = sharedColor.copy(alpha = .35f),
+            accent = sharedColor
+        )
+    } else {
+        InfiniteStatusPillPalette(
+            container = palette.surface,
+            content = palette.content,
+            border = palette.border,
+            accent = palette.accent
+        )
+    }
 }
 
 @Composable
@@ -103,8 +116,7 @@ fun InfiniteStatusPill(
             }
             Text(
                 text = label,
-                style = InfiniteFeedbackTypography.pillLabel,
-                fontWeight = FontWeight.Medium
+                style = InfiniteFeedbackTypography.pillLabel
             )
         }
     }

--- a/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
+++ b/app/src/main/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokens.kt
@@ -2,14 +2,12 @@ package com.example.infinite_track.presentation.design.tokens
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
-import com.example.infinite_track.presentation.theme.Violet_50
+import com.example.infinite_track.presentation.core.body2_5
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
 import com.example.infinite_track.presentation.theme.White
-import com.example.infinite_track.presentation.theme.sfCompact_font
 
 @Immutable
 data class InfiniteFeedbackPalette(
@@ -24,61 +22,21 @@ data class InfiniteFeedbackPalette(
 )
 
 object InfiniteFeedbackTypography {
-    val inlineTitle = body1.copy(
-        fontWeight = FontWeight.Bold,
-        lineHeight = 18.sp
-    )
-    val inlineBody = body2.copy(
-        lineHeight = 16.sp
-    )
-    val snackbarMessage = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 20.sp
-    )
-    val snackbarTitle = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Bold,
-        fontSize = 16.sp,
-        lineHeight = 20.sp
-    )
-    val supportingBody = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 20.sp
-    )
-    val pillLabel = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 14.sp
-    )
-    val actionLabel = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Bold,
-        fontSize = 12.sp,
-        lineHeight = 16.sp
-    )
-    val dialogTitle = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Bold,
-        fontSize = 20.sp,
-        lineHeight = 24.sp
-    )
-    val dialogBody = TextStyle(
-        fontFamily = sfCompact_font,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 20.sp
-    )
+    val inlineTitle = body1
+    val inlineBody = body2
+    val snackbarMessage = body1
+    val snackbarTitle = headline4
+    val supportingBody = body2
+    val pillLabel = body2_5
+    val actionLabel = body2
+    val dialogTitle = headline3
+    val dialogBody = body1
 }
 
 fun infiniteFeedbackPalette(semantic: InfiniteSemantic): InfiniteFeedbackPalette {
     val semanticColors = semanticColors(semantic)
     return InfiniteFeedbackPalette(
-        surface = Violet_50.copy(alpha = 0.5f),
+        surface = InfiniteColors.AttendanceReportGlassSurface,
         stateContainer = semanticColors.container,
         content = semanticColors.content,
         supportingContent = semanticColors.content.copy(alpha = 0.76f),

--- a/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
+++ b/app/src/test/java/com/example/infinite_track/presentation/design/tokens/InfiniteFeedbackTokensTest.kt
@@ -1,12 +1,11 @@
 package com.example.infinite_track.presentation.design.tokens
 
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Color
 import com.example.infinite_track.presentation.core.body1
 import com.example.infinite_track.presentation.core.body2
-import com.example.infinite_track.presentation.theme.Violet_50
-import com.example.infinite_track.presentation.theme.sfCompact_font
+import com.example.infinite_track.presentation.core.body2_5
+import com.example.infinite_track.presentation.core.headline3
+import com.example.infinite_track.presentation.core.headline4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -26,44 +25,18 @@ class InfiniteFeedbackTokensTest {
     }
 
     @Test
-    fun `feedback typography uses registered medium and bold styles with approved line heights`() {
+    fun `feedback typography reuses the registered project type scale`() {
         val typography = InfiniteFeedbackTypography
 
-        assertEquals(body1.fontFamily, typography.inlineTitle.fontFamily)
-        assertEquals(body2.fontFamily, typography.inlineBody.fontFamily)
-        assertEquals(14.sp, typography.inlineTitle.fontSize)
-        assertEquals(18.sp, typography.inlineTitle.lineHeight)
-        assertEquals(12.sp, typography.inlineBody.fontSize)
-        assertEquals(16.sp, typography.inlineBody.lineHeight)
-
-        listOf(
-            typography.inlineTitle,
-            typography.inlineBody,
-            typography.snackbarMessage,
-            typography.snackbarTitle,
-            typography.supportingBody,
-            typography.pillLabel,
-            typography.actionLabel,
-            typography.dialogTitle,
-            typography.dialogBody
-        ).forEach { style ->
-            assertEquals(sfCompact_font, style.fontFamily)
-            check(style.fontWeight == FontWeight.Medium || style.fontWeight == FontWeight.Bold)
-        }
-        assertEquals(14.sp, typography.snackbarMessage.fontSize)
-        assertEquals(20.sp, typography.snackbarMessage.lineHeight)
-        assertEquals(16.sp, typography.snackbarTitle.fontSize)
-        assertEquals(20.sp, typography.snackbarTitle.lineHeight)
-        assertEquals(14.sp, typography.supportingBody.fontSize)
-        assertEquals(20.sp, typography.supportingBody.lineHeight)
-        assertEquals(11.sp, typography.pillLabel.fontSize)
-        assertEquals(14.sp, typography.pillLabel.lineHeight)
-        assertEquals(12.sp, typography.actionLabel.fontSize)
-        assertEquals(16.sp, typography.actionLabel.lineHeight)
-        assertEquals(20.sp, typography.dialogTitle.fontSize)
-        assertEquals(24.sp, typography.dialogTitle.lineHeight)
-        assertEquals(14.sp, typography.dialogBody.fontSize)
-        assertEquals(20.sp, typography.dialogBody.lineHeight)
+        assertEquals(body1, typography.inlineTitle)
+        assertEquals(body2, typography.inlineBody)
+        assertEquals(body1, typography.snackbarMessage)
+        assertEquals(headline4, typography.snackbarTitle)
+        assertEquals(body2, typography.supportingBody)
+        assertEquals(body2_5, typography.pillLabel)
+        assertEquals(body2, typography.actionLabel)
+        assertEquals(headline3, typography.dialogTitle)
+        assertEquals(body1, typography.dialogBody)
     }
 
     @Test
@@ -71,7 +44,7 @@ class InfiniteFeedbackTokensTest {
         InfiniteSemantic.entries.forEach { semantic ->
             val palette = infiniteFeedbackPalette(semantic)
 
-            assertEquals(Violet_50.copy(alpha = 0.5f), palette.surface)
+            assertEquals(InfiniteColors.AttendanceReportGlassSurface, palette.surface)
             assertTrue(
                 "${semantic.name} content must meet 4.5 to 1 over the solid feedback surface",
                 contrastRatio(palette.content, palette.surface.compositedOver(Color.White)) >= 4.5


### PR DESCRIPTION
## Summary

- map inline alert, snackbar, dialog, embedded state, action, and pill typography to the existing Infinite Track core type scale
- align all state/status parent surfaces and pills with the same `AttendanceReportGlassSurface` token used by `InfiniteTopBar`
- preserve semantic differentiation through border, icon, action, and timer colors
- route legacy status tokens through the shared feedback palette
- update token and instrumentation contracts

## Why

The state/status system still maintained its own font sizes, line heights, and weights, and used a more transparent violet surface than the app bar. That made feedback components feel inconsistent with the rest of the application and difficult to read over the global background.

## Impact

No feedback behavior changes: inline alert timeout policy, snackbar queuing, dialog actions, accessibility targets, and semantic state mapping remain intact. This is a visual-system alignment only.

## Validation

- `app:testDebugUnitTest`
- `app:compileDebugAndroidTestKotlin`
- `app:assembleDebug`
- state/status source scan contains no local typography overrides
- `git diff --check`
- staged added-line secret audit; `local.properties` is not committed

Linear: INF-230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated status indicators and pills with more consistent colors across different states and display modes.
  - Improved status surfaces and borders for clearer visual separation and contrast.
  - Aligned feedback typography with the app’s established type scale for a more consistent reading experience.
- **Bug Fixes**
  - Corrected status pill palette handling to preserve the intended surface colors in shared and overridden color modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->